### PR TITLE
Modifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,13 @@ endif()
 
 ################################################################################
 # MUSICA
+message(STATUS "use musica: ${USE_MUSICA}")
 if(USE_MUSICA)
   add_subdirectory(musica)
 endif()
 
 # MUSICA-Fortran
+message(STATUS "use musica fortran: ${USE_MUSICA_FORTRAN}")
 if(USE_MUSICA_FORTRAN)
   add_subdirectory(musica-fortran)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,13 +81,11 @@ endif()
 
 ################################################################################
 # MUSICA
-message(STATUS "use musica: ${USE_MUSICA}")
 if(USE_MUSICA)
   add_subdirectory(musica)
 endif()
 
 # MUSICA-Fortran
-message(STATUS "use musica fortran: ${USE_MUSICA_FORTRAN}")
 if(USE_MUSICA_FORTRAN)
   add_subdirectory(musica-fortran)
 endif()

--- a/Dockerfile.fortran
+++ b/Dockerfile.fortran
@@ -62,12 +62,9 @@ RUN cd json-fortran-8.2.0 \
 # Set json-fortran variable to build MUSICA-Fortran using intel
 ENV JSON_FORTRAN_HOME="/usr/local/jsonfortran-intel-8.2.0"
 
-RUN cd musica \
-    && cmake -S . \
-             -B build-musica-fortran \
-             -D USE_MUSICA=OFF \
-             -D USE_MUSICA_FORTRAN=ON \
-    && cd build-musica-fortran \
+RUN cd musica/musica-fortran/test \
+    && mkdir build && cd build \
+    && cmake .. \
     && make
 
 WORKDIR musica/build-musica-fortran

--- a/musica-fortran/CMakeLists.txt
+++ b/musica-fortran/CMakeLists.txt
@@ -9,7 +9,6 @@ project(
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Options
-option(ENABLE_WRAPPER_TESTS "Builds tests for MUSICA Fortran wrapper" ON)
 message(STATUS "Build tests for MUSICA : ${ENABLE_TESTS}")
 
 # Set up include and lib directories
@@ -43,7 +42,3 @@ target_include_directories(musica-fortran
 
 # Add sources
 add_subdirectory(src)
-
-if(ENABLE_WRAPPER_TESTS)
-  add_subdirectory(test)
-endif()

--- a/musica-fortran/test/CMakeLists.txt
+++ b/musica-fortran/test/CMakeLists.txt
@@ -15,7 +15,7 @@ set(USE_MUSICA_FORTRAN ON)
 
 FetchContent_Declare(musica 
   GIT_REPOSITORY https://github.com/NCAR/musica.git
-  GIT_TAG        29f3d0e  ## todo: jiwon update this
+  GIT_TAG        0cc0192  ## todo: jiwon update this
 )
 
 FetchContent_MakeAvailable(musica)

--- a/musica-fortran/test/CMakeLists.txt
+++ b/musica-fortran/test/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 include(FetchContent)
 
+set(USE_MUSICA OFF)
+set(USE_MUSICA_FORTRAN ON)
+
 FetchContent_Declare(musica 
   GIT_REPOSITORY https://github.com/NCAR/musica.git
   GIT_TAG        48e8ce8ab78edf45f2ebab92d27e167f2b35ced1  ## todo: jiwon update this

--- a/musica-fortran/test/CMakeLists.txt
+++ b/musica-fortran/test/CMakeLists.txt
@@ -15,7 +15,7 @@ set(USE_MUSICA_FORTRAN ON)
 
 FetchContent_Declare(musica 
   GIT_REPOSITORY https://github.com/NCAR/musica.git
-  GIT_TAG        48e8ce8ab78edf45f2ebab92d27e167f2b35ced1  ## todo: jiwon update this
+  GIT_TAG        29f3d0e  ## todo: jiwon update this
 )
 
 FetchContent_MakeAvailable(musica)


### PR DESCRIPTION
I updated the files to show what I meant to describe with using the musica fortran interface.

In this scenario, musica is already installed on the machine. Someone creates a new cmake project and includes the musica fortran wrapper with fetch content and the target is linked automatically. The difference here is that the cmake files that control the building of musica are not run to create the test. Rather, the example project is built, and that itself finds the musica fortran target.