### PR TITLE
add no-micm test and fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,17 @@ jobs:
       run: docker build -t musica .
     - name: run tests in container
       run: docker run --name test-container -t musica bash -c 'make test'
+  build_test_connections_without_micm:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: build Docker image
+      run: docker build -t musica -f Dockerfile.no_micm .
+    - name: run tests in container
+      run: docker run --name test-container -t musica bash -c 'make test'
   build_test_connections_with_openmp:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,14 @@ include(GNUInstallDirs)
 set(INSTALL_PREFIX "musica-${PROJECT_VERSION}")
 set(INSTALL_MOD_DIR "${INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
 
+# MUSICA library components
+if(ENABLE_TUVX)
+  add_definitions(-DMUSICA_USE_TUVX)
+endif()
+if(ENABLE_MICM)
+  add_definitions(-DMUSICA_USE_MICM)
+endif()
+
 # MPI
 if(ENABLE_MPI)
   add_definitions(-DMUSICA_USE_MPI)

--- a/Dockerfile.no_micm
+++ b/Dockerfile.no_micm
@@ -1,0 +1,41 @@
+FROM fedora:35
+
+RUN dnf -y update \
+    && dnf -y install \
+        cmake \
+        gcc-c++ \
+        gcc-gfortran \
+        git \
+        lcov \
+        make \
+        netcdf-fortran-devel \
+        valgrind \
+    && dnf clean all
+
+# Install json-fortran
+RUN curl -LO https://github.com/jacobwilliams/json-fortran/archive/8.2.0.tar.gz \
+    && tar -zxvf 8.2.0.tar.gz \
+    && cd json-fortran-8.2.0 \
+    && mkdir build \
+    && cd build \
+    && cmake -D SKIP_DOC_GEN:BOOL=TRUE .. \
+    && make install
+
+# Set environment variables
+ENV FC=gfortran
+ENV JSON_FORTRAN_HOME="/usr/local/jsonfortran-gnu-8.2.0"
+
+# Copy the musica code
+COPY . musica
+
+# Build
+RUN cd musica \
+    && cmake -S . \
+             -B build \
+             -D ENABLE_TESTS=ON \
+             -D ENABLE_TUVX=ON \
+             -D ENABLE_MICM=OFF \
+    && cd build \
+    && make install -j 8 
+    
+WORKDIR musica/build

--- a/musica/src/CMakeLists.txt
+++ b/musica/src/CMakeLists.txt
@@ -7,4 +7,6 @@ target_sources(musica
     ${CMAKE_BINARY_DIR}/version.c
 )
 
-add_subdirectory(micm)
+if(ENABLE_MICM)
+  add_subdirectory(micm)
+endif()


### PR DESCRIPTION
Fixes a problem with building the library without micm and adds a GH action to test this build configuration