### PR TITLE
Rename micm module name

### DIFF
--- a/musica-fortran/src/micm/micm_mod.F90
+++ b/musica-fortran/src/micm/micm_mod.F90
@@ -1,4 +1,4 @@
-module micm
+module musica_micm
     use iso_c_binding
     implicit none
 

--- a/musica-fortran/test/test_musica_api.F90
+++ b/musica-fortran/test/test_musica_api.F90
@@ -1,6 +1,6 @@
 program test
     use iso_c_binding
-    use micm
+    use musica_micm
     implicit none
     type(micm_t) :: m
 


### PR DESCRIPTION
Renamed micm module name as `musica_micm` to avoid duplicates from micm in atmospheric repo