### PR TITLE
Fixes a bug with Fortran builds

### DIFF
--- a/.github/workflows/fetch_content_integration.yml
+++ b/.github/workflows/fetch_content_integration.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fetch_content_integration.yml
+++ b/.github/workflows/fetch_content_integration.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: FetchContentIntegration
 
 on: 
   push:

--- a/docker/Dockerfile.fortran-gcc.integration
+++ b/docker/Dockerfile.fortran-gcc.integration
@@ -31,10 +31,20 @@ ENV FFLAGS="-I/usr/include/"
 COPY . musica
 
 # Build and install MUSICA
+RUN cd musica \
+    && cmake -S . \
+             -B build \
+             -D CMAKE_BUILD_TYPE=Release \
+             -D MUSICA_ENABLE_TESTS=ON \
+             -D MUSICA_ENABLE_MICM=ON \
+    && cd build \
+    && make install
+
+# Build and install MUSICA
 RUN cd musica/fortran/test/fetch_content_integration \
     && mkdir build && cd build \
     && cmake .. \
-        -D CMAKE_BUILD_TYPE=Debug \
+        -D CMAKE_BUILD_TYPE=Release \
     && make
 
 RUN cp -r /musica/configs musica/fortran/test/fetch_content_integration/build

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -45,6 +45,11 @@ target_sources(musica-fortran
     util.F90
 )
 
+# Add flags for gfortran
+if(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:Fortran>:-ffree-line-length-none>)
+endif()
+
 ####################
 # TUV-x
 if (MUSICA_ENABLE_TUVX)

--- a/fortran/micm_core.F90
+++ b/fortran/micm_core.F90
@@ -42,28 +42,28 @@ module micm_core
          use musica_util, only: string_t_c
          import :: c_ptr, c_char
          type(c_ptr), value :: micm
-         character(kind=c_char), intent(in) :: species_name(*), property_name(*)
+         character(len=1, kind=c_char), intent(in) :: species_name(*), property_name(*)
          type(string_t_c) :: get_species_property_string_c
       end function get_species_property_string_c
 
       function get_species_property_double_c(micm, species_name, property_name) bind(c, name="get_species_property_double")
          import :: c_ptr, c_char, c_double
          type(c_ptr), value :: micm
-         character(kind=c_char), intent(in) :: species_name(*), property_name(*)
+         character(len=1, kind=c_char), intent(in) :: species_name(*), property_name(*)
          real(kind=c_double) :: get_species_property_double_c
       end function get_species_property_double_c
 
       function get_species_property_int_c(micm, species_name, property_name) bind(c, name="get_species_property_int")
          import :: c_ptr, c_char, c_int
          type(c_ptr), value :: micm
-         character(kind=c_char), intent(in) :: species_name(*), property_name(*)
+         character(len=1, kind=c_char), intent(in) :: species_name(*), property_name(*)
          integer(kind=c_int) :: get_species_property_int_c
       end function get_species_property_int_c
 
       function get_species_property_bool_c(micm, species_name, property_name) bind(c, name="get_species_property_bool")
          import :: c_ptr, c_char, c_bool
          type(c_ptr), value :: micm
-         character(kind=c_char), intent(in) :: species_name(*), property_name(*)
+         character(len=1, kind=c_char), intent(in) :: species_name(*), property_name(*)
          logical(kind=c_bool) :: get_species_property_bool_c
       end function get_species_property_bool_c      
 

--- a/fortran/micm_core.F90
+++ b/fortran/micm_core.F90
@@ -149,32 +149,39 @@ contains
    end subroutine solve
 
    function get_species_property_string(this, species_name, property_name) result(value)
-      use musica_util,                 only: to_f_string
+      use musica_util,                 only: to_f_string, to_c_string
       class(micm_t)                 :: this
       character(len=*), intent(in)  :: species_name, property_name
       character(len=:), allocatable :: value
-      value = to_f_string(get_species_property_string_c(this%ptr, species_name, property_name))
+      value = to_f_string(get_species_property_string_c(this%ptr,  &
+                to_c_string(species_name), to_c_string(property_name)))
    end function get_species_property_string
 
    function get_species_property_double(this, species_name, property_name) result(value)
+      use musica_util,                 only: to_c_string
       class(micm_t)                 :: this
       character(len=*), intent(in)  :: species_name, property_name
       real(c_double)                :: value
-      value = get_species_property_double_c(this%ptr, species_name, property_name)
+      value = get_species_property_double_c(this%ptr, &
+                to_c_string(species_name), to_c_string(property_name))
    end function get_species_property_double
 
    function get_species_property_int(this, species_name, property_name) result(value)
+      use musica_util,                 only: to_c_string
       class(micm_t)                 :: this
       character(len=*), intent(in)  :: species_name, property_name
       integer(c_int)                :: value
-      value = get_species_property_int_c(this%ptr, species_name, property_name)
+      value = get_species_property_int_c(this%ptr, &
+                to_c_string(species_name), to_c_string(property_name))
    end function get_species_property_int
 
    function get_species_property_bool(this, species_name, property_name) result(value)
+      use musica_util,                 only: to_c_string
       class(micm_t)                 :: this
       character(len=*), intent(in)  :: species_name, property_name
       logical                      :: value
-      value = get_species_property_bool_c(this%ptr, species_name, property_name)
+      value = get_species_property_bool_c(this%ptr, &
+                to_c_string(species_name), to_c_string(property_name))
    end function get_species_property_bool
 
    subroutine finalize(this)

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -7,7 +7,7 @@ module musica_util
   implicit none
   private
 
-  public :: string_t_c, to_f_string, assert
+  public :: string_t_c, to_c_string, to_f_string, assert
 
   !> Wrapper for a c string
   type, bind(c) :: string_t_c
@@ -16,6 +16,27 @@ module musica_util
   end type string_t_c
 
 contains
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Convert a fortran character array to a c string
+  function to_c_string( f_string ) result( c_string )
+
+    use iso_c_binding,                 only : c_char, c_null_char
+
+    character(len=*), intent(in) :: f_string
+    character(len=1, kind=c_char), allocatable :: c_string(:)
+
+    integer :: N, i
+
+    N = len_trim( f_string )
+    allocate( c_string( N + 1 ) )
+    do i = 1, N
+      c_string(i) = f_string(i:i)
+    end do
+    c_string(N + 1) = c_null_char
+
+  end function to_c_string
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
Adds a compiler flag to allow unlimited line length in F90 files, and converts fortran string to c char arrays before passing them to c functions.