### PR TITLE
Shift fortran indices to be 1-based

### DIFF
--- a/fortran/test/unit/util.F90
+++ b/fortran/test/unit/util.F90
@@ -171,23 +171,23 @@ contains
     b = mapping_t( b_c )
     c = mapping_t( c_c )
 
-    ASSERT_EQ( a%index(), 3 )
+    ASSERT_EQ( a%index(), 4 )
     ASSERT_EQ( a%name(), "foo" )
 
-    ASSERT_EQ( b%index(), 5 )
+    ASSERT_EQ( b%index(), 6 )
     ASSERT_EQ( b%name(), "bar" )
 
-    ASSERT_EQ( c%index(), 8 )
+    ASSERT_EQ( c%index(), 9 )
     ASSERT_EQ( c%name(), "baz" )
 
     ! copy assignment
     c = b
     b = a
 
-    ASSERT_EQ( c%index(), 5 )
+    ASSERT_EQ( c%index(), 6 )
     ASSERT_EQ( c%name(), "bar" )
 
-    ASSERT_EQ( b%index(), 3 )
+    ASSERT_EQ( b%index(), 4 )
     ASSERT_EQ( b%name(), "foo" )
 
     a_c%index_ = 13
@@ -199,13 +199,13 @@ contains
     ! construct and take ownership of the c mapping
     c = mapping_t( a_c )
 
-    ASSERT_EQ( a%index(), 13 )
+    ASSERT_EQ( a%index(), 14 )
     ASSERT_EQ( a%name(), "qux" )
 
-    ASSERT_EQ( b%index(), 13 )
+    ASSERT_EQ( b%index(), 14 )
     ASSERT_EQ( b%name(), "qux" )
 
-    ASSERT_EQ( c%index(), 13 )
+    ASSERT_EQ( c%index(), 14 )
     ASSERT_EQ( c%name(), "qux" )
 
     c_mappings(1)%index_ = 21
@@ -221,12 +221,13 @@ contains
     call delete_string_c( c_mappings(2)%name_ )
     call delete_string_c( c_mappings(3)%name_ )
 
+    ! indices should be shifted by 1 for fortran
     ASSERT_EQ( size( f_mappings ), 3 )
-    ASSERT_EQ( f_mappings(1)%index(), 21 )
+    ASSERT_EQ( f_mappings(1)%index(), 22 )
     ASSERT_EQ( f_mappings(1)%name(), "quux" )
-    ASSERT_EQ( f_mappings(2)%index(), 34 )
+    ASSERT_EQ( f_mappings(2)%index(), 35 )
     ASSERT_EQ( f_mappings(2)%name(), "corge" )
-    ASSERT_EQ( f_mappings(3)%index(), 55 )
+    ASSERT_EQ( f_mappings(3)%index(), 56 )
     ASSERT_EQ( f_mappings(3)%name(), "grault" )
 
   end subroutine test_mapping_t

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -60,16 +60,20 @@ module musica_util
   end interface error_t
 
   !> Wrapper for a c name-to-index mapping
+  !!
+  !! Index is 0-based for use in C
   type, bind(c) :: mapping_t_c
     type(string_t_c) :: name_
     integer(c_size_t) :: index_ = 0_c_size_t
   end type mapping_t_c
 
   !> Name-to-index mapping
+  !!
+  !! Indexing is 1-based for use in Fortran
   type :: mapping_t
   private
     type(string_t) :: name_
-    integer :: index_
+    integer :: index_ = 1
   contains
     procedure :: mapping_assign_mapping_t_c
     generic :: assignment(=) => mapping_assign_mapping_t_c
@@ -250,7 +254,7 @@ contains
     type(mapping_t) :: new_mapping
 
     new_mapping%name_ = string_t( c_mapping%name_ )
-    new_mapping%index_ = int( c_mapping%index_ )
+    new_mapping%index_ = int( c_mapping%index_ ) + 1
 
   end function mapping_constructor
 
@@ -263,7 +267,7 @@ contains
     type(mapping_t_c), intent(in) :: from
 
     to%name_ = from%name_
-    to%index_ = int( from%index_ )
+    to%index_ = int( from%index_ ) + 1
 
   end subroutine mapping_assign_mapping_t_c
 


### PR DESCRIPTION
Modifies mapping class to provide 1-based indices from the fortran wrapper