### PR TITLE
Set musica-fortran position-independent code macro to ON when building static library

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -17,6 +17,7 @@ endfunction(set_git_default)
 if (MUSICA_BUILD_FORTRAN_INTERFACE)
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(netcdff IMPORTED_TARGET REQUIRED netcdf-fortran)
+  pkg_check_modules(netcdfc IMPORTED_TARGET REQUIRED netcdf)
 endif()
 
 ################################################################################
@@ -73,7 +74,7 @@ if (MUSICA_ENABLE_TUVX AND MUSICA_BUILD_C_CXX_INTERFACE)
   set(TUVX_INSTALL_INCLUDE_DIR ${MUSICA_INSTALL_INCLUDE_DIR} CACHE STRING "" FORCE)
 
   set_git_default(TUVX_GIT_REPOSITORY https://github.com/NCAR/tuv-x.git)
-  set_git_default(TUVX_GIT_TAG 6ff27992da1485392329208b736d2ec1522dafa3)
+  set_git_default(TUVX_GIT_TAG 9900942d2ccfc9cc03516e406bda6f77a4da7d66)
 
   FetchContent_Declare(tuvx
     GIT_REPOSITORY ${TUVX_GIT_REPOSITORY}

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(netcdff IMPORTED_TARGET REQUIRED netcdf-fortran)
+pkg_check_modules(netcdfc IMPORTED_TARGET REQUIRED netcdf)
 
 if(NOT TARGET musica)
   find_package(musica REQUIRED)
@@ -24,6 +25,13 @@ endif()
 
 add_library(musica-fortran)
 add_library(musica::musica-fortran ALIAS musica-fortran)
+
+if(NOT BUILD_SHAREDS_LIBS)
+  set_target_properties(musica-fortran
+    PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+endif()
 
 set_target_properties(musica-fortran
   PROPERTIES


### PR DESCRIPTION
As reported in the team slack, there were some issues related to position-independent code which were addressed by passing `-DCMAKE_Fortran_FLAGS="-fPIE"` at configure time.  This should obviate the need for that.

The following changes were also added:

* A PkgConfig-based check for `netcdfc` whenever `netcdf-fortran` was checked for, as the latter depends on the former, and if they were built statically, the build would otherwise fail due to undefined symbols.
* Updating the default `tag` for `tuv-x` to one which incorporates the fix for the same issue (position-independent code) in the tuv-x dependency.