### PR TITLE
Modify regex for clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,13 +30,13 @@ IncludeCategories:
   - Regex:           '<(musica)\/'
     Priority:        2
   # MICM, TUV-X headers
-  - Regex:           '<(micm|tuvx)[[:alnum:].\Q/-_\E]+>'
+  - Regex:           '<(micm|tuvx)[[:alnum:].(-|_)*]+>'
     Priority:        3
   # External libraries headers
-  - Regex:           '<([[:alnum:].\Q/-_\E]+)\/'
+  - Regex:           '<[[:alnum:].(-|_)*]+\/'
     Priority:        4
   # System headers
-  - Regex:           '<[[:alnum:].\Q/-_\E]+>'
+  - Regex:           '<[[:alnum:].(-|_)*]+>'
     Priority:        5
   # Main, local, private headers
   - Regex:           '".*'


### PR DESCRIPTION
Modified regex for clang format.

The current REGEX failed to list an external header with `-` above system headers. (The example is from tuvx, which I found the failure.)
Current:
```c++: 
#include <tuvx/util/config_yaml.h>

#include <cstring>
#include <fstream>

#include <yaml-cpp/yaml.h>
```
This PR:
```c++: 
#include <tuvx/util/config_yaml.h>

#include <yaml-cpp/yaml.h>

#include <cstring>
#include <fstream>
```