### PR TITLE
setting rpath on apple

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,6 +27,10 @@ target_include_directories(musica_python
 # Set the rpath for the shared library
 if(APPLE)
   message(STATUS "Building for MacOS")
+  set_target_properties(musica_python PROPERTIES
+    INSTALL_RPATH "@loader_path"
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
 elseif(UNIX)
   message(STATUS "Building for Linux")
   set_target_properties(musica_python PROPERTIES


### PR DESCRIPTION
Set's the rpath for apple. If you `pip install .` in musica, you can then use that version of musica to debug music box and see changes you've made in musica. Without this change, you would have a linker issue for yaml-cpp 