### PR TITLE
Initialize config pointer to nullptr

### DIFF
--- a/include/musica/util.hpp
+++ b/include/musica/util.hpp
@@ -41,7 +41,7 @@ namespace musica
     /// @brief A set of configuration data
     struct Configuration
     {
-      Yaml* data_;
+      Yaml* data_ = nullptr;
     };
 
     /// @brief A struct to represent a mapping between a string and an index


### PR DESCRIPTION
Fixes a missing initialization of the pointer to the YAML parser in the `Configuration` struct