### PR TITLE
Add `contiguous` attribute for arrays passed to c functions

### DIFF
--- a/docker/Dockerfile.fortran-intel
+++ b/docker/Dockerfile.fortran-intel
@@ -1,5 +1,5 @@
 # versions and sizes from here: https://hub.docker.com/r/intel/oneapi-hpckit/tags
-FROM intel/oneapi-hpckit:latest
+FROM intel/oneapi-hpckit:2024.0.1-devel-ubuntu22.04
 
 # Based off of this: https://dgpu-docs.intel.com/driver/installation.html#repository-public-key-used-for-package-and-repository-signing
 # however those docs (at the time of this writing are incorrect) and this is the correct url

--- a/fortran/micm.F90
+++ b/fortran/micm.F90
@@ -252,16 +252,16 @@ contains
     use iso_c_binding, only: c_loc
     use iso_fortran_env, only: real64
     use musica_util, only: string_t, string_t_c, error_t_c, error_t
-    class(micm_t),        intent(in)    :: this
-    real(real64),         intent(in)    :: time_step
-    real(real64), target, intent(in)    :: temperature(:)
-    real(real64), target, intent(in)    :: pressure(:)
-    real(real64), target, intent(in)    :: air_density(:)
-    real(real64), target, intent(inout) :: concentrations(:,:)
-    real(real64), target, intent(in)    :: user_defined_reaction_rates(:,:)
-    type(string_t),       intent(out)   :: solver_state
-    type(solver_stats_t), intent(out)   :: solver_stats
-    type(error_t),        intent(out)   :: error
+    class(micm_t),                    intent(in)    :: this
+    real(real64),                     intent(in)    :: time_step
+    real(real64), target, contiguous, intent(in)    :: temperature(:)
+    real(real64), target, contiguous, intent(in)    :: pressure(:)
+    real(real64), target, contiguous, intent(in)    :: air_density(:)
+    real(real64), target, contiguous, intent(inout) :: concentrations(:,:)
+    real(real64), target, contiguous, intent(in)    :: user_defined_reaction_rates(:,:)
+    type(string_t),                   intent(out)   :: solver_state
+    type(solver_stats_t),             intent(out)   :: solver_stats
+    type(error_t),                    intent(out)   :: error
 
     type(string_t_c)       :: solver_state_c
     type(solver_stats_t_c) :: solver_stats_c

--- a/fortran/test/fetch_content_integration/test_tuvx_api.F90
+++ b/fortran/test/fetch_content_integration/test_tuvx_api.F90
@@ -78,36 +78,38 @@ contains
 
   subroutine test_tuvx_solve()
 
-    type(tuvx_t),         pointer    :: tuvx
-    type(error_t)                    :: error
-    character(len=256)               :: config_path
-    type(grid_map_t),     pointer    :: grids, grids_from_host
-    type(grid_t),         pointer    :: grid, height_grid, wavelength_grid
-    type(profile_map_t),  pointer    :: profiles, profiles_from_host
-    type(profile_t),      pointer    :: profile, profile_copy
-    type(radiator_map_t), pointer    :: radiators, radiators_from_host
-    type(radiator_t),     pointer    :: radiator, radiator_copy
-    real*8, dimension(5), target     :: edges, edge_values, temp_edge
-    real*8, dimension(4), target     :: midpoints, midpoint_values, layer_densities, temp_midpoint
-    real*8                           :: temp_real
-    integer                          :: num_vertical_layers, num_wavelength_bins
-    real*8, dimension(3,2), target   :: optical_depths, temp_od
-    real*8, dimension(3,2), target   :: single_scattering_albedos, temp_ssa
-    real*8, dimension(3,2,1), target :: asymmetry_factors, temp_asym
+    type(tuvx_t),         pointer      :: tuvx
+    type(error_t)                      :: error
+    character(len=256)                 :: config_path
+    type(grid_map_t),     pointer      :: grids, grids_from_host
+    type(grid_t),         pointer      :: grid, height_grid, wavelength_grid
+    type(profile_map_t),  pointer      :: profiles, profiles_from_host
+    type(profile_t),      pointer      :: profile, profile_copy
+    type(radiator_map_t), pointer      :: radiators, radiators_from_host
+    type(radiator_t),     pointer      :: radiator, radiator_copy
+    ! set up arrays with extra dimensions to test whether arrays passed to
+    ! c functions are contiguous
+    real*8, dimension(3,5), target     :: edges, edge_values, temp_edge
+    real*8, dimension(2,4), target     :: midpoints, midpoint_values, layer_densities, temp_midpoint
+    real*8                             :: temp_real
+    integer                            :: num_vertical_layers, num_wavelength_bins
+    real*8, dimension(4,3,2), target   :: optical_depths, temp_od
+    real*8, dimension(3,3,2), target   :: single_scattering_albedos, temp_ssa
+    real*8, dimension(2,3,2,1), target :: asymmetry_factors, temp_asym
 
-    edges = (/ 1.0, 2.0, 3.0, 4.0, 5.0 /)
-    midpoints = (/ 15.0, 25.0, 35.0, 45.0 /)  
-    edge_values = (/ 10.0, 20.0, 30.0, 40.0, 50.0 /)
-    midpoint_values = (/ 15.0, 25.0, 35.0, 45.0 /)
-    layer_densities = (/ 2.0, 4.0, 1.0, 7.0 /)
+    edges(2,:) = (/ 1.0, 2.0, 3.0, 4.0, 5.0 /)
+    midpoints(2,:) = (/ 15.0, 25.0, 35.0, 45.0 /)  
+    edge_values(2,:) = (/ 10.0, 20.0, 30.0, 40.0, 50.0 /)
+    midpoint_values(2,:) = (/ 15.0, 25.0, 35.0, 45.0 /)
+    layer_densities(2,:) = (/ 2.0, 4.0, 1.0, 7.0 /)
     num_vertical_layers = 3
     num_wavelength_bins = 2
-    optical_depths(:,1) = (/ 30.0, 20.0, 10.0 /)
-    optical_depths(:,2) = (/ 70.0, 80.0, 90.0 /)
-    single_scattering_albedos(:,1) = (/ 300.0, 200.0, 100.0 /)
-    single_scattering_albedos(:,2) = (/ 700.0, 800.0, 900.0 /)
-    asymmetry_factors(:,1,1) = (/ 3.0, 2.0, 1.0 /)
-    asymmetry_factors(:,2,1) = (/ 7.0, 8.0, 9.0 /)
+    optical_depths(2,:,1) = (/ 30.0, 20.0, 10.0 /)
+    optical_depths(2,:,2) = (/ 70.0, 80.0, 90.0 /)
+    single_scattering_albedos(2,:,1) = (/ 300.0, 200.0, 100.0 /)
+    single_scattering_albedos(2,:,2) = (/ 700.0, 800.0, 900.0 /)
+    asymmetry_factors(2,:,1,1) = (/ 3.0, 2.0, 1.0 /)
+    asymmetry_factors(2,:,2,1) = (/ 7.0, 8.0, 9.0 /)
 
     config_path = "examples/ts1_tsmlt.json"
 
@@ -137,132 +139,132 @@ contains
     ASSERT_EQ( grid%number_of_sections( error ), 4 )
     ASSERT( error%is_success() )
 
-    call grid%set_edges( edges, error )
+    call grid%set_edges( edges(2,:), error )
     ASSERT( error%is_success() )
 
-    call grid%get_edges( temp_edge, error )
+    call grid%get_edges( temp_edge(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_edge(1), 1.0 )
-    ASSERT_EQ( temp_edge(2), 2.0 )
-    ASSERT_EQ( temp_edge(3), 3.0 )
-    ASSERT_EQ( temp_edge(4), 4.0 )
-    ASSERT_EQ( temp_edge(5), 5.0 )
+    ASSERT_EQ( temp_edge(2,1), 1.0 )
+    ASSERT_EQ( temp_edge(2,2), 2.0 )
+    ASSERT_EQ( temp_edge(2,3), 3.0 )
+    ASSERT_EQ( temp_edge(2,4), 4.0 )
+    ASSERT_EQ( temp_edge(2,5), 5.0 )
 
-    edges = (/ 10.0, 20.0, 30.0, 40.0, 50.0 /)
+    edges(2,:) = (/ 10.0, 20.0, 30.0, 40.0, 50.0 /)
 
-    call grid%set_edges( edges, error )
+    call grid%set_edges( edges(2,:), error )
     ASSERT( error%is_success() )
-    call grid%set_midpoints( midpoints, error )
+    call grid%set_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
 
-    call grid%get_edges( temp_edge, error )
+    call grid%get_edges( temp_edge(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_edge(1), 10.0 )
-    ASSERT_EQ( temp_edge(2), 20.0 )
-    ASSERT_EQ( temp_edge(3), 30.0 )
-    ASSERT_EQ( temp_edge(4), 40.0 )
-    ASSERT_EQ( temp_edge(5), 50.0 )
+    ASSERT_EQ( temp_edge(2,1), 10.0 )
+    ASSERT_EQ( temp_edge(2,2), 20.0 )
+    ASSERT_EQ( temp_edge(2,3), 30.0 )
+    ASSERT_EQ( temp_edge(2,4), 40.0 )
+    ASSERT_EQ( temp_edge(2,5), 50.0 )
 
-    call grid%get_midpoints( temp_midpoint, error )
+    call grid%get_midpoints( temp_midpoint(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_midpoint(1), 15.0 )
-    ASSERT_EQ( temp_midpoint(2), 25.0 )
-    ASSERT_EQ( temp_midpoint(3), 35.0 )
-    ASSERT_EQ( temp_midpoint(4), 45.0 )
+    ASSERT_EQ( temp_midpoint(2,1), 15.0 )
+    ASSERT_EQ( temp_midpoint(2,2), 25.0 )
+    ASSERT_EQ( temp_midpoint(2,3), 35.0 )
+    ASSERT_EQ( temp_midpoint(2,4), 45.0 )
 
     call grids%add( grid, error )
 
-    edges(:) = 0.0
-    midpoints(:) = 0.0
+    edges(2,:) = 0.0
+    midpoints(2,:) = 0.0
 
-    call grid%get_edges( edges, error )
+    call grid%get_edges( edges(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( edges(1), 10.0 )
-    ASSERT_EQ( edges(2), 20.0 )
-    ASSERT_EQ( edges(3), 30.0 )
-    ASSERT_EQ( edges(4), 40.0 )
-    ASSERT_EQ( edges(5), 50.0 )
+    ASSERT_EQ( edges(2,1), 10.0 )
+    ASSERT_EQ( edges(2,2), 20.0 )
+    ASSERT_EQ( edges(2,3), 30.0 )
+    ASSERT_EQ( edges(2,4), 40.0 )
+    ASSERT_EQ( edges(2,5), 50.0 )
 
-    call grid%get_midpoints( midpoints, error )
+    call grid%get_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( midpoints(1), 15.0 )
-    ASSERT_EQ( midpoints(2), 25.0 )
-    ASSERT_EQ( midpoints(3), 35.0 )
-    ASSERT_EQ( midpoints(4), 45.0 )
+    ASSERT_EQ( midpoints(2,1), 15.0 )
+    ASSERT_EQ( midpoints(2,2), 25.0 )
+    ASSERT_EQ( midpoints(2,3), 35.0 )
+    ASSERT_EQ( midpoints(2,4), 45.0 )
 
-    edges = (/ 1.0, 2.0, 3.0, 4.0, 5.0 /)
-    midpoints = (/ 1.5, 2.5, 3.5, 4.5 /)
+    edges(2,:) = (/ 1.0, 2.0, 3.0, 4.0, 5.0 /)
+    midpoints(2,:) = (/ 1.5, 2.5, 3.5, 4.5 /)
 
-    call grid%set_edges( edges, error )
+    call grid%set_edges( edges(2,:), error )
     ASSERT( error%is_success() )
-    call grid%set_midpoints( midpoints, error )
+    call grid%set_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
 
-    edges(:) = 0.0
-    midpoints(:) = 0.0
+    edges(2,:) = 0.0
+    midpoints(2,:) = 0.0
 
-    call grid%get_edges( edges, error )
+    call grid%get_edges( edges(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( edges(1), 1.0 )
-    ASSERT_EQ( edges(2), 2.0 )
-    ASSERT_EQ( edges(3), 3.0 )
-    ASSERT_EQ( edges(4), 4.0 )
-    ASSERT_EQ( edges(5), 5.0 )
+    ASSERT_EQ( edges(2,1), 1.0 )
+    ASSERT_EQ( edges(2,2), 2.0 )
+    ASSERT_EQ( edges(2,3), 3.0 )
+    ASSERT_EQ( edges(2,4), 4.0 )
+    ASSERT_EQ( edges(2,5), 5.0 )
 
-    call grid%get_midpoints( midpoints, error )
+    call grid%get_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( midpoints(1), 1.5 )
-    ASSERT_EQ( midpoints(2), 2.5 )
-    ASSERT_EQ( midpoints(3), 3.5 )
-    ASSERT_EQ( midpoints(4), 4.5 )
+    ASSERT_EQ( midpoints(2,1), 1.5 )
+    ASSERT_EQ( midpoints(2,2), 2.5 )
+    ASSERT_EQ( midpoints(2,3), 3.5 )
+    ASSERT_EQ( midpoints(2,4), 4.5 )
 
     deallocate( grid )
 
     grid => grids%get( "foo", "bars", error )
     ASSERT( error%is_success() )
 
-    edges(:) = 0.0
-    midpoints(:) = 0.0
+    edges(2,:) = 0.0
+    midpoints(2,:) = 0.0
 
-    call grid%get_edges( edges, error )
+    call grid%get_edges( edges(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( edges(1), 1.0 )
-    ASSERT_EQ( edges(2), 2.0 )
-    ASSERT_EQ( edges(3), 3.0 )
-    ASSERT_EQ( edges(4), 4.0 )
-    ASSERT_EQ( edges(5), 5.0 )
+    ASSERT_EQ( edges(2,1), 1.0 )
+    ASSERT_EQ( edges(2,2), 2.0 )
+    ASSERT_EQ( edges(2,3), 3.0 )
+    ASSERT_EQ( edges(2,4), 4.0 )
+    ASSERT_EQ( edges(2,5), 5.0 )
 
-    call grid%get_midpoints( midpoints, error )
+    call grid%get_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( midpoints(1), 1.5 )
-    ASSERT_EQ( midpoints(2), 2.5 )
-    ASSERT_EQ( midpoints(3), 3.5 )
-    ASSERT_EQ( midpoints(4), 4.5 )
+    ASSERT_EQ( midpoints(2,1), 1.5 )
+    ASSERT_EQ( midpoints(2,2), 2.5 )
+    ASSERT_EQ( midpoints(2,3), 3.5 )
+    ASSERT_EQ( midpoints(2,4), 4.5 )
 
-    edges = (/ 10.0, 20.0, 30.0, 40.0, 50.0 /)
-    midpoints = (/ 15.0, 25.0, 35.0, 45.0 /)
+    edges(2,:) = (/ 10.0, 20.0, 30.0, 40.0, 50.0 /)
+    midpoints(2,:) = (/ 15.0, 25.0, 35.0, 45.0 /)
 
-    call grid%set_edges( edges, error )
-    call grid%set_midpoints( midpoints, error )
+    call grid%set_edges( edges(2,:), error )
+    call grid%set_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
 
-    edges(:) = 0.0
-    midpoints(:) = 0.0
+    edges(2,:) = 0.0
+    midpoints(2,:) = 0.0
 
-    call grid%get_edges( edges, error )
+    call grid%get_edges( edges(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( edges(1), 10.0 )
-    ASSERT_EQ( edges(2), 20.0 )
-    ASSERT_EQ( edges(3), 30.0 )
-    ASSERT_EQ( edges(4), 40.0 )
-    ASSERT_EQ( edges(5), 50.0 )
+    ASSERT_EQ( edges(2,1), 10.0 )
+    ASSERT_EQ( edges(2,2), 20.0 )
+    ASSERT_EQ( edges(2,3), 30.0 )
+    ASSERT_EQ( edges(2,4), 40.0 )
+    ASSERT_EQ( edges(2,5), 50.0 )
 
-    call grid%get_midpoints( midpoints, error )
+    call grid%get_midpoints( midpoints(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( midpoints(1), 15.0 )
-    ASSERT_EQ( midpoints(2), 25.0 )
-    ASSERT_EQ( midpoints(3), 35.0 )
-    ASSERT_EQ( midpoints(4), 45.0 )
+    ASSERT_EQ( midpoints(2,1), 15.0 )
+    ASSERT_EQ( midpoints(2,2), 25.0 )
+    ASSERT_EQ( midpoints(2,3), 35.0 )
+    ASSERT_EQ( midpoints(2,4), 45.0 )
 
     profiles => tuvx%get_profiles( error )
     ASSERT( error%is_success() )
@@ -278,36 +280,36 @@ contains
     profile => profile_t( "baz", "qux", grid, error )
     ASSERT( error%is_success() )
 
-    call profile%set_edge_values( edge_values, error )
+    call profile%set_edge_values( edge_values(2,:), error )
     ASSERT( error%is_success() )
 
-    call profile%get_edge_values( temp_edge, error )
+    call profile%get_edge_values( temp_edge(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_edge(1), 10.0 )
-    ASSERT_EQ( temp_edge(2), 20.0 )
-    ASSERT_EQ( temp_edge(3), 30.0 )
-    ASSERT_EQ( temp_edge(4), 40.0 )
-    ASSERT_EQ( temp_edge(5), 50.0 )
+    ASSERT_EQ( temp_edge(2,1), 10.0 )
+    ASSERT_EQ( temp_edge(2,2), 20.0 )
+    ASSERT_EQ( temp_edge(2,3), 30.0 )
+    ASSERT_EQ( temp_edge(2,4), 40.0 )
+    ASSERT_EQ( temp_edge(2,5), 50.0 )
 
-    call profile%set_midpoint_values( midpoint_values, error )
-    ASSERT( error%is_success() )
-
-    call profile%get_midpoint_values( temp_midpoint, error )
-    ASSERT( error%is_success() )
-    ASSERT_EQ( temp_midpoint(1), 15.0 )
-    ASSERT_EQ( temp_midpoint(2), 25.0 )
-    ASSERT_EQ( temp_midpoint(3), 35.0 )
-    ASSERT_EQ( temp_midpoint(4), 45.0 )
-
-    call profile%set_layer_densities( layer_densities, error )
+    call profile%set_midpoint_values( midpoint_values(2,:), error )
     ASSERT( error%is_success() )
 
-    call profile%get_layer_densities( temp_midpoint, error )
+    call profile%get_midpoint_values( temp_midpoint(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_midpoint(1), 2.0 )
-    ASSERT_EQ( temp_midpoint(2), 4.0 )
-    ASSERT_EQ( temp_midpoint(3), 1.0 )
-    ASSERT_EQ( temp_midpoint(4), 7.0 )
+    ASSERT_EQ( temp_midpoint(2,1), 15.0 )
+    ASSERT_EQ( temp_midpoint(2,2), 25.0 )
+    ASSERT_EQ( temp_midpoint(2,3), 35.0 )
+    ASSERT_EQ( temp_midpoint(2,4), 45.0 )
+
+    call profile%set_layer_densities( layer_densities(2,:), error )
+    ASSERT( error%is_success() )
+
+    call profile%get_layer_densities( temp_midpoint(2,:), error )
+    ASSERT( error%is_success() )
+    ASSERT_EQ( temp_midpoint(2,1), 2.0 )
+    ASSERT_EQ( temp_midpoint(2,2), 4.0 )
+    ASSERT_EQ( temp_midpoint(2,3), 1.0 )
+    ASSERT_EQ( temp_midpoint(2,4), 7.0 )
 
     call profile%set_exo_layer_density( 1.0d0, error )
     ASSERT( error%is_success() )
@@ -316,12 +318,12 @@ contains
     ASSERT( error%is_success() )
     ASSERT_EQ( temp_real, 1.0 )
 
-    call profile%get_layer_densities( temp_midpoint, error )
+    call profile%get_layer_densities( temp_midpoint(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_midpoint(1), 2.0 )
-    ASSERT_EQ( temp_midpoint(2), 4.0 )
-    ASSERT_EQ( temp_midpoint(3), 1.0 )
-    ASSERT_EQ( temp_midpoint(4), 7.0 + 1.0 )
+    ASSERT_EQ( temp_midpoint(2,1), 2.0 )
+    ASSERT_EQ( temp_midpoint(2,2), 4.0 )
+    ASSERT_EQ( temp_midpoint(2,3), 1.0 )
+    ASSERT_EQ( temp_midpoint(2,4), 7.0 + 1.0 )
 
     call profile%calculate_exo_layer_density( 10.0d0, error )
     ASSERT( error%is_success() )
@@ -331,34 +333,34 @@ contains
     ! Revisit this after non-SI units are converted in the TUV-x internal functions
     ASSERT_EQ( temp_real, 10.0 * 7.0 * 100.0 )
 
-    call profile%get_layer_densities( temp_midpoint, error )
+    call profile%get_layer_densities( temp_midpoint(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_midpoint(1), 2.0 )
-    ASSERT_EQ( temp_midpoint(2), 4.0 )
-    ASSERT_EQ( temp_midpoint(3), 1.0 )
-    ASSERT_EQ( temp_midpoint(4), 7.0 + 10.0 * 7.0 * 100.0 )
+    ASSERT_EQ( temp_midpoint(2,1), 2.0 )
+    ASSERT_EQ( temp_midpoint(2,2), 4.0 )
+    ASSERT_EQ( temp_midpoint(2,3), 1.0 )
+    ASSERT_EQ( temp_midpoint(2,4), 7.0 + 10.0 * 7.0 * 100.0 )
 
     call profiles%add( profile, error )
     profile_copy => profiles%get( "baz", "qux", error )
 
-    call profile_copy%get_edge_values( temp_edge, error )
+    call profile_copy%get_edge_values( temp_edge(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_edge(1), 10.0 )
-    ASSERT_EQ( temp_edge(2), 20.0 )
-    ASSERT_EQ( temp_edge(3), 30.0 )
-    ASSERT_EQ( temp_edge(4), 40.0 )
-    ASSERT_EQ( temp_edge(5), 50.0 )
+    ASSERT_EQ( temp_edge(2,1), 10.0 )
+    ASSERT_EQ( temp_edge(2,2), 20.0 )
+    ASSERT_EQ( temp_edge(2,3), 30.0 )
+    ASSERT_EQ( temp_edge(2,4), 40.0 )
+    ASSERT_EQ( temp_edge(2,5), 50.0 )
 
-    edge_values = (/ 32.0, 34.0, 36.0, 38.0, 40.0 /)
-    call profile_copy%set_edge_values( edge_values, error )
+    edge_values(2,:) = (/ 32.0, 34.0, 36.0, 38.0, 40.0 /)
+    call profile_copy%set_edge_values( edge_values(2,:), error )
 
-    call profile%get_edge_values( temp_edge, error )
+    call profile%get_edge_values( temp_edge(2,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_edge(1), 32.0 )
-    ASSERT_EQ( temp_edge(2), 34.0 )
-    ASSERT_EQ( temp_edge(3), 36.0 )
-    ASSERT_EQ( temp_edge(4), 38.0 )
-    ASSERT_EQ( temp_edge(5), 40.0 )
+    ASSERT_EQ( temp_edge(2,1), 32.0 )
+    ASSERT_EQ( temp_edge(2,2), 34.0 )
+    ASSERT_EQ( temp_edge(2,3), 36.0 )
+    ASSERT_EQ( temp_edge(2,4), 38.0 )
+    ASSERT_EQ( temp_edge(2,5), 40.0 )
 
     radiators => tuvx%get_radiators( error )
     ASSERT( error%is_success() )
@@ -376,118 +378,118 @@ contains
     radiator => radiator_t( "foo_radiator", height_grid, wavelength_grid, error )
     ASSERT( error%is_success() )
 
-    call radiator%set_optical_depths( optical_depths, error )
+    call radiator%set_optical_depths( optical_depths(2,:,:), error )
     ASSERT( error%is_success() )
 
-    call radiator%get_optical_depths( temp_od, error )
+    call radiator%get_optical_depths( temp_od(2,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_od(1,1), 30.0 )
-    ASSERT_EQ( temp_od(2,1), 20.0 )
-    ASSERT_EQ( temp_od(3,1), 10.0 )
-    ASSERT_EQ( temp_od(1,2), 70.0 )
-    ASSERT_EQ( temp_od(2,2), 80.0 )
-    ASSERT_EQ( temp_od(3,2), 90.0 )
+    ASSERT_EQ( temp_od(2,1,1), 30.0 )
+    ASSERT_EQ( temp_od(2,2,1), 20.0 )
+    ASSERT_EQ( temp_od(2,3,1), 10.0 )
+    ASSERT_EQ( temp_od(2,1,2), 70.0 )
+    ASSERT_EQ( temp_od(2,2,2), 80.0 )
+    ASSERT_EQ( temp_od(2,3,2), 90.0 )
 
-    call radiator%set_single_scattering_albedos( single_scattering_albedos, error )
-    ASSERT( error%is_success() )
-
-    call radiator%get_single_scattering_albedos( temp_ssa, error )
-    ASSERT( error%is_success() )
-    ASSERT_EQ( temp_ssa(1,1), 300.0 )
-    ASSERT_EQ( temp_ssa(2,1), 200.0 )
-    ASSERT_EQ( temp_ssa(3,1), 100.0 )
-    ASSERT_EQ( temp_ssa(1,2), 700.0 )
-    ASSERT_EQ( temp_ssa(2,2), 800.0 )
-    ASSERT_EQ( temp_ssa(3,2), 900.0 )
-
-    call radiator%set_asymmetry_factors( asymmetry_factors, error )
+    call radiator%set_single_scattering_albedos( single_scattering_albedos(2,:,:), error )
     ASSERT( error%is_success() )
 
-    call radiator%get_asymmetry_factors( temp_asym, error )
+    call radiator%get_single_scattering_albedos( temp_ssa(2,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( temp_asym(1,1,1), 3.0 )
-    ASSERT_EQ( temp_asym(2,1,1), 2.0 )
-    ASSERT_EQ( temp_asym(3,1,1), 1.0 )
-    ASSERT_EQ( temp_asym(1,2,1), 7.0 )
-    ASSERT_EQ( temp_asym(2,2,1), 8.0 )
-    ASSERT_EQ( temp_asym(3,2,1), 9.0 )
+    ASSERT_EQ( temp_ssa(2,1,1), 300.0 )
+    ASSERT_EQ( temp_ssa(2,2,1), 200.0 )
+    ASSERT_EQ( temp_ssa(2,3,1), 100.0 )
+    ASSERT_EQ( temp_ssa(2,1,2), 700.0 )
+    ASSERT_EQ( temp_ssa(2,2,2), 800.0 )
+    ASSERT_EQ( temp_ssa(2,3,2), 900.0 )
+
+    call radiator%set_asymmetry_factors( asymmetry_factors(2,:,:,:), error )
+    ASSERT( error%is_success() )
+
+    call radiator%get_asymmetry_factors( temp_asym(2,:,:,:), error )
+    ASSERT( error%is_success() )
+    ASSERT_EQ( temp_asym(2,1,1,1), 3.0 )
+    ASSERT_EQ( temp_asym(2,2,1,1), 2.0 )
+    ASSERT_EQ( temp_asym(2,3,1,1), 1.0 )
+    ASSERT_EQ( temp_asym(2,1,2,1), 7.0 )
+    ASSERT_EQ( temp_asym(2,2,2,1), 8.0 )
+    ASSERT_EQ( temp_asym(2,3,2,1), 9.0 )
 !
     call radiators%add( radiator, error )
     radiator_copy => radiators%get( "foo_radiator", error )
 
-    optical_depths(:,:) = 0.0
-    single_scattering_albedos(:,:) = 0.0
-    asymmetry_factors(:,:,:) = 0.0
+    optical_depths(2,:,:) = 0.0
+    single_scattering_albedos(2,:,:) = 0.0
+    asymmetry_factors(2,:,:,:) = 0.0
 
-    call radiator_copy%get_optical_depths( optical_depths, error )
+    call radiator_copy%get_optical_depths( optical_depths(2,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( optical_depths(1,1), 30.0 )
-    ASSERT_EQ( optical_depths(2,1), 20.0 )
-    ASSERT_EQ( optical_depths(3,1), 10.0 )
-    ASSERT_EQ( optical_depths(1,2), 70.0 )
-    ASSERT_EQ( optical_depths(2,2), 80.0 )
-    ASSERT_EQ( optical_depths(3,2), 90.0 )
+    ASSERT_EQ( optical_depths(2,1,1), 30.0 )
+    ASSERT_EQ( optical_depths(2,2,1), 20.0 )
+    ASSERT_EQ( optical_depths(2,3,1), 10.0 )
+    ASSERT_EQ( optical_depths(2,1,2), 70.0 )
+    ASSERT_EQ( optical_depths(2,2,2), 80.0 )
+    ASSERT_EQ( optical_depths(2,3,2), 90.0 )
 
-    call radiator_copy%get_single_scattering_albedos( single_scattering_albedos, error )
+    call radiator_copy%get_single_scattering_albedos( single_scattering_albedos(2,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( single_scattering_albedos(1,1), 300.0 )
-    ASSERT_EQ( single_scattering_albedos(2,1), 200.0 )
-    ASSERT_EQ( single_scattering_albedos(3,1), 100.0 )
-    ASSERT_EQ( single_scattering_albedos(1,2), 700.0 )
-    ASSERT_EQ( single_scattering_albedos(2,2), 800.0 )
-    ASSERT_EQ( single_scattering_albedos(3,2), 900.0 )
+    ASSERT_EQ( single_scattering_albedos(2,1,1), 300.0 )
+    ASSERT_EQ( single_scattering_albedos(2,2,1), 200.0 )
+    ASSERT_EQ( single_scattering_albedos(2,3,1), 100.0 )
+    ASSERT_EQ( single_scattering_albedos(2,1,2), 700.0 )
+    ASSERT_EQ( single_scattering_albedos(2,2,2), 800.0 )
+    ASSERT_EQ( single_scattering_albedos(2,3,2), 900.0 )
 
-    call radiator_copy%get_asymmetry_factors( asymmetry_factors, error )
+    call radiator_copy%get_asymmetry_factors( asymmetry_factors(2,:,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( asymmetry_factors(1,1,1), 3.0 )
-    ASSERT_EQ( asymmetry_factors(2,1,1), 2.0 )
-    ASSERT_EQ( asymmetry_factors(3,1,1), 1.0 )
-    ASSERT_EQ( asymmetry_factors(1,2,1), 7.0 )
-    ASSERT_EQ( asymmetry_factors(2,2,1), 8.0 )
-    ASSERT_EQ( asymmetry_factors(3,2,1), 9.0 )
+    ASSERT_EQ( asymmetry_factors(2,1,1,1), 3.0 )
+    ASSERT_EQ( asymmetry_factors(2,2,1,1), 2.0 )
+    ASSERT_EQ( asymmetry_factors(2,3,1,1), 1.0 )
+    ASSERT_EQ( asymmetry_factors(2,1,2,1), 7.0 )
+    ASSERT_EQ( asymmetry_factors(2,2,2,1), 8.0 )
+    ASSERT_EQ( asymmetry_factors(2,3,2,1), 9.0 )
 
-    optical_depths(:,1) = (/ 90.0, 80.0, 70.0 /)
-    optical_depths(:,2) = (/ 75.0, 85.0, 95.0 /)
-    single_scattering_albedos(:,1) = (/ 900.0, 800.0, 700.0 /)
-    single_scattering_albedos(:,2) = (/ 750.0, 850.0, 950.0 /)
-    asymmetry_factors(:,1,1) = (/ 9.0, 8.0, 7.0 /)
-    asymmetry_factors(:,2,1) = (/ 5.0, 4.0, 3.0 /)
+    optical_depths(2,:,1) = (/ 90.0, 80.0, 70.0 /)
+    optical_depths(2,:,2) = (/ 75.0, 85.0, 95.0 /)
+    single_scattering_albedos(2,:,1) = (/ 900.0, 800.0, 700.0 /)
+    single_scattering_albedos(2,:,2) = (/ 750.0, 850.0, 950.0 /)
+    asymmetry_factors(2,:,1,1) = (/ 9.0, 8.0, 7.0 /)
+    asymmetry_factors(2,:,2,1) = (/ 5.0, 4.0, 3.0 /)
 
-    call radiator_copy%set_optical_depths( optical_depths, error )
-    call radiator_copy%set_single_scattering_albedos( single_scattering_albedos, error )
-    call radiator_copy%set_asymmetry_factors( asymmetry_factors, error )
+    call radiator_copy%set_optical_depths( optical_depths(2,:,:), error )
+    call radiator_copy%set_single_scattering_albedos( single_scattering_albedos(2,:,:), error )
+    call radiator_copy%set_asymmetry_factors( asymmetry_factors(2,:,:,:), error )
     ASSERT( error%is_success() )
 
-    optical_depths(:,:) = 0.0
-    single_scattering_albedos(:,:) = 0.0
-    asymmetry_factors(:,:,:) = 0.0
+    optical_depths(:,:,:) = 0.0
+    single_scattering_albedos(:,:,:) = 0.0
+    asymmetry_factors(:,:,:,:) = 0.0
 
-    call radiator%get_optical_depths( optical_depths, error )
+    call radiator%get_optical_depths( optical_depths(2,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( optical_depths(1,1), 90.0 )
-    ASSERT_EQ( optical_depths(2,1), 80.0 )
-    ASSERT_EQ( optical_depths(3,1), 70.0 )
-    ASSERT_EQ( optical_depths(1,2), 75.0 )
-    ASSERT_EQ( optical_depths(2,2), 85.0 )
-    ASSERT_EQ( optical_depths(3,2), 95.0 )
+    ASSERT_EQ( optical_depths(2,1,1), 90.0 )
+    ASSERT_EQ( optical_depths(2,2,1), 80.0 )
+    ASSERT_EQ( optical_depths(2,3,1), 70.0 )
+    ASSERT_EQ( optical_depths(2,1,2), 75.0 )
+    ASSERT_EQ( optical_depths(2,2,2), 85.0 )
+    ASSERT_EQ( optical_depths(2,3,2), 95.0 )
 
-    call radiator%get_single_scattering_albedos( single_scattering_albedos, error )
+    call radiator%get_single_scattering_albedos( single_scattering_albedos(2,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( single_scattering_albedos(1,1), 900.0 )
-    ASSERT_EQ( single_scattering_albedos(2,1), 800.0 )
-    ASSERT_EQ( single_scattering_albedos(3,1), 700.0 )
-    ASSERT_EQ( single_scattering_albedos(1,2), 750.0 )
-    ASSERT_EQ( single_scattering_albedos(2,2), 850.0 )
-    ASSERT_EQ( single_scattering_albedos(3,2), 950.0 )
+    ASSERT_EQ( single_scattering_albedos(2,1,1), 900.0 )
+    ASSERT_EQ( single_scattering_albedos(2,2,1), 800.0 )
+    ASSERT_EQ( single_scattering_albedos(2,3,1), 700.0 )
+    ASSERT_EQ( single_scattering_albedos(2,1,2), 750.0 )
+    ASSERT_EQ( single_scattering_albedos(2,2,2), 850.0 )
+    ASSERT_EQ( single_scattering_albedos(2,3,2), 950.0 )
 
-    call radiator%get_asymmetry_factors( asymmetry_factors, error )
+    call radiator%get_asymmetry_factors( asymmetry_factors(2,:,:,:), error )
     ASSERT( error%is_success() )
-    ASSERT_EQ( asymmetry_factors(1,1,1), 9.0 )
-    ASSERT_EQ( asymmetry_factors(2,1,1), 8.0 )
-    ASSERT_EQ( asymmetry_factors(3,1,1), 7.0 )
-    ASSERT_EQ( asymmetry_factors(1,2,1), 5.0 )
-    ASSERT_EQ( asymmetry_factors(2,2,1), 4.0 )
-    ASSERT_EQ( asymmetry_factors(3,2,1), 3.0 )
+    ASSERT_EQ( asymmetry_factors(2,1,1,1), 9.0 )
+    ASSERT_EQ( asymmetry_factors(2,2,1,1), 8.0 )
+    ASSERT_EQ( asymmetry_factors(2,3,1,1), 7.0 )
+    ASSERT_EQ( asymmetry_factors(2,1,2,1), 5.0 )
+    ASSERT_EQ( asymmetry_factors(2,2,2,1), 4.0 )
+    ASSERT_EQ( asymmetry_factors(2,3,2,1), 3.0 )
 
     deallocate( grid )
     deallocate( grids )

--- a/fortran/tuvx/grid.F90
+++ b/fortran/tuvx/grid.F90
@@ -175,9 +175,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(grid_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(in) :: edges
-    type(error_t), intent(inout) :: error
+    class(grid_t),                intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: edges(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -197,9 +197,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(grid_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(inout) :: edges
-    type(error_t), intent(inout) :: error
+    class(grid_t),                intent(inout) :: this
+    real(dk), target, contiguous, intent(inout) :: edges(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -219,9 +219,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(grid_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(in) :: midpoints
-    type(error_t), intent(inout) :: error
+    class(grid_t),                intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: midpoints(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -241,9 +241,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(grid_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(inout) :: midpoints
-    type(error_t), intent(inout) :: error
+    class(grid_t),                intent(inout) :: this
+    real(dk), target, contiguous, intent(inout) :: midpoints(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c

--- a/fortran/tuvx/grid.F90
+++ b/fortran/tuvx/grid.F90
@@ -157,7 +157,7 @@ contains
     use musica_util, only: error_t, error_t_c
 
     ! Arguments
-    class(grid_t), intent(inout) :: this
+    class(grid_t), intent(in)    :: this
     type(error_t), intent(inout) :: error
 
     ! Local variables
@@ -197,8 +197,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(grid_t),                intent(inout) :: this
-    real(dk), target, contiguous, intent(inout) :: edges(:)
+    class(grid_t),                intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: edges(:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables
@@ -241,8 +241,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(grid_t),                intent(inout) :: this
-    real(dk), target, contiguous, intent(inout) :: midpoints(:)
+    class(grid_t),                intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: midpoints(:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables

--- a/fortran/tuvx/profile.F90
+++ b/fortran/tuvx/profile.F90
@@ -205,9 +205,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(in) :: edge_values
-    type(error_t), intent(inout) :: error
+    class(profile_t),             intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: edge_values(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -228,9 +228,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(inout) :: edge_values
-    type(error_t), intent(inout) :: error
+    class(profile_t),             intent(inout) :: this
+    real(dk), target, contiguous, intent(inout) :: edge_values(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -251,9 +251,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(in) :: midpoint_values
-    type(error_t), intent(inout) :: error
+    class(profile_t),             intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: midpoint_values(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -274,9 +274,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(inout) :: midpoint_values
-    type(error_t), intent(inout) :: error
+    class(profile_t),             intent(inout) :: this
+    real(dk), target, contiguous, intent(inout) :: midpoint_values(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -297,9 +297,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(in) :: layer_densities
-    type(error_t), intent(inout) :: error
+    class(profile_t),             intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: layer_densities(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -320,9 +320,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
-    real(dk), target, dimension(:), intent(inout) :: layer_densities
-    type(error_t), intent(inout) :: error
+    class(profile_t),             intent(inout) :: this
+    real(dk), target, contiguous, intent(inout) :: layer_densities(:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c

--- a/fortran/tuvx/profile.F90
+++ b/fortran/tuvx/profile.F90
@@ -228,8 +228,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t),             intent(inout) :: this
-    real(dk), target, contiguous, intent(inout) :: edge_values(:)
+    class(profile_t),             intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: edge_values(:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables
@@ -274,8 +274,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t),             intent(inout) :: this
-    real(dk), target, contiguous, intent(inout) :: midpoint_values(:)
+    class(profile_t),             intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: midpoint_values(:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables
@@ -320,8 +320,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t),             intent(inout) :: this
-    real(dk), target, contiguous, intent(inout) :: layer_densities(:)
+    class(profile_t),             intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: layer_densities(:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables
@@ -383,7 +383,7 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(profile_t), intent(inout) :: this
+    class(profile_t), intent(in)    :: this
     type(error_t),    intent(inout) :: error
 
     ! Return value

--- a/fortran/tuvx/radiator.F90
+++ b/fortran/tuvx/radiator.F90
@@ -182,9 +182,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),                intent(inout) :: this
-    real(dk), target, dimension(:,:), intent(in)    :: optical_depths
-    type(error_t),                    intent(inout) :: error
+    class(radiator_t),            intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: optical_depths(:,:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c)        :: error_c
@@ -207,9 +207,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),                intent(inout) :: this
-    real(dk), target, dimension(:,:), intent(in)    :: optical_depths
-    type(error_t),                    intent(inout) :: error
+    class(radiator_t),            intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: optical_depths(:,:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c)        :: error_c
@@ -233,9 +233,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),                intent(inout) :: this
-    real(dk), target, dimension(:,:), intent(in)    :: single_scattering_albedos
-    type(error_t),                    intent(inout) :: error
+    class(radiator_t),            intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: single_scattering_albedos(:,:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -260,9 +260,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),                intent(inout) :: this
-    real(dk), target, dimension(:,:), intent(in)    :: single_scattering_albedos
-    type(error_t),                    intent(inout) :: error
+    class(radiator_t),            intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: single_scattering_albedos(:,:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c)        :: error_c
@@ -286,9 +286,9 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),                  intent(inout) :: this
-    real(dk), target, dimension(:,:,:), intent(in)    :: asymmetry_factors
-    type(error_t),                      intent(inout) :: error
+    class(radiator_t),            intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: asymmetry_factors(:,:,:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c
@@ -313,9 +313,9 @@ end subroutine set_asymmetry_factors
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),                  intent(inout) :: this
-    real(dk), target, dimension(:,:,:), intent(in)    :: asymmetry_factors
-    type(error_t),                      intent(inout) :: error
+    class(radiator_t),            intent(inout) :: this
+    real(dk), target, contiguous, intent(in)    :: asymmetry_factors(:,:,:)
+    type(error_t),                intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c

--- a/fortran/tuvx/radiator.F90
+++ b/fortran/tuvx/radiator.F90
@@ -207,8 +207,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),            intent(inout) :: this
-    real(dk), target, contiguous, intent(in)    :: optical_depths(:,:)
+    class(radiator_t),            intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: optical_depths(:,:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables
@@ -260,8 +260,8 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),            intent(inout) :: this
-    real(dk), target, contiguous, intent(in)    :: single_scattering_albedos(:,:)
+    class(radiator_t),            intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: single_scattering_albedos(:,:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables
@@ -313,8 +313,8 @@ end subroutine set_asymmetry_factors
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(radiator_t),            intent(inout) :: this
-    real(dk), target, contiguous, intent(in)    :: asymmetry_factors(:,:,:)
+    class(radiator_t),            intent(in)    :: this
+    real(dk), target, contiguous, intent(out)   :: asymmetry_factors(:,:,:)
     type(error_t),                intent(inout) :: error
 
     ! Local variables

--- a/fortran/tuvx/tuvx.F90
+++ b/fortran/tuvx/tuvx.F90
@@ -285,12 +285,12 @@ contains
     use musica_util, only: error_t, error_t_c, dk => musica_dk
 
     ! Arguments
-    class(tuvx_t),         intent(inout) :: this
-    real(kind=dk),         intent(in)    :: solar_zenith_angle             ! radians
-    real(kind=dk),         intent(in)    :: earth_sun_distance             ! AU
-    real(kind=dk), target, intent(inout) :: photolysis_rate_constants(:,:) ! s-1 (layer, reaction)
-    real(kind=dk), target, intent(inout) :: heating_rates(:,:)             ! K s-1 (layer, reaction)
-    type(error_t),         intent(inout) :: error
+    class(tuvx_t),                     intent(inout) :: this
+    real(kind=dk),                     intent(in)    :: solar_zenith_angle             ! radians
+    real(kind=dk),                     intent(in)    :: earth_sun_distance             ! AU
+    real(kind=dk), target, contiguous, intent(inout) :: photolysis_rate_constants(:,:) ! s-1 (layer, reaction)
+    real(kind=dk), target, contiguous, intent(inout) :: heating_rates(:,:)             ! K s-1 (layer, reaction)
+    type(error_t),                     intent(inout) :: error
 
     ! Local variables
     type(error_t_c) :: error_c

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -747,9 +747,9 @@ contains
 
     use iso_c_binding, only: c_loc
 
-    class(index_mappings_t),      intent(inout) :: this
-    real(kind=musica_dk), target, intent(in)    :: source(:)
-    real(kind=musica_dk), target, intent(in)    :: target(:)
+    class(index_mappings_t),                  intent(inout) :: this
+    real(kind=musica_dk), target, contiguous, intent(in)    :: source(:)
+    real(kind=musica_dk), target, contiguous, intent(in)    :: target(:)
 
     call copy_data_c( this%mappings_c_, c_loc( source ), c_loc( target ) )
 


### PR DESCRIPTION
Adds the `contiguous` attribute to fortran API function array arguments that are passed as C-style pointers to MUSICA library C functions. This allows strided-access array slices to be passed to these functions, but still pass contiguous-in-memory arrays to the C functions. Updates related tests to pass array slices from fortran.