### PR TITLE
Fixes the intent of the target array in the `copy_data` function

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -86,7 +86,7 @@ if (MUSICA_ENABLE_TUVX AND MUSICA_BUILD_C_CXX_INTERFACE)
   set(TUVX_INSTALL_INCLUDE_DIR ${MUSICA_INSTALL_INCLUDE_DIR} CACHE STRING "" FORCE)
 
   set_git_default(TUVX_GIT_REPOSITORY https://github.com/NCAR/tuv-x.git)
-  set_git_default(TUVX_GIT_TAG v0.10.0)
+  set_git_default(TUVX_GIT_TAG fbe0f8aa73f6630d230c6463b603d6ba64c65dcf)
 
   FetchContent_Declare(tuvx
     GIT_REPOSITORY ${TUVX_GIT_REPOSITORY}

--- a/fortran/test/unit/util.F90
+++ b/fortran/test/unit/util.F90
@@ -280,7 +280,7 @@ contains
     type(mappings_t), pointer :: source_map, target_map
     type(index_mappings_t), pointer :: index_mappings
     type(error_t) :: error
-    real(dk), allocatable :: source_data(:), target_data(:)
+    real(dk) :: source_data(2,5), target_data(3,4)
 
     allocate( f_map( 2 ) )
     map => mapping_t( "Test", 2 )
@@ -302,14 +302,14 @@ contains
     index_mappings => index_mappings_t( config, source_map, target_map, error )
     ASSERT( error%is_success() )
 
-    source_data = (/ 1.0_dk, 2.0_dk, 3.0_dk, 4.0_dk, 5.0_dk /)
-    target_data = (/ 10.0_dk, 20.0_dk, 30.0_dk, 40.0_dk /)
+    source_data(2,:) = (/ 1.0_dk, 2.0_dk, 3.0_dk, 4.0_dk, 5.0_dk /)
+    target_data(2,:) = (/ 10.0_dk, 20.0_dk, 30.0_dk, 40.0_dk /)
 
-    call index_mappings%copy_data( source_data, target_data )
-    ASSERT_EQ( target_data( 1 ), 5.0_dk * 0.82_dk )
-    ASSERT_EQ( target_data( 2 ), 20.0_dk )
-    ASSERT_EQ( target_data( 3 ), 2.0_dk )
-    ASSERT_EQ( target_data( 4 ), 40.0_dk )
+    call index_mappings%copy_data( source_data(2,:), target_data(2,:) )
+    ASSERT_EQ( target_data( 2, 1 ), 5.0_dk * 0.82_dk )
+    ASSERT_EQ( target_data( 2, 2 ), 20.0_dk )
+    ASSERT_EQ( target_data( 2, 3 ), 2.0_dk )
+    ASSERT_EQ( target_data( 2, 4 ), 40.0_dk )
     deallocate( index_mappings )
     deallocate( source_map )
     deallocate( target_map )

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -749,7 +749,7 @@ contains
 
     class(index_mappings_t),                  intent(inout) :: this
     real(kind=musica_dk), target, contiguous, intent(in)    :: source(:)
-    real(kind=musica_dk), target, contiguous, intent(in)    :: target(:)
+    real(kind=musica_dk), target, contiguous, intent(inout) :: target(:)
 
     call copy_data_c( this%mappings_c_, c_loc( source ), c_loc( target ) )
 


### PR DESCRIPTION
Fixes the intent to be `inout` for the target data array in the `index_mapping_t::copy_data()` function and adds a test with strided-access array slices.

Also, updates the build scripts to use the latest commit on main for TUV-x