### PR TITLE
Add map matching options

### DIFF
--- a/fortran/test/unit/util.F90
+++ b/fortran/test/unit/util.F90
@@ -271,9 +271,10 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine build_and_check_index_mapping_t(config)
+  subroutine build_and_check_index_mapping_t(config, should_pass_map_all)
 
     type(configuration_t), intent(inout) :: config
+    logical, intent(in) :: should_pass_map_all
 
     type(mapping_t), pointer :: map
     type(mapping_t), allocatable :: f_map(:)
@@ -299,7 +300,25 @@ contains
     target_map => mappings_t( f_map )
     deallocate( f_map )
 
-    index_mappings => index_mappings_t( config, source_map, target_map, error )
+    index_mappings => index_mappings_t( config, MUSICA_INDEX_MAPPINGS_MAP_ALL, &
+        source_map, target_map, error )
+    if ( should_pass_map_all ) then
+      ASSERT( error%is_success() )
+      source_data(2,:) = (/ 1.0_dk, 2.0_dk, 3.0_dk, 4.0_dk, 5.0_dk /)
+      target_data(2,:) = (/ 10.0_dk, 20.0_dk, 30.0_dk, 40.0_dk /)
+
+      ASSERT_EQ( index_mappings%size( ), 2 )
+      call index_mappings%copy_data( source_data(2,:), target_data(2,:) )
+      ASSERT_EQ( target_data( 2, 1 ), 5.0_dk * 0.82_dk )
+      ASSERT_EQ( target_data( 2, 2 ), 20.0_dk )
+      ASSERT_EQ( target_data( 2, 3 ), 2.0_dk )
+      ASSERT_EQ( target_data( 2, 4 ), 40.0_dk )
+    else
+      ASSERT( error%code() == MUSICA_ERROR_CODE_MAPPING_NOT_FOUND )
+    end if
+    deallocate( index_mappings )
+    index_mappings => index_mappings_t( config, MUSICA_INDEX_MAPPINGS_MAP_ANY, &
+        source_map, target_map, error )
     ASSERT( error%is_success() )
 
     source_data(2,:) = (/ 1.0_dk, 2.0_dk, 3.0_dk, 4.0_dk, 5.0_dk /)
@@ -315,7 +334,7 @@ contains
     deallocate( source_map )
     deallocate( target_map )
 
-  end subroutine build_and_check_index_mapping_t
+  end subroutine build_and_check_index_mapping_t 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -332,12 +351,23 @@ contains
       "  target: Test3"//new_line('a')// &
       "  scale factor: 0.82"//new_line('a'), error )
     ASSERT( error%is_success() )
-    call build_and_check_index_mapping_t( config )
+    call build_and_check_index_mapping_t( config, .true. )
 
     call config%load_from_file( "test/data/util_index_mapping_from_file.json", &
                                 error )
     ASSERT( error%is_success() )
-    call build_and_check_index_mapping_t( config )
+    call build_and_check_index_mapping_t( config, .true. )
+
+    call config%load_from_string( &
+      "- source: Test"//new_line('a')// &
+      "  target: Test2"//new_line('a')// &
+      "- source: Test2"//new_line('a')// & 
+      "  target: Test3"//new_line('a')// &
+      "  scale factor: 0.82"//new_line('a')// &
+      "- source: Test"//new_line('a')// &
+      "  target: Test4"//new_line('a')//new_line('a'), error )
+    ASSERT( error%is_success() )
+    call build_and_check_index_mapping_t( config, .false. )
 
   end subroutine test_index_mapping_t
 

--- a/include/musica/util.hpp
+++ b/include/musica/util.hpp
@@ -4,11 +4,12 @@
 
 #include <cstddef>
 
-#define MUSICA_ERROR_CATEGORY                   "MUSICA Error"
-#define MUSICA_ERROR_CODE_SPECIES_NOT_FOUND     1
-#define MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND 2
-#define MUSICA_ERROR_CODE_MAPPING_NOT_FOUND     3
-#define MUSICA_ERROR_CODE_PARSING_FAILED        4
+#define MUSICA_ERROR_CATEGORY                       "MUSICA Error"
+#define MUSICA_ERROR_CODE_SPECIES_NOT_FOUND         1
+#define MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND     2
+#define MUSICA_ERROR_CODE_MAPPING_NOT_FOUND         3
+#define MUSICA_ERROR_CODE_PARSING_FAILED            4
+#define MUSICA_ERROR_CODE_MAPPING_OPTIONS_UNDEFINED 5
 
 #ifdef __cplusplus
   #include <yaml-cpp/yaml.h>
@@ -22,6 +23,13 @@ namespace musica
   {
     typedef YAML::Node Yaml;
 #endif
+    /// @brief Options for mapping between indices in two arrays
+    enum IndexMappingOptions
+    {
+      UndefinedMapping = 0,  // Undefined mapping
+      MapAny = 1,            // Map any pair of source and target elements that exists
+      MapAll = 2             // Map every pair of source and target elements and fail if any are missing
+    };
 
     /// @brief A struct to represent a string
     struct String
@@ -124,12 +132,13 @@ namespace musica
 
     /// @brief Creates a set of index mappings
     /// @param configuration The Configuration containing the mappings
+    /// @param map_options The options for mapping
     /// @param source The source array of name-index Mappings
     /// @param target The target array of name-index Mappings
     /// @param error The Error to populate if a Mapping is not found
     /// @return The array of IndexMappings
     IndexMappings
-    CreateIndexMappings(const Configuration configuration, const Mappings source, const Mappings target, Error* error);
+    CreateIndexMappings(const Configuration configuration, const IndexMappingOptions map_options, Mappings source, const Mappings target, Error* error);
 
     /// @brief Returns the number of elements in an IndexMappings container
     /// @param mappings The IndexMappings container

--- a/src/test/unit/util.cpp
+++ b/src/test/unit/util.cpp
@@ -109,7 +109,7 @@ TEST(Util, IndexMappingFromString)
   source_map.size_ = 2;
   target_map.mappings_ = target_map_array;
   target_map.size_ = 2;
-  IndexMappings index_mappings = CreateIndexMappings(config, source_map, target_map, &error);
+  IndexMappings index_mappings = CreateIndexMappings(config, IndexMappingOptions::MapAll, source_map, target_map, &error);
   EXPECT_TRUE(IsSuccess(error));
   EXPECT_EQ(index_mappings.mappings_[0].source_, 1);
   EXPECT_EQ(index_mappings.mappings_[0].target_, 2);
@@ -148,7 +148,7 @@ TEST(Util, IndexMappingFromFile)
   source_map.size_ = 2;
   target_map.mappings_ = target_map_array;
   target_map.size_ = 2;
-  IndexMappings index_mappings = CreateIndexMappings(config, source_map, target_map, &error);
+  IndexMappings index_mappings = CreateIndexMappings(config, IndexMappingOptions::MapAll, source_map, target_map, &error);
   EXPECT_TRUE(IsSuccess(error));
   EXPECT_EQ(index_mappings.mappings_[0].source_, 1);
   EXPECT_EQ(index_mappings.mappings_[0].target_, 2);
@@ -166,6 +166,139 @@ TEST(Util, IndexMappingFromFile)
   EXPECT_EQ(target[2], 2.0);
   EXPECT_EQ(target[3], 40.0);
   DeleteIndexMappings(&index_mappings);
+  DeleteMapping(&(source_map_array[0]));
+  DeleteMapping(&(source_map_array[1]));
+  DeleteMapping(&(target_map_array[0]));
+  DeleteMapping(&(target_map_array[1]));
+  DeleteConfiguration(&config);
+  DeleteError(&error);
+}
+
+TEST(Util, IndexMappingMissingSource)
+{
+  Error error = NoError();
+  Configuration config = LoadConfigurationFromString(
+      "- source: Test\n"
+      "  target: Test2\n"
+      "- source: Test2\n"
+      "  target: Test3\n"
+      "  scale factor: 0.82\n"
+      "- source: Test4\n"
+      "  target: Test2\n",
+      &error);
+  EXPECT_TRUE(IsSuccess(error));
+  Mappings source_map;
+  Mappings target_map;
+  Mapping source_map_array[] = { ToMapping("Test", 1), ToMapping("Test2", 4) };
+  Mapping target_map_array[] = { ToMapping("Test2", 2), ToMapping("Test3", 0) };
+  source_map.mappings_ = source_map_array;
+  source_map.size_ = 2;
+  target_map.mappings_ = target_map_array;
+  target_map.size_ = 2;
+  IndexMappings index_mappings = CreateIndexMappings(config, IndexMappingOptions::MapAll, source_map, target_map, &error);
+  EXPECT_EQ(error.code_, MUSICA_ERROR_CODE_MAPPING_NOT_FOUND);
+  EXPECT_EQ(index_mappings.size_, 0);
+  EXPECT_EQ(index_mappings.mappings_, nullptr);
+  index_mappings = CreateIndexMappings(config, IndexMappingOptions::MapAny, source_map, target_map, &error);
+  EXPECT_TRUE(IsSuccess(error));
+  EXPECT_EQ(index_mappings.mappings_[0].source_, 1);
+  EXPECT_EQ(index_mappings.mappings_[0].target_, 2);
+  EXPECT_EQ(index_mappings.mappings_[0].scale_factor_, 1.0);
+  EXPECT_EQ(index_mappings.mappings_[1].source_, 4);
+  EXPECT_EQ(index_mappings.mappings_[1].target_, 0);
+  EXPECT_EQ(index_mappings.mappings_[1].scale_factor_, 0.82);
+  EXPECT_EQ(index_mappings.size_, 2);
+  EXPECT_EQ(GetIndexMappingsSize(index_mappings), 2);
+  double source[] = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+  double target[] = { 10.0, 20.0, 30.0, 40.0 };
+  CopyData(index_mappings, source, target);
+  EXPECT_EQ(target[0], 5.0 * 0.82);
+  EXPECT_EQ(target[1], 20.0);
+  EXPECT_EQ(target[2], 2.0);
+  EXPECT_EQ(target[3], 40.0);
+  DeleteIndexMappings(&index_mappings);
+  DeleteMapping(&(source_map_array[0]));
+  DeleteMapping(&(source_map_array[1]));
+  DeleteMapping(&(target_map_array[0]));
+  DeleteMapping(&(target_map_array[1]));
+  DeleteConfiguration(&config);
+  DeleteError(&error);
+}
+
+TEST(Util, IndexMappingMissingTarget)
+{
+  Error error = NoError();
+  Configuration config = LoadConfigurationFromString(
+      "- source: Test\n"
+      "  target: Test2\n"
+      "- source: Test2\n"
+      "  target: Test3\n"
+      "  scale factor: 0.82\n"
+      "- source: Test\n"
+      "  target: Test4\n",
+      &error);
+  EXPECT_TRUE(IsSuccess(error));
+  Mappings source_map;
+  Mappings target_map;
+  Mapping source_map_array[] = { ToMapping("Test", 1), ToMapping("Test2", 4) };
+  Mapping target_map_array[] = { ToMapping("Test2", 2), ToMapping("Test3", 0) };
+  source_map.mappings_ = source_map_array;
+  source_map.size_ = 2;
+  target_map.mappings_ = target_map_array;
+  target_map.size_ = 2;
+  IndexMappings index_mappings = CreateIndexMappings(config, IndexMappingOptions::MapAll, source_map, target_map, &error);
+  EXPECT_EQ(error.code_, MUSICA_ERROR_CODE_MAPPING_NOT_FOUND);
+  EXPECT_EQ(index_mappings.size_, 0);
+  EXPECT_EQ(index_mappings.mappings_, nullptr);
+  index_mappings = CreateIndexMappings(config, IndexMappingOptions::MapAny, source_map, target_map, &error);
+  EXPECT_TRUE(IsSuccess(error));
+  EXPECT_EQ(index_mappings.mappings_[0].source_, 1);
+  EXPECT_EQ(index_mappings.mappings_[0].target_, 2);
+  EXPECT_EQ(index_mappings.mappings_[0].scale_factor_, 1.0);
+  EXPECT_EQ(index_mappings.mappings_[1].source_, 4);
+  EXPECT_EQ(index_mappings.mappings_[1].target_, 0);
+  EXPECT_EQ(index_mappings.mappings_[1].scale_factor_, 0.82);
+  EXPECT_EQ(index_mappings.size_, 2);
+  EXPECT_EQ(GetIndexMappingsSize(index_mappings), 2);
+  double source[] = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+  double target[] = { 10.0, 20.0, 30.0, 40.0 };
+  CopyData(index_mappings, source, target);
+  EXPECT_EQ(target[0], 5.0 * 0.82);
+  EXPECT_EQ(target[1], 20.0);
+  EXPECT_EQ(target[2], 2.0);
+  EXPECT_EQ(target[3], 40.0);
+  DeleteIndexMappings(&index_mappings);
+  DeleteMapping(&(source_map_array[0]));
+  DeleteMapping(&(source_map_array[1]));
+  DeleteMapping(&(target_map_array[0]));
+  DeleteMapping(&(target_map_array[1]));
+  DeleteConfiguration(&config);
+  DeleteError(&error);
+}
+
+TEST(Util, IndexMappingUndefinedOptions)
+{
+  Error error = NoError();
+  Configuration config = LoadConfigurationFromString(
+      "- source: Test\n"
+      "  target: Test2\n"
+      "- source: Test2\n"
+      "  target: Test3\n"
+      "  scale factor: 0.82\n",
+      &error);
+  EXPECT_TRUE(IsSuccess(error));
+  Mappings source_map;
+  Mappings target_map;
+  Mapping source_map_array[] = { ToMapping("Test", 1), ToMapping("Test2", 4) };
+  Mapping target_map_array[] = { ToMapping("Test2", 2), ToMapping("Test3", 0) };
+  source_map.mappings_ = source_map_array;
+  source_map.size_ = 2;
+  target_map.mappings_ = target_map_array;
+  target_map.size_ = 2;
+  IndexMappings index_mappings = CreateIndexMappings(config, IndexMappingOptions::UndefinedMapping, source_map, target_map, &error);
+  EXPECT_EQ(error.code_, MUSICA_ERROR_CODE_MAPPING_OPTIONS_UNDEFINED);
+  EXPECT_EQ(index_mappings.size_, 0);
+  EXPECT_EQ(index_mappings.mappings_, nullptr);
   DeleteMapping(&(source_map_array[0]));
   DeleteMapping(&(source_map_array[1]));
   DeleteMapping(&(target_map_array[0]));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -217,7 +217,6 @@ namespace musica
         }
       } else if (!IsSuccess(*error))
       {
-        DeleteIndexMappings(&index_mappings);
         return index_mappings;
       }
       std::size_t target_index = FindMappingIndex(target, target_name.c_str(), error);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -185,36 +185,70 @@ namespace musica
   }
 
   IndexMappings
-  CreateIndexMappings(const Configuration configuration, const Mappings source, const Mappings target, Error* error)
+  CreateIndexMappings(const Configuration configuration, const IndexMappingOptions map_options, const Mappings source, const Mappings target, Error* error)
   {
     DeleteError(error);
     std::size_t size = configuration.data_->size();
+    std::vector<IndexMapping> mappings;
     IndexMappings index_mappings;
-    index_mappings.mappings_ = new IndexMapping[size];
-    index_mappings.size_ = size;
+    index_mappings.size_ = 0;
+    if (map_options == IndexMappingOptions::UndefinedMapping)
+    {
+      *error = ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_MAPPING_OPTIONS_UNDEFINED, "Mapping options are undefined");
+      return index_mappings;   
+    }
     for (std::size_t i = 0; i < size; i++)
     {
       const YAML::Node& node = (*configuration.data_)[i];
       std::string source_name = node["source"].as<std::string>();
       std::string target_name = node["target"].as<std::string>();
       std::size_t source_index = FindMappingIndex(source, source_name.c_str(), error);
-      if (!IsSuccess(*error))
+      if (error->code_ == MUSICA_ERROR_CODE_MAPPING_NOT_FOUND)
+      {
+        if (map_options == IndexMappingOptions::MapAll)
+        {
+          return index_mappings;
+        }
+        else
+        {
+          DeleteError(error);
+          *error = NoError();
+          continue;
+        }
+      } else if (!IsSuccess(*error))
       {
         DeleteIndexMappings(&index_mappings);
         return index_mappings;
       }
       std::size_t target_index = FindMappingIndex(target, target_name.c_str(), error);
-      if (!IsSuccess(*error))
+      if (error->code_ == MUSICA_ERROR_CODE_MAPPING_NOT_FOUND)
       {
-        DeleteIndexMappings(&index_mappings);
+        if (map_options == IndexMappingOptions::MapAll)
+        {
+          return index_mappings;
+        }
+        else
+        {
+          DeleteError(error);
+          *error = NoError();
+          continue;
+        }
+      } else if (!IsSuccess(*error))
+      {
         return index_mappings;
       }
-      index_mappings.mappings_[i].source_ = source_index;
-      index_mappings.mappings_[i].target_ = target_index;
+      double scale_factor = 1.0;
       if (node["scale factor"].IsDefined())
       {
-        index_mappings.mappings_[i].scale_factor_ = node["scale factor"].as<double>();
+        scale_factor = node["scale factor"].as<double>();
       }
+      mappings.push_back({ source_index, target_index, scale_factor });
+    }
+    index_mappings.mappings_ = new IndexMapping[mappings.size()];
+    index_mappings.size_ = mappings.size();
+    for (std::size_t i = 0; i < mappings.size(); i++)
+    {
+      index_mappings.mappings_[i] = mappings[i];
     }
     return index_mappings;
   }


### PR DESCRIPTION
Adds the ability to create index mappings that match every source-target pair in the configuration file, or only those where the source and target labels are both present in the source and target arrays.