### PR TITLE
Fix bugs when building and linking MUSICA with MUSICA-CCPP sources

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -36,8 +36,13 @@ set_target_properties(musica-fortran
     SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
+add_custom_command(TARGET musica-fortran POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+  ${MUSICA_FORTRAN_MOD_DIR} ${MUSICA_MOD_DIR}
+)
+
 target_include_directories(musica-fortran
-  PUBLIC  
+  PUBLIC
     $<BUILD_INTERFACE:${MUSICA_MOD_DIR}>
     $<BUILD_INTERFACE:${MUSICA_FORTRAN_MOD_DIR}>
     $<INSTALL_INTERFACE:${MUSICA_INSTALL_INCLUDE_DIR}>

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -159,7 +159,7 @@ module musica_util
 
   !> Array of index-to-index mappings
   type :: index_mappings_t
-  private
+  ! private
     type(index_mappings_t_c) :: mappings_c_
   contains
     procedure :: size => index_mappings_size

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -159,7 +159,7 @@ module musica_util
 
   !> Array of index-to-index mappings
   type :: index_mappings_t
-  ! private
+  private
     type(index_mappings_t_c) :: mappings_c_
   contains
     procedure :: size => index_mappings_size

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,7 @@ if(MUSICA_ENABLE_TUVX)
 
   target_include_directories(musica
     PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+      $<BUILD_INTERFACE:${MUSICA_MOD_DIR}>
       $<INSTALL_INTERFACE:${MUSICA_INSTALL_INCLUDE_DIR}>
   )
 


### PR DESCRIPTION
Fixed an issue of the installed musica-fortran modules being not placed in the include path.