### PR TITLE
Updates MICM version

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -69,7 +69,7 @@ endif()
 
 if (MUSICA_ENABLE_MICM AND MUSICA_BUILD_C_CXX_INTERFACE)
   set_git_default(MICM_GIT_REPOSITORY https://github.com/NCAR/micm.git)
-  set_git_default(MICM_GIT_TAG v3.8.0)
+  set_git_default(MICM_GIT_TAG 7f9b66ef2bf36579b523d5a740e9a40e59f71745)
 
   FetchContent_Declare(micm
       GIT_REPOSITORY ${MICM_GIT_REPOSITORY}

--- a/fortran/micm/micm.F90
+++ b/fortran/micm/micm.F90
@@ -216,6 +216,8 @@ contains
     type(error_t_c)                       :: error_c
     
     call micm_solve_c(this%ptr, state%ptr, time_step, solver_state_c, solver_stats_c, error_c)
+    call state%update_references(error)
+    if (.not. error%is_success()) return
     solver_state = string_t(solver_state_c)
     solver_stats = solver_stats_t(solver_stats_c)
     error = error_t(error_c)

--- a/fortran/micm/state.F90
+++ b/fortran/micm/state.F90
@@ -94,6 +94,7 @@ module musica_state
     real(kind=real64), pointer :: rates(:,:) => null()
     type(mappings_t), pointer :: user_defined_reaction_rates => null()
   contains
+    procedure :: update_references
     final :: finalize
   end type state_t
 
@@ -176,6 +177,20 @@ contains
   end if
   end function constructor
   
+  subroutine update_references(this, error)
+    use iso_c_binding, only : c_f_pointer
+    use musica_util, only: error_t, error_t_c
+    class(state_t), intent(inout) :: this
+    type(error_t),  intent(out)   :: error
+
+    type(error_t_c) :: error_c
+    integer         :: n_species, n_grid_cells
+
+    this%double_array_pointer_concentration = get_concentrations_pointer(this%ptr, n_species, n_grid_cells, error_c)
+    call c_f_pointer( this%double_array_pointer_concentration, this%concentrations, [ n_species, n_grid_cells ] )
+    error = error_t(error_c) 
+  end subroutine update_references
+
   subroutine finalize(this)
     use musica_util, only: error_t, error_t_c
     type(state_t), intent(inout) :: this


### PR DESCRIPTION
Uses the latest version of MICM and adds a function that resets the pointers to the concentration array because the solver does swaps on the `std::vector` and the Fortran State wrapper class maintains c pointers to the first array element.