### PR TITLE
Updates API for MICM correct vector matrix traversing

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -73,7 +73,7 @@ endif()
 
 if (MUSICA_ENABLE_MICM AND MUSICA_BUILD_C_CXX_INTERFACE)
   set_git_default(MICM_GIT_REPOSITORY https://github.com/NCAR/micm.git)
-  set_git_default(MICM_GIT_TAG 651aacfe35339f0b99a4549808bd3c72ea39380a)
+  set_git_default(MICM_GIT_TAG 39941a7a63916d8d3d343154759b3b5fe05ed062)
 
   FetchContent_Declare(micm
       GIT_REPOSITORY ${MICM_GIT_REPOSITORY}

--- a/fortran/micm/micm.F90
+++ b/fortran/micm/micm.F90
@@ -263,7 +263,7 @@ contains
       maximum_number_of_grid_cells = int(max_cells_c)
     end if
     ! The Fortran int(c_size_t) doesn't seem to be able to hold the actual
-    ! maximum value of a C size_t. We there is an overflow, we set it to the largest int.
+    ! maximum value of a C size_t. When there is an overflow, we set it to the largest int.
     if (maximum_number_of_grid_cells < 0) then
       maximum_number_of_grid_cells = huge(0)
     end if

--- a/fortran/micm/state.F90
+++ b/fortran/micm/state.F90
@@ -24,7 +24,7 @@ module musica_state
     end function create_state_c
 
     function get_conditions_pointer (state, number_of_grid_cells, error) &
-      bind(C, name="GetConditionsToStateFortran")
+      bind(C, name="GetConditionsPointer")
       import c_int, c_ptr, error_t_c
       type(c_ptr), value,   intent(in)    :: state
       integer(c_int),       intent(out)   :: number_of_grid_cells
@@ -33,7 +33,7 @@ module musica_state
     end function get_conditions_pointer
 
     function get_concentrations_pointer(state, number_of_species, number_of_grid_cells, error) & !(this is correct)
-      bind(C, name="GetOrderedConcentrationsToStateFortran")
+      bind(C, name="GetOrderedConcentrationsPointer")
       import c_int, c_ptr, error_t_c
       type(c_ptr), value,   intent(in)    :: state
       integer(c_int),       intent(out)   :: number_of_species
@@ -43,7 +43,7 @@ module musica_state
     end function get_concentrations_pointer
 
     function get_ordered_rate_constants_pointer(state, number_of_rate_constants, number_of_grid_cells, error) & !(this is correct)
-      bind(C, name="GetOrderedRateConstantsToStateFortran")
+      bind(C, name="GetOrderedRateConstantsPointer")
       import c_int, c_ptr, error_t_c
       type(c_ptr), value,   intent(in)    :: state
       integer(c_int),       intent(out)   :: number_of_rate_constants

--- a/fortran/test/fetch_content_integration/test_micm_box_model.F90
+++ b/fortran/test/fetch_content_integration/test_micm_box_model.F90
@@ -47,8 +47,15 @@ contains
     state%conditions(1)%pressure    = 1.0e5
     state%conditions(1)%air_density = state%conditions(1)%pressure / (GAS_CONSTANT * state%conditions(1)%temperature)
 
-    state%concentrations = reshape((/ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 /), shape=[6,1])
-    state%rates = reshape((/ 0.001, 0.002 /), shape=[2,1])
+    associate( var_stride => state%species_strides%variable )
+      do i = 1, 6
+        state%concentrations(i * var_stride) = 1.0
+      end do
+    end associate
+    associate( var_stride => state%rate_parameters_strides%variable )
+      state%rate_parameters( 1 ) = 0.001
+      state%rate_parameters( 1 + var_stride ) = 0.002
+    end associate
     
     do i = 1, state%species_ordering%size()
       print *, "Species Name:", state%species_ordering%name(i), &
@@ -93,8 +100,15 @@ contains
     state%conditions(1)%pressure    = 1.0e5
     state%conditions(1)%air_density = state%conditions(1)%pressure / (GAS_CONSTANT * state%conditions(1)%temperature)
 
-    state%concentrations = reshape((/ 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 /), shape=[6,1])
-    state%rates = reshape((/ 0.001, 0.002 /), shape=[2,1])
+    associate( var_stride => state%species_strides%variable )
+      do i = 1, 6
+        state%concentrations(i * var_stride) = 1.0
+      end do
+    end associate
+    associate( var_stride => state%rate_parameters_strides%variable )
+      state%rate_parameters( 1 ) = 0.001
+      state%rate_parameters( 1 + var_stride ) = 0.002
+    end associate
 
     do i = 1, state%species_ordering%size()
       print *, "Species Name:", state%species_ordering%name(i), &

--- a/include/musica/micm/micm.hpp
+++ b/include/musica/micm/micm.hpp
@@ -141,7 +141,6 @@ namespace musica
     }
 
     /// @brief Solve the system
-    /// @param micm Pointer to MICM object
     /// @param state Pointer to state object
     /// @param time_step Time [s] to advance the state by
     /// @param solver_state State of the solver
@@ -164,6 +163,13 @@ namespace musica
         }
       }
       throw std::system_error(make_error_code(MusicaErrCode::SpeciesNotFound), "Species '" + species_name + "' not found");
+    }
+
+    /// @brief Get the maximum number of grid cells per state
+    /// @return Maximum number of grid cells
+    std::size_t GetMaximumNumberOfGridCells()
+    {
+      return std::visit([](auto &solver) { return solver->MaximumNumberOfGridCells(); }, solver_variant_);
     }
   };
 

--- a/include/musica/micm/micm_c_interface.hpp
+++ b/include/musica/micm/micm_c_interface.hpp
@@ -76,6 +76,11 @@ namespace musica
     int GetSpeciesPropertyInt(MICM *micm, const char *species_name, const char *property_name, Error *error);
     bool GetSpeciesPropertyBool(MICM *micm, const char *species_name, const char *property_name, Error *error);
 
+    /// @brief Get the maximum number of grid cells per state
+    /// @param micm Pointer to MICM object
+    /// @return Maximum number of grid cells
+    size_t GetMaximumNumberOfGridCells(MICM *micm);
+
     bool _IsCudaAvailable(Error *error);
 #ifdef __cplusplus
   }

--- a/include/musica/micm/state.hpp
+++ b/include/musica/micm/state.hpp
@@ -74,38 +74,19 @@ namespace musica
 
     /// @brief Get the vector of rate constants
     /// @return Vector of doubles
-    std::vector<double>& GetOrderedRateConstants();
+    std::vector<double>& GetOrderedRateParameters();
 
     /// @brief Set the rate constants to the state variant
     /// @param rateConstant Vector of Rate constants
     void SetOrderedRateConstants(const std::vector<double>& rateConstant);
 
-    /// @brief Get the pointer to the conditions struct
-    /// @param state Pointer to state object
-    /// @param number_of_grid_cells Pointer to num of grid cells
-    micm::Conditions* GetConditionsPointer(musica::State* state, int* number_of_grid_cells);
-
-    /// @brief Get the point to the vector of the concentrations
-    /// @param state Pointer to state object
-    /// @param number_of_species Pointer to number of species
-    /// @param number_of_grid_cells Pointer to num of grid cells
-    /// @return Pointer to the vector
-    double* GetOrderedConcentrationsPointer(musica::State* state, int* number_of_species, int* number_of_grid_cells);
-
-    /// @brief Get the point to the vector of the rates
-    /// @param state Pointer to state object
-    /// @param number_of_species Pointer to number of rate constants
-    /// @param number_of_grid_cells Pointer to num of grid cells
-    /// @return Pointer to the vector
-    double* GetOrderedRateConstantsPointer(musica::State* state, int* number_of_rate_constants, int* number_of_grid_cells);
-
     /// @brief Get the underlying strides for the concentration matrix
     /// @return Strides for the concentration matrix (grid cells, species)
-    std::pair<std::size_t, std::size_t> GetConcentrationStrides();
+    std::pair<std::size_t, std::size_t> GetConcentrationsStrides();
 
     /// @brief Get the underlying strides for the user-defined rate parameter matrix
     /// @return Strides for the rate parameter matrix (grid cells, rate parameters)
-    std::pair<std::size_t, std::size_t> GetUserDefinedRateParameterStrides();
+    std::pair<std::size_t, std::size_t> GetUserDefinedRateParametersStrides();
 
     StateVariant state_variant_;
   };

--- a/include/musica/micm/state.hpp
+++ b/include/musica/micm/state.hpp
@@ -48,6 +48,14 @@ namespace musica
     /// @return Number of grid cells
     std::size_t NumberOfGridCells();
 
+    /// @brief Get the number of species
+    /// @return Number of species
+    std::size_t NumberOfSpecies();
+
+    /// @brief Get the number of user-defined rate parameters
+    /// @return Number of user-defined rate parameters
+    std::size_t NumberOfUserDefinedRateParameters();
+
     /// @brief Get the vector of conditions struct
     /// @return Vector of conditions struct
     std::vector<micm::Conditions>& GetConditions();
@@ -75,21 +83,21 @@ namespace musica
     /// @brief Get the pointer to the conditions struct
     /// @param state Pointer to state object
     /// @param number_of_grid_cells Pointer to num of grid cells
-    std::vector<micm::Conditions>* GetConditionsToState(musica::State* state, int* number_of_grid_cells);
+    micm::Conditions* GetConditionsPointer(musica::State* state, int* number_of_grid_cells);
 
     /// @brief Get the point to the vector of the concentrations
     /// @param state Pointer to state object
     /// @param number_of_species Pointer to number of species
     /// @param number_of_grid_cells Pointer to num of grid cells
     /// @return Pointer to the vector
-    double* GetOrderedConcentrationsToState(musica::State* state, int* number_of_species, int* number_of_grid_cells);
+    double* GetOrderedConcentrationsPointer(musica::State* state, int* number_of_species, int* number_of_grid_cells);
 
     /// @brief Get the point to the vector of the rates
     /// @param state Pointer to state object
     /// @param number_of_species Pointer to number of rate constants
     /// @param number_of_grid_cells Pointer to num of grid cells
     /// @return Pointer to the vector
-    double* GetOrderedRateConstantsToState(musica::State* state, int* number_of_rate_constants, int* number_of_grid_cells);
+    double* GetOrderedRateConstantsPointer(musica::State* state, int* number_of_rate_constants, int* number_of_grid_cells);
 
     /// @brief Get the underlying strides for the concentration matrix
     /// @return Strides for the concentration matrix (grid cells, species)

--- a/include/musica/micm/state_c_interface.hpp
+++ b/include/musica/micm/state_c_interface.hpp
@@ -31,7 +31,7 @@ namespace musica
     /// @param state Pointer to state object
     /// @param number_of_grid_cells Pointer to num of grid cells
     /// @param error Error struct to indicate success or failure
-    micm::Conditions* GetConditionsToStateFortran(musica::State* state, int* number_of_grid_cells, Error* error);
+    micm::Conditions* GetConditionsPointer(musica::State* state, int* number_of_grid_cells, Error* error);
 
     /// @brief Get the point to the vector of the concentrations for Fortran interface
     /// @param state Pointer to state object
@@ -39,7 +39,7 @@ namespace musica
     /// @param number_of_grid_cells Pointer to num of grid cells
     /// @param error Error struct to indicate success or failure
     /// @return Pointer to the vector
-    double* GetOrderedConcentrationsToStateFortran(
+    double* GetOrderedConcentrationsPointer(
         musica::State* state,
         int* number_of_species,
         int* number_of_grid_cells,
@@ -47,11 +47,11 @@ namespace musica
 
     /// @brief Get the point to the vector of the rates for Fortran interface
     /// @param state Pointer to state object
-    /// @param number_of_species Pointer to number of rate constants
+    /// @param number_of_rate_constants Pointer to number of rate constants
     /// @param number_of_grid_cells Pointer to num of grid cells
     /// @param error Error struct to indicate success or failure
     /// @return Pointer to the vector
-    double* GetOrderedRateConstantsToStateFortran(
+    double* GetOrderedRateConstantsPointer(
         musica::State* state,
         int* number_of_rate_constants,
         int* number_of_grid_cells,
@@ -68,6 +68,41 @@ namespace musica
     /// @param error Error struct to indicate success or failure
     /// @return Array of reaction rate name-index pairs
     Mappings GetUserDefinedReactionRatesOrdering(musica::State* state, Error* error);
+
+    /// @brief Returns the number of grid cells in the solver state
+    /// @param state Pointer to state object
+    /// @param error Error struct to indicate success or failure
+    /// @return Number of grid cells
+    size_t GetNumberOfGridCells(musica::State* state, Error* error);
+
+    /// @brief Returns the number of species in the solver state
+    /// @param state Pointer to state object
+    /// @param error Error struct to indicate success or failure
+    /// @return Number of species
+    size_t GetNumberOfSpecies(musica::State* state, Error* error);
+
+    /// @brief Returns the stride across grid cells for the concentration matrix
+    /// @param state Pointer to state object
+    /// @param error Error struct to indicate success or failure
+    /// @param grid_cell_stride Pointer to the stride across grid cells
+    /// @param species_stride Pointer to the stride across species
+    void GetConcentrationStrides(musica::State* state, Error* error, size_t* grid_cell_stride, size_t* species_stride); 
+
+    /// @brief Returns the number of user-defined rate parameters
+    /// @param state Pointer to state object
+    /// @param error Error struct to indicate success or failure
+    /// @return Number of user-defined rate parameters
+    size_t GetNumberOfUserDefinedRateParameters(musica::State* state, Error* error);
+
+    /// @brief Returns the stride across grid cells for the user-defined rate parameter matrix
+    /// @param state Pointer to state object
+    /// @param error Error struct to indicate success or failure
+    /// @param grid_cell_stride Pointer to the stride across grid cells
+    /// @param user_defined_rate_parameter_stride Pointer to the stride across user-defined rate parameters
+    void GetUserDefinedRateParameterStrides(musica::State* state, Error* error, 
+                                            size_t* grid_cell_stride,
+                                            size_t* user_defined_rate_parameter_stride);
+
 #ifdef __cplusplus
   }
 #endif

--- a/include/musica/micm/state_c_interface.hpp
+++ b/include/musica/micm/state_c_interface.hpp
@@ -29,32 +29,28 @@ namespace musica
 
     /// @brief Get the pointer to the conditions struct
     /// @param state Pointer to state object
-    /// @param number_of_grid_cells Pointer to num of grid cells
+    /// @param array_size Overall size of the array (output)
     /// @param error Error struct to indicate success or failure
-    micm::Conditions* GetConditionsPointer(musica::State* state, int* number_of_grid_cells, Error* error);
+    micm::Conditions* GetConditionsPointer(musica::State* state, size_t* array_size, Error* error);
 
     /// @brief Get the point to the vector of the concentrations for Fortran interface
     /// @param state Pointer to state object
-    /// @param number_of_species Pointer to number of species
-    /// @param number_of_grid_cells Pointer to num of grid cells
+    /// @param array_size Overall size of the array (output)
     /// @param error Error struct to indicate success or failure
     /// @return Pointer to the vector
     double* GetOrderedConcentrationsPointer(
         musica::State* state,
-        int* number_of_species,
-        int* number_of_grid_cells,
+        size_t* array_size,
         Error* error);
 
     /// @brief Get the point to the vector of the rates for Fortran interface
     /// @param state Pointer to state object
-    /// @param number_of_rate_constants Pointer to number of rate constants
-    /// @param number_of_grid_cells Pointer to num of grid cells
+    /// @param array_size Overall size of the array (output)
     /// @param error Error struct to indicate success or failure
     /// @return Pointer to the vector
-    double* GetOrderedRateConstantsPointer(
+    double* GetOrderedRateParametersPointer(
         musica::State* state,
-        int* number_of_rate_constants,
-        int* number_of_grid_cells,
+        size_t* array_size,
         Error* error);
 
     /// @brief Get the ordering of species
@@ -67,7 +63,7 @@ namespace musica
     /// @param state Pointer to state object
     /// @param error Error struct to indicate success or failure
     /// @return Array of reaction rate name-index pairs
-    Mappings GetUserDefinedReactionRatesOrdering(musica::State* state, Error* error);
+    Mappings GetUserDefinedRateParametersOrdering(musica::State* state, Error* error);
 
     /// @brief Returns the number of grid cells in the solver state
     /// @param state Pointer to state object
@@ -86,7 +82,7 @@ namespace musica
     /// @param error Error struct to indicate success or failure
     /// @param grid_cell_stride Pointer to the stride across grid cells
     /// @param species_stride Pointer to the stride across species
-    void GetConcentrationStrides(musica::State* state, Error* error, size_t* grid_cell_stride, size_t* species_stride); 
+    void GetConcentrationsStrides(musica::State* state, Error* error, size_t* grid_cell_stride, size_t* species_stride); 
 
     /// @brief Returns the number of user-defined rate parameters
     /// @param state Pointer to state object
@@ -99,7 +95,7 @@ namespace musica
     /// @param error Error struct to indicate success or failure
     /// @param grid_cell_stride Pointer to the stride across grid cells
     /// @param user_defined_rate_parameter_stride Pointer to the stride across user-defined rate parameters
-    void GetUserDefinedRateParameterStrides(musica::State* state, Error* error, 
+    void GetUserDefinedRateParametersStrides(musica::State* state, Error* error, 
                                             size_t* grid_cell_stride,
                                             size_t* user_defined_rate_parameter_stride);
 

--- a/musica/musica.cpp
+++ b/musica/musica.cpp
@@ -52,17 +52,17 @@ void bind_musica(py::module_ &core)
       .def_property(
           "user_defined_rate_parameters",
           [](musica::State &state) -> std::vector<double>& {
-            return state.GetOrderedRateConstants();
+            return state.GetOrderedRateParameters();
           },
           nullptr,
           "native 1D list of user-defined rate parameters, ordered by parameter and grid cell according to matrix type")
       .def("concentration_strides",
           [](musica::State &state) {
-            return state.GetConcentrationStrides();
+            return state.GetConcentrationsStrides();
           })
       .def("user_defined_rate_parameter_strides",
           [](musica::State &state) {
-            return state.GetUserDefinedRateParameterStrides();
+            return state.GetUserDefinedRateParametersStrides();
           });
 
   py::enum_<musica::MICMSolver>(core, "_SolverType")

--- a/musica/types.py
+++ b/musica/types.py
@@ -125,7 +125,7 @@ class State():
 
         Parameters
         ----------
-        concentrations : Dict[str, Union[Union[float, int ], List[Union[float, int]]]]
+        concentrations : Dict[str, Union[Union[float, int], List[Union[float, int]]]]
             Dictionary of species names and their concentrations.
         """
         for name, value in concentrations.items():

--- a/src/micm/micm_c_interface.cpp
+++ b/src/micm/micm_c_interface.cpp
@@ -129,4 +129,9 @@ namespace musica
     return HandleErrors([&]() { return musica::IsCudaAvailable(); }, error);
   }
 
+  size_t GetMaximumNumberOfGridCells(MICM *micm)
+  {
+    return micm->GetMaximumNumberOfGridCells();
+  }
+
 }  // namespace musica

--- a/src/micm/state.cpp
+++ b/src/micm/state.cpp
@@ -24,6 +24,16 @@ namespace musica
     return std::visit([](auto& st) -> std::size_t { return st.NumberOfGridCells(); }, state_variant_);
   }
 
+  std::size_t State::NumberOfSpecies()
+  {
+    return std::visit([](auto& st) -> std::size_t { return st.variables_.NumColumns(); }, state_variant_);
+  }
+
+  std::size_t State::NumberOfUserDefinedRateParameters()
+  {
+    return std::visit([](auto& st) -> std::size_t { return st.custom_rate_parameters_.NumColumns(); }, state_variant_);
+  }
+
   std::vector<micm::Conditions>& State::GetConditions()
   {
     return std::visit([](auto& st) -> std::vector<micm::Conditions>& { return st.conditions_; }, state_variant_);
@@ -80,37 +90,38 @@ namespace musica
   }
 
   double*
-  State::GetOrderedRateConstantsToState(musica::State* state, int* number_of_rate_constants, int* number_of_grid_cells)
+  State::GetOrderedRateConstantsPointer(musica::State* state, int* number_of_rate_constants, int* number_of_grid_cells)
   {
     auto& vec =
         std::visit([](auto& st) -> std::vector<double>& { return st.custom_rate_parameters_.AsVector(); }, state_variant_);
 
     *number_of_grid_cells =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.conditions_.size()); }, state_variant_);
+        std::visit([](auto& st) -> int { return static_cast<int>(st.custom_rate_parameters_.NumRows()); }, state_variant_);
 
-    *number_of_rate_constants = static_cast<int>(vec.size() / *number_of_grid_cells);
+    *number_of_rate_constants =
+        std::visit([](auto& st) -> int { return static_cast<int>(st.custom_rate_parameters_.NumColumns()); }, state_variant_);
     return vec.data();
   }
 
-  std::vector<micm::Conditions>* State::GetConditionsToState(musica::State* state, int* number_of_grid_cells)
+  micm::Conditions* State::GetConditionsPointer(musica::State* state, int* number_of_grid_cells)
   {
     auto& vec = std::visit([](auto& st) -> std::vector<micm::Conditions>& { return st.conditions_; }, state_variant_);
 
     *number_of_grid_cells =
         std::visit([](auto& st) -> int { return static_cast<int>(st.conditions_.size()); }, state_variant_);
 
-    return &vec;
+    return vec.data();
   }
 
-  double* State::GetOrderedConcentrationsToState(musica::State* state, int* number_of_species, int* number_of_grid_cells)
+  double* State::GetOrderedConcentrationsPointer(musica::State* state, int* number_of_species, int* number_of_grid_cells)
   {
     auto& vec = std::visit([](auto& st) -> std::vector<double>& { return st.variables_.AsVector(); }, state_variant_);
 
     *number_of_grid_cells =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.conditions_.size()); }, state_variant_);
+        std::visit([](auto& st) -> int { return static_cast<int>(st.variables_.NumRows()); }, state_variant_);
 
-    *number_of_species = static_cast<int>(vec.size() / *number_of_grid_cells);
-
+    *number_of_species =
+        std::visit([](auto& st) -> int { return static_cast<int>(st.variables_.NumColumns()); }, state_variant_);
     return vec.data();
   }
 

--- a/src/micm/state.cpp
+++ b/src/micm/state.cpp
@@ -70,7 +70,7 @@ namespace musica
         state_variant_);
   }
 
-  std::vector<double>& State::GetOrderedRateConstants()
+  std::vector<double>& State::GetOrderedRateParameters()
   {
     return std::visit(
         [](auto& st) -> std::vector<double>& { return st.custom_rate_parameters_.AsVector(); }, state_variant_);
@@ -89,43 +89,7 @@ namespace musica
         state_variant_);
   }
 
-  double*
-  State::GetOrderedRateConstantsPointer(musica::State* state, int* number_of_rate_constants, int* number_of_grid_cells)
-  {
-    auto& vec =
-        std::visit([](auto& st) -> std::vector<double>& { return st.custom_rate_parameters_.AsVector(); }, state_variant_);
-
-    *number_of_grid_cells =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.custom_rate_parameters_.NumRows()); }, state_variant_);
-
-    *number_of_rate_constants =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.custom_rate_parameters_.NumColumns()); }, state_variant_);
-    return vec.data();
-  }
-
-  micm::Conditions* State::GetConditionsPointer(musica::State* state, int* number_of_grid_cells)
-  {
-    auto& vec = std::visit([](auto& st) -> std::vector<micm::Conditions>& { return st.conditions_; }, state_variant_);
-
-    *number_of_grid_cells =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.conditions_.size()); }, state_variant_);
-
-    return vec.data();
-  }
-
-  double* State::GetOrderedConcentrationsPointer(musica::State* state, int* number_of_species, int* number_of_grid_cells)
-  {
-    auto& vec = std::visit([](auto& st) -> std::vector<double>& { return st.variables_.AsVector(); }, state_variant_);
-
-    *number_of_grid_cells =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.variables_.NumRows()); }, state_variant_);
-
-    *number_of_species =
-        std::visit([](auto& st) -> int { return static_cast<int>(st.variables_.NumColumns()); }, state_variant_);
-    return vec.data();
-  }
-
-  std::pair<std::size_t, std::size_t> State::GetConcentrationStrides()
+  std::pair<std::size_t, std::size_t> State::GetConcentrationsStrides()
   {
     return std::visit(
         [](auto& st) -> std::pair<std::size_t, std::size_t>
@@ -133,7 +97,7 @@ namespace musica
         state_variant_);
   }
 
-  std::pair<std::size_t, std::size_t> State::GetUserDefinedRateParameterStrides()
+  std::pair<std::size_t, std::size_t> State::GetUserDefinedRateParametersStrides()
   {
     return std::visit(
         [](auto& st) -> std::pair<std::size_t, std::size_t>

--- a/src/micm/state_c_interface.cpp
+++ b/src/micm/state_c_interface.cpp
@@ -64,32 +64,39 @@ namespace musica
         error);
   }
 
-  micm::Conditions* GetConditionsPointer(musica::State* state, int* number_of_grid_cells, Error* error)
+  micm::Conditions* GetConditionsPointer(musica::State* state, size_t* array_size, Error* error)
   {
     return HandleErrors(
-        [&]() -> micm::Conditions* { return state->GetConditionsPointer(state, number_of_grid_cells); }, error);
+        [&]() -> micm::Conditions* {
+          std::vector<micm::Conditions>& conditions = state->GetConditions();
+          *array_size = conditions.size();
+          return conditions.data(); },
+        error);
   }
 
   double* GetOrderedConcentrationsPointer(
       musica::State* state,
-      int* number_of_species,
-      int* number_of_grid_cells,
+      size_t* array_size,
       Error* error)
   {
     return HandleErrors(
-        [&]() -> double* { return state->GetOrderedConcentrationsPointer(state, number_of_species, number_of_grid_cells); },
-        error);
-  }
+        [&]() -> double* {
+          std::vector<double>& concentrations = state->GetOrderedConcentrations();
+          *array_size = concentrations.size();
+          return concentrations.data(); },
+          error);
+        }
 
-  double* GetOrderedRateConstantsPointer(
+  double* GetOrderedRateParametersPointer(
       musica::State* state,
-      int* number_of_rate_constants,
-      int* number_of_grid_cells,
+      size_t* array_size,
       Error* error)
   {
     return HandleErrors(
-        [&]() -> double*
-        { return state->GetOrderedRateConstantsPointer(state, number_of_rate_constants, number_of_grid_cells); },
+        [&]() -> double* { 
+          std::vector<double>& rate_constants = state->GetOrderedRateParameters();
+          *array_size = rate_constants.size();
+          return rate_constants.data(); },
         error);
   }
 
@@ -118,7 +125,7 @@ namespace musica
         error);
   }
 
-  Mappings GetUserDefinedReactionRatesOrdering(musica::State* state, Error* error)
+  Mappings GetUserDefinedRateParametersOrdering(musica::State* state, Error* error)
   {
     return HandleErrors(
         [&]()
@@ -167,12 +174,12 @@ namespace musica
         error);
   }
 
-  void GetConcentrationStrides(musica::State* state, Error* error, size_t* grid_cell_stride, size_t* species_stride)
+  void GetConcentrationsStrides(musica::State* state, Error* error, size_t* grid_cell_stride, size_t* species_stride)
   {
     HandleErrors(
         [&]() -> void
         {
-          auto strides = state->GetConcentrationStrides();
+          auto strides = state->GetConcentrationsStrides();
           *grid_cell_stride = strides.first;
           *species_stride = strides.second;
           *error = NoError();
@@ -192,7 +199,7 @@ namespace musica
         error);
   }
 
-  void GetUserDefinedRateParameterStrides(
+  void GetUserDefinedRateParametersStrides(
       musica::State* state,
       Error* error,
       size_t* grid_cell_stride,
@@ -201,7 +208,7 @@ namespace musica
     HandleErrors(
         [&]() -> void
         {
-          auto strides = state->GetUserDefinedRateParameterStrides();
+          auto strides = state->GetUserDefinedRateParametersStrides();
           *grid_cell_stride = strides.first;
           *rate_parameter_stride = strides.second;
           *error = NoError();

--- a/src/micm/state_c_interface.cpp
+++ b/src/micm/state_c_interface.cpp
@@ -64,24 +64,24 @@ namespace musica
         error);
   }
 
-  micm::Conditions* GetConditionsToStateFortran(musica::State* state, int* number_of_grid_cells, Error* error)
+  micm::Conditions* GetConditionsPointer(musica::State* state, int* number_of_grid_cells, Error* error)
   {
     return HandleErrors(
-        [&]() -> micm::Conditions* { return state->GetConditionsToState(state, number_of_grid_cells)->data(); }, error);
+        [&]() -> micm::Conditions* { return state->GetConditionsPointer(state, number_of_grid_cells); }, error);
   }
 
-  double* GetOrderedConcentrationsToStateFortran(
+  double* GetOrderedConcentrationsPointer(
       musica::State* state,
       int* number_of_species,
       int* number_of_grid_cells,
       Error* error)
   {
     return HandleErrors(
-        [&]() -> double* { return state->GetOrderedConcentrationsToState(state, number_of_species, number_of_grid_cells); },
+        [&]() -> double* { return state->GetOrderedConcentrationsPointer(state, number_of_species, number_of_grid_cells); },
         error);
   }
 
-  double* GetOrderedRateConstantsToStateFortran(
+  double* GetOrderedRateConstantsPointer(
       musica::State* state,
       int* number_of_rate_constants,
       int* number_of_grid_cells,
@@ -89,7 +89,7 @@ namespace musica
   {
     return HandleErrors(
         [&]() -> double*
-        { return state->GetOrderedRateConstantsToState(state, number_of_rate_constants, number_of_grid_cells); },
+        { return state->GetOrderedRateConstantsPointer(state, number_of_rate_constants, number_of_grid_cells); },
         error);
   }
 
@@ -139,6 +139,72 @@ namespace musica
 
           *error = NoError();
           return reaction_rates;
+        },
+        error);
+  }
+
+  size_t GetNumberOfGridCells(musica::State* state, Error* error)
+  {
+    return HandleErrors(
+        [&]() -> size_t
+        {
+          size_t number_of_grid_cells = state->NumberOfGridCells();
+          *error = NoError();
+          return number_of_grid_cells;
+        },
+        error);
+  }
+
+  size_t GetNumberOfSpecies(musica::State* state, Error* error)
+  {
+    return HandleErrors(
+        [&]() -> size_t
+        {
+          size_t number_of_species = state->NumberOfSpecies();
+          *error = NoError();
+          return number_of_species;
+        },
+        error);
+  }
+
+  void GetConcentrationStrides(musica::State* state, Error* error, size_t* grid_cell_stride, size_t* species_stride)
+  {
+    HandleErrors(
+        [&]() -> void
+        {
+          auto strides = state->GetConcentrationStrides();
+          *grid_cell_stride = strides.first;
+          *species_stride = strides.second;
+          *error = NoError();
+        },
+        error);
+  }
+  
+  size_t GetNumberOfUserDefinedRateParameters(musica::State* state, Error* error)
+  {
+    return HandleErrors(
+        [&]() -> size_t
+        {
+          size_t number_of_user_defined_rate_parameters = state->NumberOfUserDefinedRateParameters();
+          *error = NoError();
+          return number_of_user_defined_rate_parameters;
+        },
+        error);
+  }
+
+  void GetUserDefinedRateParameterStrides(
+      musica::State* state,
+      Error* error,
+      size_t* grid_cell_stride,
+      size_t* rate_parameter_stride)
+  {
+    HandleErrors(
+        [&]() -> void
+        {
+          auto strides = state->GetUserDefinedRateParameterStrides();
+          *grid_cell_stride = strides.first;
+          *rate_parameter_stride = strides.second;
+          *error = NoError();
         },
         error);
   }

--- a/src/test/unit/micm/micm_c_api.cpp
+++ b/src/test/unit/micm/micm_c_api.cpp
@@ -551,22 +551,188 @@ void TestVectorMultipleGridCells(
   }
 }
 
+void TestMultipleGridCells(
+    MICM* micm,
+    const size_t num_grid_cells,
+    const double time_step,
+    const double test_accuracy)
+{
+  const size_t num_concentrations = 6;
+  const size_t num_user_defined_reaction_rates = 2;
+  constexpr double GAS_CONSTANT = 8.31446261815324;  // J mol-1 K-1
+
+  Error error;
+  
+  // Create MICM states
+  size_t state_1_size = std::min(num_grid_cells, micm->GetMaximumNumberOfGridCells());
+  size_t state_2_size = (num_grid_cells - state_1_size) % micm->GetMaximumNumberOfGridCells();
+  musica::State* state_1 = CreateMicmState(micm, state_1_size, &error);
+  ASSERT_TRUE(IsSuccess(error));
+  musica::State* state_2 = nullptr;
+  if (state_2_size > 0)
+  {
+    state_2 = CreateMicmState(micm, state_2_size, &error);
+    ASSERT_TRUE(IsSuccess(error));
+  }
+    
+  // Get species indices in concentration array
+  Mappings species_ordering = GetSpeciesOrdering(state_1, &error);
+  ASSERT_TRUE(IsSuccess(error));
+  ASSERT_EQ(species_ordering.size_, num_concentrations);
+  std::size_t A_index = FindMappingIndex(species_ordering, "A", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  std::size_t B_index = FindMappingIndex(species_ordering, "B", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  std::size_t C_index = FindMappingIndex(species_ordering, "C", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  std::size_t D_index = FindMappingIndex(species_ordering, "D", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  std::size_t E_index = FindMappingIndex(species_ordering, "E", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  std::size_t F_index = FindMappingIndex(species_ordering, "F", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  DeleteMappings(&species_ordering);
+
+  // Get user-defined reaction rates indices in user-defined reaction rates array
+  Mappings rate_ordering = GetUserDefinedReactionRatesOrdering(state_1, &error);
+  ASSERT_TRUE(IsSuccess(error));
+  ASSERT_EQ(rate_ordering.size_, num_user_defined_reaction_rates);
+  std::size_t R1_index = FindMappingIndex(rate_ordering, "USER.reaction 1", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  std::size_t R2_index = FindMappingIndex(rate_ordering, "USER.reaction 2", &error);
+  ASSERT_TRUE(IsSuccess(error));
+  DeleteMappings(&rate_ordering);
+
+  for (int i_state = 0; i_state < std::ceil(num_grid_cells/state_1_size); ++i_state)
+  {
+    // Get the right state and set dimensions
+    size_t state_size = std::min(num_grid_cells - i_state * state_1_size, state_1_size);
+    musica::State* current_state = (state_size == state_1_size) ? state_1 : state_2;
+    ASSERT_TRUE(current_state != nullptr);
+    ASSERT_EQ(GetNumberOfGridCells(current_state, &error), state_size);
+    ASSERT_TRUE(IsSuccess(error));
+    ASSERT_EQ(GetNumberOfSpecies(current_state, &error), num_concentrations);
+    ASSERT_TRUE(IsSuccess(error));
+    ASSERT_EQ(GetNumberOfUserDefinedRateParameters(current_state, &error), num_user_defined_reaction_rates);
+    ASSERT_TRUE(IsSuccess(error));
+
+    // Get pointers to the data
+    int n_species, n_cells, n_params;
+    micm::Conditions* conditions = GetConditionsPointer(current_state, &n_cells, &error);
+    ASSERT_TRUE(IsSuccess(error));
+    ASSERT_EQ(n_cells, state_size);
+    double* concentrations = GetOrderedConcentrationsPointer(current_state, &n_species, &n_cells, &error);
+    ASSERT_TRUE(IsSuccess(error));
+    ASSERT_EQ(n_species, num_concentrations);
+    ASSERT_EQ(n_cells, state_size);
+    double* user_defined_params = GetOrderedRateConstantsPointer(current_state, &n_params, &n_cells, &error);
+    ASSERT_TRUE(IsSuccess(error));
+    ASSERT_EQ(n_params, num_user_defined_reaction_rates);
+    ASSERT_EQ(n_cells, state_size);
+    
+    // Get matrix strides
+    size_t grid_cell_stride_species;
+    size_t species_stride;
+    size_t grid_cell_stride_params;
+    size_t params_stride;
+    GetConcentrationStrides(current_state, &error, &grid_cell_stride_species, &species_stride);
+    ASSERT_TRUE(IsSuccess(error));
+    GetUserDefinedRateParameterStrides(current_state, &error, &grid_cell_stride_params, &params_stride);
+    ASSERT_TRUE(IsSuccess(error));
+
+    // Set up an intial concentration vector
+    std::vector<double> initial_concentrations(state_size * num_concentrations);
+
+    for (int i = 0; i < state_size; ++i)
+    {
+      conditions[i].temperature_ = 275.0 + (rand() % 20 - 10);
+      conditions[i].pressure_ = 101253.3 + (rand() % 1000 - 500);
+      conditions[i].air_density_ = conditions[i].pressure_ / (GAS_CONSTANT * conditions[i].temperature_);
+      concentrations[i * grid_cell_stride_species + A_index * species_stride] = 0.75 + (rand() % 10 - 5) * 0.01;
+      concentrations[i * grid_cell_stride_species + B_index * species_stride] = 0.0;
+      concentrations[i * grid_cell_stride_species + C_index * species_stride] = 0.4 + (rand() % 10 - 5) * 0.01;
+      concentrations[i * grid_cell_stride_species + D_index * species_stride] = 0.8 + (rand() % 10 - 5) * 0.01;
+      concentrations[i * grid_cell_stride_species + E_index * species_stride] = 0.0;
+      concentrations[i * grid_cell_stride_species + F_index * species_stride] = 0.1 + (rand() % 10 - 5) * 0.01;
+      user_defined_params[i * grid_cell_stride_params + R1_index * params_stride] = 0.001 + (rand() % 10 - 5) * 0.0001;
+      user_defined_params[i * grid_cell_stride_params + R2_index * params_stride] = 0.002 + (rand() % 10 - 5) * 0.0001;
+      for (int j = 0; j < num_concentrations; ++j)
+      {
+        initial_concentrations[i * num_concentrations + j] = concentrations[i * grid_cell_stride_species + j * species_stride];
+      }
+    }
+
+    String solver_state;
+    SolverResultStats solver_stats;
+    MicmSolve(micm, current_state, time_step, &solver_state, &solver_stats, &error);
+    ASSERT_TRUE(IsSuccess(error));
+    DeleteError(&error);
+
+    // update the concentrations pointer because MICM solve function may have swapped temporary state vectors
+    concentrations = GetOrderedConcentrationsPointer(current_state, &n_species, &n_cells, &error);
+    ASSERT_TRUE(IsSuccess(error));
+
+    // Add assertions to check the solved concentrations
+    ArrheniusReaction arr1;
+    arr1.A_ = 0.004;
+    arr1.C_ = 50.0;
+    ArrheniusReaction arr2{ 0.012, -2, 75, 50, 1.0e-6 };
+
+    ASSERT_STREQ(solver_state.value_, "Converged");
+    DeleteString(&solver_state);
+
+    for (int i_cell = 0; i_cell < state_size; ++i_cell)
+    {
+      double initial_A = initial_concentrations[i_cell * num_concentrations + A_index];
+      double initial_C = initial_concentrations[i_cell * num_concentrations + C_index];
+      double initial_D = initial_concentrations[i_cell * num_concentrations + D_index];
+      double initial_F = initial_concentrations[i_cell * num_concentrations + F_index];
+      double k1 = user_defined_params[i_cell * grid_cell_stride_params + R1_index * params_stride];
+      double k2 = user_defined_params[i_cell * grid_cell_stride_params + R2_index * params_stride];
+      double k3 = CalculateArrhenius(arr1, conditions[i_cell].temperature_, conditions[i_cell].pressure_);
+      double k4 = CalculateArrhenius(arr2, conditions[i_cell].temperature_, conditions[i_cell].pressure_);
+      double A = initial_A * std::exp(-k3 * time_step);
+      double B = initial_A * (k3 / (k4 - k3)) * (std::exp(-k3 * time_step) - std::exp(-k4 * time_step));
+      double C = initial_C + initial_A * (1.0 + (k3 * std::exp(-k4 * time_step) - k4 * std::exp(-k3 * time_step)) / (k4 - k3));
+      double D = initial_D * std::exp(-k1 * time_step);
+      double E = initial_D * (k1 / (k2 - k1)) * (std::exp(-k1 * time_step) - std::exp(-k2 * time_step));
+      double F = initial_F + initial_D * (1.0 + (k1 * std::exp(-k2 * time_step) - k2 * std::exp(-k1 * time_step)) / (k2 - k1));
+      ASSERT_NEAR(concentrations[i_cell * grid_cell_stride_species + A_index * species_stride], A, test_accuracy);
+      ASSERT_NEAR(concentrations[i_cell * grid_cell_stride_species + B_index * species_stride], B, test_accuracy);
+      ASSERT_NEAR(concentrations[i_cell * grid_cell_stride_species + C_index * species_stride], C, test_accuracy);
+      ASSERT_NEAR(concentrations[i_cell * grid_cell_stride_species + D_index * species_stride], D, test_accuracy);
+      ASSERT_NEAR(concentrations[i_cell * grid_cell_stride_species + E_index * species_stride], E, test_accuracy);
+      ASSERT_NEAR(concentrations[i_cell * grid_cell_stride_species + F_index * species_stride], F, test_accuracy);
+    }
+  }
+  DeleteState(state_1, &error);
+  ASSERT_TRUE(IsSuccess(error));
+  if (state_2 != nullptr)
+  {
+    DeleteState(state_2, &error);
+    ASSERT_TRUE(IsSuccess(error));
+  }
+  DeleteError(&error);
+}
+
 // Test case for solving multiple grid cells using vector-ordered Rosenbrock solver
 TEST_F(MicmCApiTestFixture, SolveMultipleGridCellsUsingVectorOrderedRosenbrock)
 {
-  constexpr size_t num_grid_cells = MICM_DEFAULT_VECTOR_SIZE;
   constexpr double time_step = 200.0;
   constexpr double test_accuracy = 5.0e-3;
   const char* config_path = "configs/analytical";
   Error error;
   DeleteMicm(micm, &error);
-  DeleteState(state, &error);
   ASSERT_TRUE(IsSuccess(error));
   micm = CreateMicm(config_path, MICMSolver::Rosenbrock, &error);
-  state = CreateMicmState(micm, num_grid_cells, &error);
   ASSERT_TRUE(IsSuccess(error));
-  TestVectorMultipleGridCells(micm, state, num_grid_cells, time_step, test_accuracy);
-  DeleteError(&error);
+  size_t max_cells = GetMaximumNumberOfGridCells(micm);
+  ASSERT_GT(max_cells, 0);
+  for (int num_grid_cells = 1; num_grid_cells <= max_cells * 3; num_grid_cells += std::floor(max_cells / 3))
+  {
+    TestMultipleGridCells(micm, num_grid_cells, time_step, test_accuracy);
+    DeleteError(&error);
+  }
 }
 
 // Test case for solving multiple grid cells using standard-ordered Rosenbrock solver

--- a/src/test/unit/micm/micm_c_api.cpp
+++ b/src/test/unit/micm/micm_c_api.cpp
@@ -387,7 +387,7 @@ void TestSolver(
   ASSERT_TRUE(IsSuccess(error));
   DeleteMappings(&rate_ordering);
 
-  for (int i_state = 0; i_state < std::ceil(num_grid_cells/state_1_size); ++i_state)
+  for (int i_state = 0; i_state < std::ceil(static_cast<double>(num_grid_cells)/state_1_size); ++i_state)
   {
     // Get the right state and set dimensions
     size_t state_size = std::min(num_grid_cells - i_state * state_1_size, state_1_size);
@@ -510,7 +510,7 @@ TEST_F(MicmCApiTestFixture, SolveMultipleGridCellsUsingVectorOrderedRosenbrock)
   ASSERT_TRUE(IsSuccess(error));
   size_t max_cells = GetMaximumNumberOfGridCells(micm);
   ASSERT_GT(max_cells, 0);
-  for (int num_grid_cells = 1; num_grid_cells <= max_cells * 3; num_grid_cells += std::floor(max_cells / 3))
+  for (int num_grid_cells = 1; num_grid_cells <= max_cells * 3; num_grid_cells += static_cast<int>(std::floor(max_cells / 3)))
   {
     TestSolver(micm, num_grid_cells, time_step, test_accuracy);
     DeleteError(&error);


### PR DESCRIPTION
Updates the C and Fortran APIs to correctly traverse the vector-ordered MICM matrices.

Now, there is a single user-side pattern that can be used to interact with MICM state data without specific logic for vector or standard matrix ordering. Also, updates naming and removes unneeded functions to improve the consistency across the C, Fortran, and Python APIs.

closes #272