### PR TITLE
testing build action

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: CI Build Wheels with GPU support
       uses: pypa/cibuildwheel@v2.17
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: github.event_name != 'release'
       env:
         CIBW_ENVIRONMENT_PASS_LINUX: CIBW_ARCHS
         CIBW_ENVIRONMENT_LINUX: >

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -48,7 +48,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: pypa/cibuildwheel@v2.17
+    - name: CI Build Wheels with GPU support
+      uses: pypa/cibuildwheel@v2.17
+      if: github.event_name == 'release' && github.event.action == 'published'
       env:
         CIBW_ENVIRONMENT_PASS_LINUX: CIBW_ARCHS
         CIBW_ENVIRONMENT_LINUX: >
@@ -62,6 +64,16 @@ jobs:
         CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
         CIBW_BEFORE_ALL_LINUX: musica/tools/prepare_build_environment_linux.sh
         # CIBW_BEFORE_ALL_WINDOWS: bash musica/tools/prepare_build_environment_windows.sh
+
+    - name: CI Build Wheels without GPU support for release
+      uses: pypa/cibuildwheel@v2.17
+      if: github.event_name == 'release' && github.event.action == 'published'
+      env:
+        CIBW_ENVIRONMENT_PASS_LINUX: CIBW_ARCHS
+        CIBW_ENVIRONMENT_PASS_WINDOWS: CIBW_ARCHS
+        CIBW_ARCHS_MACOS: arm64 x86_64
+        CIBW_SKIP: cp27-* cp34-* cp35-* cp36-* *musllinux*
+        CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
It turns out when building the python library with cuda support, we end up needing to include the cuda libraries in the wheel file and they are over 100MB. That is too much for pypi. [The error showing it's too large.](https://github.com/NCAR/musica/actions/runs/14937523426/job/42075150698)

This PR adds a test to make sure the cuda python build will succeed, but we will only package up the CPU code for the actual pypi release (for now).

Below lists the size of the cuda files
```
:: zipinfo musica-0.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Archive:  musica-0.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Zip file size: 419880595 bytes, number of entries: 42
drwxr-xr-x  2.0 unx        0 b- stor 25-May-09 21:04 lib64/
drwxr-xr-x  2.0 unx        0 b- stor 25-May-09 21:04 musica.libs/
drwxr-xr-x  2.0 unx        0 b- stor 25-May-09 21:04 musica-0.11.0.dist-info/
drwxr-xr-x  2.0 unx        0 b- stor 25-May-09 21:04 musica/
-rwxr-xr-x  2.0 unx  4221985 b- defN 25-May-09 21:04 _musica.cpython-310-x86_64-linux-gnu.so
-rw-r--r--  2.0 unx  2621314 b- defN 25-May-09 21:04 lib64/libmusica.a
-rw-r--r--  2.0 unx  1158838 b- defN 25-May-09 21:04 lib64/libyaml-cpp.a
-rwxr-xr-x  2.0 unx   699273 b- defN 25-May-09 21:04 musica.libs/libcudart-b5a066d7.so.12.2.140
-rwxr-xr-x  2.0 unx 106737761 b- defN 25-May-09 21:04 musica.libs/libcublas-e779a79d.so.12.2.5.6
-rwxr-xr-x  2.0 unx 525872001 b- defN 25-May-09 21:04 musica.libs/libcublasLt-fbfbc8a1.so.12.2.5.6
...
(base) [kshores] ~/Downloads/cibw-wheels-ubuntu-latest-py3.12 

```

- [Relevant discussion](https://discuss.python.org/t/what-to-do-about-gpus-and-the-built-distributions-that-support-them/7125/64)