### PR TITLE
putting so file into musica folder, updating relative rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # must be on the same line so that pyproject.toml can correctly identify the version
-project(musica-distribution VERSION 0.11.1.2)
+project(musica-distribution VERSION 0.11.1.3)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_USER_MAKE_RULES_OVERRIDE ${PROJECT_SOURCE_DIR}/cmake/SetDefaults.cmake)

--- a/musica/CMakeLists.txt
+++ b/musica/CMakeLists.txt
@@ -19,15 +19,8 @@ if (APPLE)
     BUILD_WITH_INSTALL_RPATH TRUE
   )
 elseif(UNIX)
-  set(CUDA_RPATH
-    "$ORIGIN/../../nvidia/cublas/lib"
-    "$ORIGIN/../../nvidia/cuda_runtime/lib"
-  )
-
-  message(STATUS "Adding RPATH for python site packages libs at ${CUDA_RPATH}")
-
   set_target_properties(_musica PROPERTIES
-    INSTALL_RPATH "$ORIGIN;${CUDA_RPATH}"
+    INSTALL_RPATH "$ORIGIN"
     BUILD_WITH_INSTALL_RPATH TRUE
   )
 endif()
@@ -44,4 +37,11 @@ else()
   set(PYTHON_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
-install(TARGETS _musica yaml-cpp musica LIBRARY DESTINATION .)
+install(TARGETS _musica LIBRARY DESTINATION musica)
+
+install(
+  TARGETS 
+    yaml-cpp musica 
+    LIBRARY DESTINATION musica/lib
+    ARCHIVE DESTINATION musica/lib
+)

--- a/musica/__init__.py
+++ b/musica/__init__.py
@@ -1,3 +1,3 @@
-from _musica import *
+from musica._musica import *
 from .types import *
 from .mechanism_configuration import *

--- a/musica/mechanism_configuration.py
+++ b/musica/mechanism_configuration.py
@@ -4,7 +4,7 @@
 # This file is part of the musica Python package.
 # For more information, see the LICENSE file in the top-level directory of this distribution.
 from typing import Optional, Any, Dict, List, Union, Tuple
-from _musica._mechanism_configuration import (
+from musica._musica._mechanism_configuration import (
     _ReactionType,
     _Species,
     _Phase,

--- a/musica/test/test_analytical.py
+++ b/musica/test/test_analytical.py
@@ -3,7 +3,7 @@ import numpy as np
 import musica
 import random
 import musica.mechanism_configuration as mc
-from _musica._core import _is_cuda_available
+from musica._musica._core import _is_cuda_available
 
 
 def TestSingleGridCell(solver, state, time_step, places=5):

--- a/musica/test/test_parser.py
+++ b/musica/test/test_parser.py
@@ -1,6 +1,6 @@
 import pytest
 from musica.mechanism_configuration import *
-from _musica._mechanism_configuration import _ReactionType
+from musica._musica._mechanism_configuration import _ReactionType
 
 
 def validate_species(species):

--- a/musica/tools/repair_wheel_gpu.sh
+++ b/musica/tools/repair_wheel_gpu.sh
@@ -11,7 +11,7 @@ for whl in "$2"/*.whl; do
   readelf -d "$tmpdir"/_musica*.so
   # Use patchelf to fix the rpath and library dependencies
   patchelf --remove-rpath "$tmpdir"/_musica*.so
-  patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../../nvidia/cublas/lib:\$ORIGIN/../../nvidia/cuda_runtime/lib" --force-rpath "$tmpdir"/_musica*.so
+  patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../nvidia/cublas/lib:\$ORIGIN/../nvidia/cuda_runtime/lib" --force-rpath "$tmpdir"/_musica*.so
   # these may need to be periodically updated
   patchelf --replace-needed libcudart-b5a066d7.so.12.2.140 libcudart.so.12 "$tmpdir"/_musica*.so
   patchelf --replace-needed libcublas-e779a79d.so.12.2.5.6 libcublas.so.12 "$tmpdir"/_musica*.so

--- a/musica/tools/repair_wheel_gpu.sh
+++ b/musica/tools/repair_wheel_gpu.sh
@@ -7,21 +7,22 @@ for whl in "$2"/*.whl; do
   tmpdir=$(mktemp -d)
   unzip -q "$whl" -d "$tmpdir"
   tree "$tmpdir"
+  so_path="$tmpdir"/musica/_musica*.so
   echo "Before patchelf:"
-  readelf -d "$tmpdir"/_musica*.so
+  readelf -d $so_path
   # Use patchelf to fix the rpath and library dependencies
-  patchelf --remove-rpath "$tmpdir"/_musica*.so
-  patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../nvidia/cublas/lib:\$ORIGIN/../nvidia/cuda_runtime/lib" --force-rpath "$tmpdir"/_musica*.so
+  patchelf --remove-rpath $so_path
+  patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../nvidia/cublas/lib:\$ORIGIN/../nvidia/cuda_runtime/lib" --force-rpath $so_path
   # these may need to be periodically updated
-  patchelf --replace-needed libcudart-b5a066d7.so.12.2.140 libcudart.so.12 "$tmpdir"/_musica*.so
-  patchelf --replace-needed libcublas-e779a79d.so.12.2.5.6 libcublas.so.12 "$tmpdir"/_musica*.so
-  patchelf --replace-needed libcublasLt-fbfbc8a1.so.12.2.5.6 libcublasLt.so.12 "$tmpdir"/_musica*.so
+  patchelf --replace-needed libcudart-b5a066d7.so.12.2.140 libcudart.so.12 $so_path
+  patchelf --replace-needed libcublas-e779a79d.so.12.2.5.6 libcublas.so.12 $so_path
+  patchelf --replace-needed libcublasLt-fbfbc8a1.so.12.2.5.6 libcublasLt.so.12 $so_path
   # Remove bundled CUDA libraries
   rm -f "$tmpdir"/musica.libs/libcudart-*.so*
   rm -f "$tmpdir"/musica.libs/libcublas-*.so*
   rm -f "$tmpdir"/musica.libs/libcublasLt-*.so*
   echo "After patchelf:"
-  readelf -d "$tmpdir"/_musica*.so
+  readelf -d $so_path
   # Repack the wheel with correct structure
   (cd "$tmpdir" && zip -qr "${whl%.whl}.patched.whl" .)
   rm -rf "$tmpdir"

--- a/musica/types.py
+++ b/musica/types.py
@@ -3,10 +3,10 @@
 #
 # This file is part of the musica Python package.
 # For more information, see the LICENSE file in the top-level directory of this distribution.
-from typing import Optional, Any, Dict, List, Union, Tuple
+from typing import Optional, Dict, List, Union, Tuple
 from os import PathLike
 import math
-from _musica._core import (
+from musica._musica._core import (
     _Conditions,
     _SolverType,
     _Solver,


### PR DESCRIPTION
This PR restructures the python package

before, in the site packages directory we would install `lib` `_musica*.so`, and `musica`. Now, all files are under `musica`. 

I also corrected the path of the nvidia files which should be located at `../nvidia/*`, meaning relative to the `so` location. I misunderstood where this would be from before. 

I think with these changes, we may actually be able to install musica from pypi on linux. A remaining problem is that now linux users are required to install the gpu option, I think, because the `so` file requires the cuda files to be found. That's an issue I'll solve once I can verify this works. I was able to test an install from a wheel file like this on derecho:

```
pip install "musica[gpu] @ file://$HOME/temp/musica-0.11.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
```

That worked. But I won't believe it until I see it from pypi