### PR TITLE
Fix case sensitive string comparison in pkgconfig generation

### DIFF
--- a/fortran/packaging/CMakeLists.txt
+++ b/fortran/packaging/CMakeLists.txt
@@ -41,7 +41,7 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion
 )
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if("${CMAKE_BUILD_TYPE}" MATCHES "^[Dd][Ee][Bb][Uu][Gg]$")
   set(IS_DEBUG "")
 else()
   set(IS_DEBUG "#")

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -93,7 +93,7 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion
 )
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if("${CMAKE_BUILD_TYPE}" MATCHES "^[Dd][Ee][Bb][Uu][Gg]$")
   set(IS_DEBUG "")
 else()
   set(IS_DEBUG "#")


### PR DESCRIPTION
A case-sensitive string comparison was being used to check the CMake build type when creating the pkf-config file. This modifies the logic to use case-insensitive comparisons.