### PR TITLE
Update the Spack script to use the new version of MUSICA

### DIFF
--- a/.github/workflows/format-python.yml
+++ b/.github/workflows/format-python.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          git commit -am "Auto-format code using Clang-Format" || echo "No changes to commit"
+          git commit -am "Auto-format code using PEP8" || echo "No changes to commit"
 
       - name: Push changes to main-autopep8 branch
         if: steps.check-changes.outcome != 'success'

--- a/spack/packages/musica/package.py
+++ b/spack/packages/musica/package.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
 from spack.package import *
 
 
@@ -17,7 +19,7 @@ class Musica(CMakePackage):
     """
 
     homepage = "https://github.com/NCAR/musica"
-    url = "https://github.com/NCAR/musica/archive/refs/tags/v0.10.1.tar.gz"
+    url = "https://github.com/NCAR/musica/archive/refs/tags/v0.12.0.tar.gz"
     git = "https://github.com/NCAR/musica.git"
 
     maintainers("kshores", "mattldawson", "boulderdaze")
@@ -25,6 +27,7 @@ class Musica(CMakePackage):
     license("Apache-2.0", checked_by="kshores")
 
     # Versions
+    version("0.12.0", sha256="e81279fbdd42af8bf6540f18e72857ed34e081421a90333c77f9952a3069363b")
     version("0.10.1", sha256="edefab03a676a449761997734e6c5b654b2c4f92ce8f1cc66ef63b8ae8ccccf1")
 
     # Options from CMake
@@ -40,6 +43,7 @@ class Musica(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build")
     depends_on("mpi", when="+mpi")
+    depends_on("netcdf-fortran", when="+tuvx")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
Update the Spack script to use the new version of MUSICA

This is the same change that got approved in the last PR. I messed up when reverting the main branch, and the update got lost.