### PR TITLE
add intersphinx linking to Musica

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx'
 ]
 
 breathe_default_project = "musica"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,13 @@ exclude_patterns = []
 
 autosummary_generate = True
 
+# -- Intersphinx mappings -------------
+intersphinx_mapping = {
+    'musica': ('http://localhost:8000/', None),
+    'micm': ('https://ncar.github.io/micm/', None),
+    'mc': ('https://ncar.github.io/MechanismConfiguration/', None),
+    'mb': ('https://ncar.github.io/music-box/',None)
+}
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,6 @@ autosummary_generate = True
 
 # -- Intersphinx mappings -------------
 intersphinx_mapping = {
-    'musica': ('http://localhost:8000/', None),
     'micm': ('https://ncar.github.io/micm/', None),
     'mc': ('https://ncar.github.io/MechanismConfiguration/', None),
     'mb': ('https://ncar.github.io/music-box/',None)

--- a/docs/source/user_guide/configurations.rst
+++ b/docs/source/user_guide/configurations.rst
@@ -1,5 +1,3 @@
 ##############
 Configurations
 ##############
-
-:class:`mb:acom_music_box.music_box.MusicBox`

--- a/docs/source/user_guide/configurations.rst
+++ b/docs/source/user_guide/configurations.rst
@@ -2,3 +2,4 @@
 Configurations
 ##############
 
+:class:`mb:acom_music_box.music_box.MusicBox`


### PR DESCRIPTION
intersphinx extension sets up an objects.inv file to be referenced from MusicBox (and other documentation in the future). I set up links to MICM, MusicBox, and Mechanism Configuration for future reference. 

Note: I tested the existing MusicBox links to this new Musica intersphinx object on my local server and they all work. But I will still be adjusting MusicBox slightly

closes #386 