### PR TITLE
moving backend import logic to its own file

### DIFF
--- a/musica/__init__.py
+++ b/musica/__init__.py
@@ -1,51 +1,11 @@
-import importlib.util
+"""
+MUSICA: A Python library for atmospheric chemistry simulations.
+"""
 
-
-def _safe_find_spec(name):
-    try:
-        return importlib.util.find_spec(name)
-    except ModuleNotFoundError:
-        return None
-
-
-def _gpu_deps_installed():
-    return (
-        _safe_find_spec("nvidia.cublas") is not None or
-        _safe_find_spec("nvidia_cuda_runtime") is not None or
-        _safe_find_spec("nvidia-cublas-cu12") is not None or
-        _safe_find_spec("nvidia-cuda-runtime-cu12") is not None
-    )
-
-
-if _gpu_deps_installed():
-    from . import _musica_gpu as _backend
-else:
-    from . import _musica as _backend
-
-# Helper to re-export names from a module
-def _export_all(module, names, globals_):
-    for name in names:
-        globals_[name] = getattr(module, name)
-
-
-_core_names = [
-    "_Conditions", "_SolverType", "_Solver", "_State", "_create_solver",
-    "_create_solver_from_mechanism", "_create_state", "_micm_solve", "_vector_size",
-    "_species_ordering", "_user_defined_rate_parameters_ordering",
-]
-_mechanism_names = [
-    "_ReactionType", "_Species", "_Phase", "_ReactionComponent", "_Arrhenius",
-    "_CondensedPhaseArrhenius", "_Troe", "_Branched", "_Tunneling", "_Surface",
-    "_Photolysis", "_CondensedPhasePhotolysis", "_Emission", "_FirstOrderLoss",
-    "_AqueousEquilibrium", "_WetDeposition", "_HenrysLaw", "_SimpolPhaseTransfer",
-    "_UserDefined", "_Reactions", "_ReactionsIterator", "_Mechanism", "_Version", "_Parser"
-]
-
-# this allows us to use the same symbols in both the GPU and CPU versionspp
-_export_all(_backend._core, _core_names, globals())
-_export_all(_backend._mechanism_configuration, _mechanism_names, globals())
-
-__all__ = _core_names + _mechanism_names
-
-from .types import MICM, SolverType, State, Conditions
 from ._version import version as __version__
+from .types import MICM, SolverType, State, Conditions
+from . import mechanism_configuration
+
+__all__ = [
+    "MICM", "SolverType", "State", "Conditions", "mechanism_configuration",
+]

--- a/musica/backend.py
+++ b/musica/backend.py
@@ -1,0 +1,29 @@
+"""
+Backend selection and symbol loading for MUSICA.
+"""
+import importlib.util
+
+
+def _safe_find_spec(name):
+    try:
+        return importlib.util.find_spec(name)
+    except ModuleNotFoundError:
+        return None
+
+
+def _gpu_deps_installed():
+    return (
+        _safe_find_spec("nvidia.cublas") is not None or
+        _safe_find_spec("nvidia_cuda_runtime") is not None or
+        _safe_find_spec("nvidia-cublas-cu12") is not None or
+        _safe_find_spec("nvidia-cuda-runtime-cu12") is not None
+    )
+
+
+def get_backend():
+    """Get the appropriate backend module."""
+    if _gpu_deps_installed():
+        import musica._musica_gpu as backend
+    else:
+        import musica._musica as backend
+    return backend

--- a/musica/cuda.py
+++ b/musica/cuda.py
@@ -1,4 +1,4 @@
-from . import _backend
+from . import backend
 
 def is_cuda_available() -> bool:
     """
@@ -7,4 +7,4 @@ def is_cuda_available() -> bool:
     Returns:
         bool: True if CUDA is available, False otherwise.
     """
-    return _backend._core._is_cuda_available()
+    return backend.get_backend()._core._is_cuda_available()

--- a/musica/mechanism_configuration.py
+++ b/musica/mechanism_configuration.py
@@ -1,0 +1,46 @@
+"""
+Mechanism configuration module for MUSICA.
+
+This module provides classes and functions for creating and configuring
+chemical mechanisms for use with MICM solvers.
+"""
+
+from ._backend_loader import get_backend
+
+# Get the backend and expose mechanism configuration classes
+_backend = get_backend()
+_mc = _backend._mechanism_configuration
+
+# Re-export all mechanism configuration classes without underscores
+ReactionType = _mc._ReactionType
+Species = _mc._Species
+Phase = _mc._Phase
+ReactionComponent = _mc._ReactionComponent
+Arrhenius = _mc._Arrhenius
+CondensedPhaseArrhenius = _mc._CondensedPhaseArrhenius
+Troe = _mc._Troe
+Branched = _mc._Branched
+Tunneling = _mc._Tunneling
+Surface = _mc._Surface
+Photolysis = _mc._Photolysis
+CondensedPhasePhotolysis = _mc._CondensedPhasePhotolysis
+Emission = _mc._Emission
+FirstOrderLoss = _mc._FirstOrderLoss
+AqueousEquilibrium = _mc._AqueousEquilibrium
+WetDeposition = _mc._WetDeposition
+HenrysLaw = _mc._HenrysLaw
+SimpolPhaseTransfer = _mc._SimpolPhaseTransfer
+UserDefined = _mc._UserDefined
+Reactions = _mc._Reactions
+ReactionsIterator = _mc._ReactionsIterator
+Mechanism = _mc._Mechanism
+Version = _mc._Version
+Parser = _mc._Parser
+
+__all__ = [
+    "ReactionType", "Species", "Phase", "ReactionComponent", "Arrhenius",
+    "CondensedPhaseArrhenius", "Troe", "Branched", "Tunneling", "Surface",
+    "Photolysis", "CondensedPhasePhotolysis", "Emission", "FirstOrderLoss",
+    "AqueousEquilibrium", "WetDeposition", "HenrysLaw", "SimpolPhaseTransfer",
+    "UserDefined", "Reactions", "ReactionsIterator", "Mechanism", "Version", "Parser"
+]

--- a/musica/mechanism_configuration/aqueous_equilibrium.py
+++ b/musica/mechanism_configuration/aqueous_equilibrium.py
@@ -1,9 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _AqueousEquilibrium, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_AqueousEquilibrium = _backend._mechanism_configuration._AqueousEquilibrium
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class AqueousEquilibrium(_AqueousEquilibrium):
@@ -28,7 +33,8 @@ class AqueousEquilibrium(_AqueousEquilibrium):
         name: Optional[str] = None,
         aerosol_phase: Optional[Phase] = None,
         aerosol_phase_water: Optional[Species] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         A: Optional[float] = None,
         C: Optional[float] = None,

--- a/musica/mechanism_configuration/arrhenius.py
+++ b/musica/mechanism_configuration/arrhenius.py
@@ -1,10 +1,15 @@
 from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Arrhenius, _ReactionComponent
+from .. import backend
 from .phase import Phase
 from .species import Species
 from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
 from musica.constants import BOLTZMANN
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Arrhenius = _backend._mechanism_configuration._Arrhenius
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Arrhenius(_Arrhenius):
@@ -46,7 +51,8 @@ class Arrhenius(_Arrhenius):
         Ea: Optional[float] = None,
         D: Optional[float] = None,
         E: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,

--- a/musica/mechanism_configuration/branched.py
+++ b/musica/mechanism_configuration/branched.py
@@ -1,9 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Branched, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Branched = _backend._mechanism_configuration._Branched
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Branched(_Branched):
@@ -32,9 +37,12 @@ class Branched(_Branched):
         Y: Optional[float] = None,
         a0: Optional[float] = None,
         n: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
-        nitrate_products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
-        alkoxy_products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
+        nitrate_products: Optional[List[Union[Species,
+                                              Tuple[float, Species]]]] = None,
+        alkoxy_products: Optional[List[Union[Species,
+                                             Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,
     ):

--- a/musica/mechanism_configuration/condensed_phase_arrhenius.py
+++ b/musica/mechanism_configuration/condensed_phase_arrhenius.py
@@ -1,10 +1,15 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _CondensedPhaseArrhenius, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
-from .utils import _add_other_properties, _remove_empty_keys
 from musica.constants import BOLTZMANN
+from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_CondensedPhaseArrhenius = _backend._mechanism_configuration._CondensedPhaseArrhenius
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class CondensedPhaseArrhenius(_CondensedPhaseArrhenius):
@@ -35,7 +40,8 @@ class CondensedPhaseArrhenius(_CondensedPhaseArrhenius):
         Ea: Optional[float] = None,
         D: Optional[float] = None,
         E: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         aerosol_phase: Optional[Phase] = None,
         aerosol_phase_water: Optional[Species] = None,

--- a/musica/mechanism_configuration/condensed_phase_photolysis.py
+++ b/musica/mechanism_configuration/condensed_phase_photolysis.py
@@ -1,10 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _CondensedPhasePhotolysis, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
 
+# Get backend symbols
+_backend = backend.get_backend()
+_CondensedPhasePhotolysis = _backend._mechanism_configuration._CondensedPhasePhotolysis
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class CondensedPhasePhotolysis(_CondensedPhasePhotolysis):
@@ -25,7 +29,8 @@ class CondensedPhasePhotolysis(_CondensedPhasePhotolysis):
         self,
         name: Optional[str] = None,
         scaling_factor: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         aerosol_phase: Optional[Phase] = None,
         aerosol_phase_water: Optional[Species] = None,

--- a/musica/mechanism_configuration/emission.py
+++ b/musica/mechanism_configuration/emission.py
@@ -1,9 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Emission, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Emission = _backend._mechanism_configuration._Emission
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Emission(_Emission):

--- a/musica/mechanism_configuration/first_order_loss.py
+++ b/musica/mechanism_configuration/first_order_loss.py
@@ -1,9 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _FirstOrderLoss, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_FirstOrderLoss = _backend._mechanism_configuration._FirstOrderLoss
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class FirstOrderLoss(_FirstOrderLoss):
@@ -22,7 +27,8 @@ class FirstOrderLoss(_FirstOrderLoss):
         self,
         name: Optional[str] = None,
         scaling_factor: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,
     ):

--- a/musica/mechanism_configuration/henrys_law.py
+++ b/musica/mechanism_configuration/henrys_law.py
@@ -1,8 +1,13 @@
 from typing import Optional, Any, Dict, Union, Tuple
-from musica import _HenrysLaw, _ReactionComponent
+from .. import backend
 from .phase import Phase
 from .species import Species
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_HenrysLaw = _backend._mechanism_configuration._HenrysLaw
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class HenrysLaw(_HenrysLaw):
@@ -23,10 +28,12 @@ class HenrysLaw(_HenrysLaw):
         self,
         name: Optional[str] = None,
         gas_phase: Optional[Phase] = None,
-        gas_phase_species: Optional[Union[Species, Tuple[float, Species]]] = None,
+        gas_phase_species: Optional[Union[Species,
+                                          Tuple[float, Species]]] = None,
         aerosol_phase: Optional[Phase] = None,
         aerosol_phase_water: Optional[Species] = None,
-        aerosol_phase_species: Optional[Union[Species, Tuple[float, Species]]] = None,
+        aerosol_phase_species: Optional[Union[Species,
+                                              Tuple[float, Species]]] = None,
         other_properties: Optional[Dict[str, Any]] = None,
     ):
         """

--- a/musica/mechanism_configuration/mechanism_configuration.py
+++ b/musica/mechanism_configuration/mechanism_configuration.py
@@ -3,29 +3,36 @@
 #
 # This file is part of the musica Python package.
 # For more information, see the LICENSE file in the top-level directory of this distribution.
+from .reactions import Reactions, ReactionType
+from .user_defined import UserDefined, _UserDefined
+from .simpol_phase_transfer import SimpolPhaseTransfer, _SimpolPhaseTransfer
+from .henrys_law import HenrysLaw, _HenrysLaw
+from .wet_deposition import WetDeposition, _WetDeposition
+from .aqueous_equilibrium import AqueousEquilibrium, _AqueousEquilibrium
+from .first_order_loss import FirstOrderLoss, _FirstOrderLoss
+from .emission import Emission, _Emission
+from .condensed_phase_photolysis import CondensedPhasePhotolysis, _CondensedPhasePhotolysis
+from .photolysis import Photolysis, _Photolysis
+from .surface import Surface, _Surface
+from .tunneling import Tunneling, _Tunneling
+from .branched import Branched, _Branched
+from .troe import Troe, _Troe
+from .condensed_phase_arrhenius import CondensedPhaseArrhenius, _CondensedPhaseArrhenius
+from .arrhenius import Arrhenius, _Arrhenius
+from .phase import Phase
+from .species import Species
 import os
 import json
 import yaml
 from typing import Optional, Any, Dict, List
-from musica import _Mechanism, _Version, _Parser
-from .species import Species
-from .phase import Phase
-from .arrhenius import Arrhenius, _Arrhenius
-from .condensed_phase_arrhenius import CondensedPhaseArrhenius, _CondensedPhaseArrhenius
-from .troe import Troe, _Troe
-from .branched import Branched, _Branched
-from .tunneling import Tunneling, _Tunneling
-from .surface import Surface, _Surface
-from .photolysis import Photolysis, _Photolysis
-from .condensed_phase_photolysis import CondensedPhasePhotolysis, _CondensedPhasePhotolysis
-from .emission import Emission, _Emission
-from .first_order_loss import FirstOrderLoss, _FirstOrderLoss
-from .aqueous_equilibrium import AqueousEquilibrium, _AqueousEquilibrium
-from .wet_deposition import WetDeposition, _WetDeposition
-from .henrys_law import HenrysLaw, _HenrysLaw
-from .simpol_phase_transfer import SimpolPhaseTransfer, _SimpolPhaseTransfer
-from .user_defined import UserDefined, _UserDefined
-from .reactions import Reactions, ReactionType
+from musica import backend
+
+# Get the backend and import mechanism configuration classes
+_backend = backend.get_backend()
+_mc = _backend._mechanism_configuration
+_Mechanism = _mc._Mechanism
+_Version = _mc._Version
+_Parser = _mc._Parser
 
 
 class Version(_Version):
@@ -68,7 +75,8 @@ class Mechanism(_Mechanism):
         self.name = name
         self.species = species if species is not None else []
         self.phases = phases if phases is not None else []
-        self.reactions = Reactions(reactions=reactions if reactions is not None else [])
+        self.reactions = Reactions(
+            reactions=reactions if reactions is not None else [])
         self.version = version if version is not None else Version()
 
     def to_dict(self) -> Dict:
@@ -87,9 +95,11 @@ class Mechanism(_Mechanism):
             elif isinstance(reaction, (_Branched, Branched)):
                 reactions_list.append(Branched.serialize(reaction))
             elif isinstance(reaction, (_CondensedPhaseArrhenius, CondensedPhaseArrhenius)):
-                reactions_list.append(CondensedPhaseArrhenius.serialize(reaction))
+                reactions_list.append(
+                    CondensedPhaseArrhenius.serialize(reaction))
             elif isinstance(reaction, (_CondensedPhasePhotolysis, CondensedPhasePhotolysis)):
-                reactions_list.append(CondensedPhasePhotolysis.serialize(reaction))
+                reactions_list.append(
+                    CondensedPhasePhotolysis.serialize(reaction))
             elif isinstance(reaction, (_Emission, Emission)):
                 reactions_list.append(Emission.serialize(reaction))
             elif isinstance(reaction, (_FirstOrderLoss, FirstOrderLoss)):
@@ -113,7 +123,8 @@ class Mechanism(_Mechanism):
             elif isinstance(reaction, (_UserDefined, UserDefined)):
                 reactions_list.append(UserDefined.serialize(reaction))
             else:
-                raise TypeError(f'Reaction type {type(reaction)} is not supported for export.')
+                raise TypeError(
+                    f'Reaction type {type(reaction)} is not supported for export.')
 
         return {
             "name": self.name,
@@ -139,7 +150,7 @@ class MechanismSerializer():
     """
 
     @staticmethod
-    def serialize(mechanism: Mechanism, file_path: str = "./mechanism.json") -> None:        
+    def serialize(mechanism: Mechanism, file_path: str = "./mechanism.json") -> None:
         if not isinstance(mechanism, Mechanism):
             raise TypeError(f"Object {mechanism} is not of type Mechanism.")
 
@@ -147,7 +158,7 @@ class MechanismSerializer():
         if directory:
             os.makedirs(directory, exist_ok=True)
         dictionary = mechanism.to_dict()
-        
+
         _, file_ext = os.path.splitext(file)
         file_ext = file_ext.lower()
         if file_ext in ['.yaml', '.yml']:
@@ -158,4 +169,5 @@ class MechanismSerializer():
             with open(file_path, 'w') as file:
                 file.write(json_str)
         else:
-            raise Exception('Allowable write formats are .json, .yaml, and .yml')
+            raise Exception(
+                'Allowable write formats are .json, .yaml, and .yml')

--- a/musica/mechanism_configuration/phase.py
+++ b/musica/mechanism_configuration/phase.py
@@ -1,7 +1,11 @@
 from typing import Optional, Any, Dict, List
-from musica import _Phase
+from .. import backend
 from .species import Species
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Phase = _backend._mechanism_configuration._Phase
 
 
 class Phase(_Phase):
@@ -30,7 +34,8 @@ class Phase(_Phase):
         """
         super().__init__()
         self.name = name if name is not None else self.name
-        self.species = [s.name for s in species] if species is not None else self.species
+        self.species = [
+            s.name for s in species] if species is not None else self.species
         self.other_properties = other_properties if other_properties is not None else self.other_properties
 
     @staticmethod

--- a/musica/mechanism_configuration/photolysis.py
+++ b/musica/mechanism_configuration/photolysis.py
@@ -1,9 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Photolysis, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Photolysis = _backend._mechanism_configuration._Photolysis
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Photolysis(_Photolysis):
@@ -23,7 +28,8 @@ class Photolysis(_Photolysis):
         self,
         name: Optional[str] = None,
         scaling_factor: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,

--- a/musica/mechanism_configuration/reactions.py
+++ b/musica/mechanism_configuration/reactions.py
@@ -1,13 +1,13 @@
 from typing import Optional, Any, Dict, List, Union
-from musica import _ReactionType, _Reactions, _ReactionsIterator
+from .. import backend
 from .species import Species, _Species
 from .utils import _remove_empty_keys
 
-
-class ReactionType(_ReactionType):
-    """
-    A enum class representing a reaction type in a chemical mechanism.
-    """
+# Get backend symbols
+_backend = backend.get_backend()
+ReactionType = _backend._mechanism_configuration._ReactionType
+_Reactions = _backend._mechanism_configuration._Reactions
+_ReactionsIterator = _backend._mechanism_configuration._ReactionsIterator
 
 
 class Reactions(_Reactions):
@@ -57,5 +57,6 @@ class ReactionComponentSerializer():
     def serialize_list_reaction_components(reaction_component_list) -> List[Union[Dict, str]]:
         ret = []
         for rc in reaction_component_list:
-            ret.append(ReactionComponentSerializer.serialize_reaction_component(rc))
+            ret.append(
+                ReactionComponentSerializer.serialize_reaction_component(rc))
         return ret

--- a/musica/mechanism_configuration/simpol_phase_transfer.py
+++ b/musica/mechanism_configuration/simpol_phase_transfer.py
@@ -1,8 +1,13 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _SimpolPhaseTransfer, _ReactionComponent
-from .phase import Phase
-from .species import Species
 from .utils import _add_other_properties, _remove_empty_keys
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_SimpolPhaseTransfer = _backend._mechanism_configuration._SimpolPhaseTransfer
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class SimpolPhaseTransfer(_SimpolPhaseTransfer):
@@ -23,9 +28,11 @@ class SimpolPhaseTransfer(_SimpolPhaseTransfer):
         self,
         name: Optional[str] = None,
         gas_phase: Optional[Phase] = None,
-        gas_phase_species: Optional[Union[Species, Tuple[float, Species]]] = None,
+        gas_phase_species: Optional[Union[Species,
+                                          Tuple[float, Species]]] = None,
         aerosol_phase: Optional[Phase] = None,
-        aerosol_phase_species: Optional[Union[Species, Tuple[float, Species]]] = None,
+        aerosol_phase_species: Optional[Union[Species,
+                                              Tuple[float, Species]]] = None,
         B: Optional[List[float]] = None,
         other_properties: Optional[Dict[str, Any]] = None,
     ):

--- a/musica/mechanism_configuration/species.py
+++ b/musica/mechanism_configuration/species.py
@@ -1,6 +1,10 @@
 from typing import Optional, Any, Dict
-from musica import _Species
+from .. import backend
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Species = _backend._mechanism_configuration._Species
 
 
 class Species(_Species):

--- a/musica/mechanism_configuration/surface.py
+++ b/musica/mechanism_configuration/surface.py
@@ -1,9 +1,14 @@
 from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Surface, _ReactionComponent
+from .. import backend
 from .phase import Phase
 from .species import Species
 from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Surface = _backend._mechanism_configuration._Surface
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Surface(_Surface):
@@ -26,7 +31,8 @@ class Surface(_Surface):
         self,
         name: Optional[str] = None,
         reaction_probability: Optional[float] = None,
-        gas_phase_species: Optional[Union[Species, Tuple[float, Species]]] = None,
+        gas_phase_species: Optional[Union[Species,
+                                          Tuple[float, Species]]] = None,
         gas_phase_products: Optional[
             List[Union[Species, Tuple[float, Species]]]
         ] = None,

--- a/musica/mechanism_configuration/troe.py
+++ b/musica/mechanism_configuration/troe.py
@@ -1,9 +1,14 @@
 from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Troe, _ReactionComponent
+from .. import backend
 from .phase import Phase
 from .species import Species
 from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Troe = _backend._mechanism_configuration._Troe
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Troe(_Troe):
@@ -37,7 +42,8 @@ class Troe(_Troe):
         kinf_C: Optional[float] = None,
         Fc: Optional[float] = None,
         N: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,

--- a/musica/mechanism_configuration/tunneling.py
+++ b/musica/mechanism_configuration/tunneling.py
@@ -1,9 +1,14 @@
-from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _Tunneling, _ReactionComponent
-from .phase import Phase
-from .species import Species
-from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+from .reactions import ReactionComponentSerializer
+from .species import Species
+from .phase import Phase
+from typing import Optional, Any, Dict, List, Union, Tuple
+from .. import backend
+
+# Get backend symbols
+_backend = backend.get_backend()
+_Tunneling = _backend._mechanism_configuration._Tunneling
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class Tunneling(_Tunneling):
@@ -37,7 +42,8 @@ class Tunneling(_Tunneling):
         A: Optional[float] = None,
         B: Optional[float] = None,
         C: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,

--- a/musica/mechanism_configuration/user_defined.py
+++ b/musica/mechanism_configuration/user_defined.py
@@ -1,9 +1,14 @@
 from typing import Optional, Any, Dict, List, Union, Tuple
-from musica import _UserDefined, _ReactionComponent
+from .. import backend
 from .phase import Phase
 from .species import Species
 from .reactions import ReactionComponentSerializer
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_UserDefined = _backend._mechanism_configuration._UserDefined
+_ReactionComponent = _backend._mechanism_configuration._ReactionComponent
 
 
 class UserDefined(_UserDefined):
@@ -23,7 +28,8 @@ class UserDefined(_UserDefined):
         self,
         name: Optional[str] = None,
         scaling_factor: Optional[float] = None,
-        reactants: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
+        reactants: Optional[List[Union[Species,
+                                       Tuple[float, Species]]]] = None,
         products: Optional[List[Union[Species, Tuple[float, Species]]]] = None,
         gas_phase: Optional[Phase] = None,
         other_properties: Optional[Dict[str, Any]] = None,

--- a/musica/mechanism_configuration/wet_deposition.py
+++ b/musica/mechanism_configuration/wet_deposition.py
@@ -1,7 +1,11 @@
 from typing import Optional, Any, Dict
-from musica import _WetDeposition
+from .. import backend
 from .phase import Phase
 from .utils import _add_other_properties, _remove_empty_keys
+
+# Get backend symbols
+_backend = backend.get_backend()
+_WetDeposition = _backend._mechanism_configuration._WetDeposition
 
 
 class WetDeposition(_WetDeposition):


### PR DESCRIPTION
The `__init__.py` file would get a circular import if the imports in `__init__.py` were re-ordered. This is because of the conditional import logic we need to do of the pybind11 musica targets for cpu vs gpu. This, I think, should fix that circular import and allow our python format actions to be turned on again

Closes #370