### PR TITLE
Add Missing Packages to Install Instructions

### DIFF
--- a/tutorial/1. multiple_grid_cells.ipynb
+++ b/tutorial/1. multiple_grid_cells.ipynb
@@ -25,7 +25,7 @@
     "conda create --name musica python=3.9\n",
     "conda activate musica\n",
     "pip install musica\n",
-    "conda install ipykernel scikit-learn seaborn\n",
+    "conda install ipykernel scikit-learn seaborn scipy dask\n",
     "```"
    ]
   },

--- a/tutorial/6. gpu_solver.ipynb
+++ b/tutorial/6. gpu_solver.ipynb
@@ -28,7 +28,7 @@
     "pip install --upgrade setuptools pip wheel\n",
     "pip install nvidia-pyindex\n",
     "pip install musica[gpu]\n",
-    "conda install ipykernel scikit-learn seaborn\n",
+    "conda install ipykernel scikit-learn seaborn scipy dask\n",
     "```"
    ]
   },


### PR DESCRIPTION
No issue is being closed since it is very minor. All this merge does is add scipy and dask as packages to install in the instructions since they were missing before.