### PR TITLE
populate contributing, citing, and python API pages

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-book-theme
 sphinx-copybutton
 sphinx-design
 sphinxcontrib-bibtex
+nbsphinx

--- a/docs/source/api/python.rst
+++ b/docs/source/api/python.rst
@@ -7,14 +7,14 @@ C++ Bindings
 Core
 ^^^^
 
-.. automodule:: _musica._core
+.. automodule:: musica._musica._core
    :members:
    :undoc-members:
    :show-inheritance:
    :private-members:
    :exclude-members: _SolverType
 
-.. autoclass:: _musica._core._SolverType
+.. autoclass:: musica._musica._core._SolverType
    :members:
    :undoc-members:
    :show-inheritance:
@@ -24,14 +24,14 @@ Core
 Mechanism Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: _musica._mechanism_configuration
+.. automodule:: musica._musica._mechanism_configuration
    :members:
    :undoc-members:
    :show-inheritance:
    :private-members:
    :exclude-members: _ReactionType
   
-.. autoclass:: _musica._mechanism_configuration._ReactionType
+.. autoclass:: musica._musica._mechanism_configuration._ReactionType
     :members:
     :undoc-members:
     :show-inheritance:
@@ -42,15 +42,6 @@ Musica Types
 ------------
 
 .. automodule:: musica.types
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-Mechanism Configuraiton
------------------------
-
-.. automodule:: musica.mechanism_configuration
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/citing/index.rst
+++ b/docs/source/citing/index.rst
@@ -1,3 +1,40 @@
-#################
+##############
 Citing MUSICA
-#################
+##############
+
+MUSICA can be cited in 2 ways:
+
+1. Cite the `foundational paper <https://journals.ametsoc.org/view/journals/bams/101/10/bamsD190331.xml>`_ that defines the vision of the MUSICA software:
+
+.. code-block:: console
+
+    @Article { acom.software.musica-vision,
+        author = "Gabriele G. Pfister and Sebastian D. Eastham and Avelino F. Arellano and Bernard Aumont and Kelley C. Barsanti and Mary C. Barth and Andrew Conley and Nicholas A. Davis and Louisa K. Emmons and Jerome D. Fast and Arlene M. Fiore and Benjamin Gaubert and Steve Goldhaber and Claire Granier and Georg A. Grell and Marc Guevara and Daven K. Henze and Alma Hodzic and Xiaohong Liu and Daniel R. Marsh and John J. Orlando and John M. C. Plane and Lorenzo M. Polvani and Karen H. Rosenlof and Allison L. Steiner and Daniel J. Jacob and Guy P. Brasseur",
+        title = "The Multi-Scale Infrastructure for Chemistry and Aerosols (MUSICA)",
+        journal = "Bulletin of the American Meteorological Society",
+        year = "2020",
+        publisher = "American Meteorological Society",
+        address = "Boston MA, USA",
+        volume = "101",
+        number = "10",
+        doi = "10.1175/BAMS-D-19-0331.1",
+        pages= "E1743 - E1760",
+        url = "https://journals.ametsoc.org/view/journals/bams/101/10/bamsD190331.xml"
+    }
+
+2. Cite the `MUSICA software <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2021MS002889>`_ and its evaluation (MUSICAv0):
+
+.. code-block:: console
+
+    @Article{acom.software.musica,
+        author = {Schwantes, Rebecca H. and Lacey, Forrest G. and Tilmes, Simone and Emmons, Louisa K. and Lauritzen, Peter H. and Walters, Stacy and Callaghan, Patrick and Zarzycki, Colin M. and Barth, Mary C. and Jo, Duseong S. and Bacmeister, Julio T. and Neale, Richard B. and Vitt, Francis and Kluzek, Erik and Roozitalab, Behrooz and Hall, Samuel R. and Ullmann, Kirk and Warneke, Carsten and Peischl, Jeff and Pollack, Ilana B. and Flocke, Frank and Wolfe, Glenn M. and Hanisco, Thomas F. and Keutsch, Frank N. and Kaiser, Jennifer and Bui, Thao Paul V. and Jimenez, Jose L. and Campuzano-Jost, Pedro and Apel, Eric C. and Hornbrook, Rebecca S. and Hills, Alan J. and Yuan, Bin and Wisthaler, Armin},
+        title = {Evaluating the Impact of Chemical Complexity and Horizontal Resolution on Tropospheric Ozone Over the Conterminous US With a Global Variable Resolution Chemistry Model},
+        journal = {Journal of Advances in Modeling Earth Systems},
+        volume = {14},
+        number = {6},
+        pages = {e2021MS002889},
+        doi = {https://doi.org/10.1029/2021MS002889},
+        url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021MS002889},
+        eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021MS002889},
+        year = {2022}
+    }

--- a/docs/source/contributing/index.rst
+++ b/docs/source/contributing/index.rst
@@ -9,12 +9,134 @@ describing your request or planned contribution.
 
 Creating a development environment
 -----------------------------------
+To contribute to MUSICA and test changes locally, we recommend making a `conda <https://www.anaconda.com/docs/getting-started/miniconda/main>`_ environment:
 
-Testing with continuous integration
-------------------------------------
+.. code-block:: console
 
-Style guide
------------
+    $ git clone https://github.com/NCAR/musica.git
+    $ cd musica
+    $ conda create --name musica python=<minimum-3.9> --yes
+    $ conda activate musica
+
+After the GitHub repository is cloned and the virtual environment made, the MUSICA project can be built as follows:
+
+.. code-block:: console
+
+    $ mkdir build && cd build
+    $ ccmake ..
+    $ make
+
+and `pip` can be used for an editable installation:
+
+.. code-block:: console
+
+    $ pip install -e .
+
+For detailed developer options and dependency management, see our `Software Development Plan <https://github.com/NCAR/musica/blob/main/docs/Software%20Development%20Plan.pdf>`_.
+
+Types of contributions
+-----------------------
+We appreciate all types of contributions:
+
+Code Contributions
+^^^^^^^^^^^^^^^^^^^
+- Bug fixes
+- New features
+- Performance improvements
+- Test coverage improvements
+
+Documentation
+^^^^^^^^^^^^^^^
+- README improvements
+- Code documentation
+- Tutorial and example updates
+- Wiki contributions
+
+Testing and Validation
+^^^^^^^^^^^^^^^^^^^^^^^
+- Bug reports with reproducible examples
+- Testing on different platforms
+- Validation against known results
+
+Scientific Contributions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+- New chemical mechanisms
+- Algorithm improvements
+- Performance optimizations
+
+Contribution process
+---------------------
+1. **Fork the repository** and create a feature branch
+2. **Make your changes** following our coding standards
+3. **Add tests** for new functionality
+4. **Update documentation** as needed
+5. **Submit a pull request** with a clear description
+
+Development guidelines
+-----------------------
+This section outlines best practices and requirements for contributing code, managing dependencies, and ensuring compatibility across platforms.
+
+Code standards
+^^^^^^^^^^^^^^
+- Follow existing code style and conventions. We primarily follow the `Google C++ Style Guide <https://google.github.io/styleguide/cppguide.html>`_ and `PEP 8 <https://peps.python.org/pep-0008/>`_ for Python.
+- Include appropriate tests for new functionality
+- Document new features and APIs
+
+Dependency management
+^^^^^^^^^^^^^^^^^^^^^^
+We use CMake for C++ dependencies and pip for Python dependencies. See our `README <https://github.com/NCAR/musica?tab=readme-ov-file#developer-options>`_ for information about specifying dependency versions during development.
+
+GPU support
+^^^^^^^^^^^^
+If contributing GPU-related code, please test on appropriate hardware and
+follow our GPU build guidelines.
 
 Documentation
 -------------
+All of our docs are stored in the ``docs`` directory and built using `Sphinx <https://www.sphinx-doc.org/en/master/>`_. 
+There are several Python dependencies that are necessary to build the documentation locally. These dependencies can be installed by 
+running the following from your cloned ``music-box`` directory:
+
+.. code-block:: console
+
+    $ cd docs
+    $ pip install -r requirements.txt
+
+For contributors wanting to visualize changes to the C++ API Reference, a separate xml folder must be generated in the ``/build`` folder with the following command run from the ``docs`` directory:
+
+.. code-block:: console
+
+    $ doxygen Doxyfile.in
+
+To build the documentation locally after edits:
+
+- On macOS/Linux: ``make html``
+- On Windows (cmd or PowerShell): ``.\make.bat html``
+
+Recognition policy
+------------------
+We believe in recognizing all contributors appropriately:
+
+Core Development Team
+^^^^^^^^^^^^^^^^^^^^^^^
+Contributors who make substantial, ongoing contributions to the codebase, architecture, or project direction will be listed as authors in:
+
+- `pyproject.toml` (for Python package metadata)
+- `.zenodo.json` (as "creators" for software citations)
+- `AUTHORS.md` (as core developers)
+
+Additional Contributors  
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Contributors who make valuable but smaller contributions will be acknowledged in:
+
+- `.zenodo.json` (as "contributors" with appropriate type)
+- `AUTHORS.md` (in the Additional Contributors section)
+- GitHub's contributor list (automatic)
+
+Questions?
+-----------
+- Check our `documentation <https://ncar.github.io/musica/index.html>`_
+- Read our `Software Development Plan <https://github.com/NCAR/musica/blob/main/docs/Software%20Development%20Plan.pdf>`_
+- Contact the maintainers at musica-support@ucar.edu
+
+Thank you for your interest in contributing to MUSICA!

--- a/docs/source/getting_started/python.rst
+++ b/docs/source/getting_started/python.rst
@@ -35,6 +35,7 @@ The system is the fundamental building block of MUSICA. The following steps will
 ~~~~~~~~~~~~~~~~~~~~~~~~
 A species is a reactant or product in a chemical reaction. You have the freedom to name a species anything in MusicBox, just make sure that it is logical to you.
 For extended documentation about the Species class, go `here <https://ncar.github.io/musica/api/python.html#musica.mechanism_configuration.Species>`_.
+
 Here is a snippet that defines three chemical species::
 
     A = mc.Species(name="A")
@@ -66,7 +67,7 @@ There are a handful of solvers available, but Rosenbrock Standard Order is used 
 
     solver = musica.MICM(mechanism=mechanism, solver_type=musica.SolverType.rosenbrock_standard_order)
 
-For more information on the types of solvers available, go `here <https://ncar.github.io/micm/user_guide/solver_configurations.html>`_.
+For more information on the types of solvers available, see the :doc:`MICM User Guide <micm:user_guide/solver_configurations>`.
 
 5. Define environmental conditions
 -----------------------------------

--- a/docs/source/user_guide/model/index.rst
+++ b/docs/source/user_guide/model/index.rst
@@ -5,7 +5,7 @@ Model solving and options
 .. note::
     
     MUSICA uses the Model-Independent Chemical Module (MICM) as its core chemistry solver. For more information about available reaction types,
-    species configuration, and solver behavior, see the `MICM documentation <micm:index>`_.
+    species configuration, and solver behavior, see the `MICM documentation <https://ncar.github.io/micm/index.html>`_.
 
 To work with a MUSICA model and solve, please be sure to import the following::
 
@@ -16,7 +16,7 @@ the previously defined in-code mechanism (see :ref:`Defining chemical systems <c
     
     solver = musica.MICM(mechanism=mechanism, solver_type=musica.SolverType.rosenbrock_standard_order)
 
-While the Rosenbrock Standard Order solver was used here, several other types of solvers are made available `through MICM <https://ncar.github.io/micm/user_guide/solver_configurations.html>`_.
+While the Rosenbrock Standard Order solver was used here, several other types of solvers are made available :doc:`through MICM <micm:user_guide/solver_configurations>`.
 
 Conditions
 -----------
@@ -38,7 +38,7 @@ Each MUSICA model should be run for a given amount of time (seconds) and that ti
     time_step = 4  # stepping
     sim_length = 20  # total simulation time
 
-For further descriptions of these MusicBox attributes, please see the `API Reference <https://ncar.github.io/music-box/branch/main/api/index.html>`_.
+For further descriptions of these MusicBox attributes, please see the :doc:`API Reference <mb:api/index>`.
 
 Solving
 --------


### PR DESCRIPTION
Updated docs to use intersphinx references to MICM and MusicBox where applicable, includes citation info, combines contribution.md with contributing page. Addressed auto doc failure with modules bound with pybind11 for the API Reference generation.

Note: Mechanism_Configuration and Solver_Type arguments don't yet generate properly from docstrings for the Python API, but I'm pausing for the refactoring work because I imagine this would change anyways as the inheritances change.

closes #431 