### PR TITLE
making sure github pages on main deploys on each push to main

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,11 +1,8 @@
 # Build and deploy documentation to GitHub Pages
 name: GitHub Pages
 
-on:
+on: 
   push:
-    branches:
-      - main
-      - release
   pull_request:
   workflow_dispatch:
 
@@ -15,14 +12,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build and deploy to gh-pages
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        gcc-version: [13]
-    env:
-      CXX: g++-${{ matrix.gcc-version }}
-      CC: gcc-${{ matrix.gcc-version }}
-      FC: gfortran-${{ matrix.gcc-version }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +58,7 @@ jobs:
           # 1. the frozen version, represented as vX.X in the version switcher
           docker build -t musica -f docker/Dockerfile.docs .
           id=$(docker create musica)
-          docker cp $id:/build/docs/sphinx tmpdocs
+          docker cp $id:/musica/docs/build/html  tmpdocs
           docker rm -v $id
           version=$(sed -nr "s/^release = f'v(.+)\{suffix\}'.*$/\1/p" docs/source/conf.py)
           mv tmpdocs _build/html/versions/${version}
@@ -77,7 +67,7 @@ jobs:
           # edit conf.py to produce a version string that looks like vX.X (stable)
           docker build -t musica -f docker/Dockerfile.docs --build-arg SUFFIX=" (stable)" .
           id=$(docker create musica)
-          docker cp $id:/build/docs/sphinx tmpdocs
+          docker cp $id:/musica/docs/build/html  tmpdocs
           docker rm -v $id
           mv tmpdocs _build/html/versions/stable
           # Delete everything under _gh-pages/ that is from the
@@ -94,18 +84,25 @@ jobs:
       # _gh-pages/branch/$brname (transforming '/' into '--')
       - name: Build and copy documentation (branch)
         if: |
-          contains(github.event_name, 'push') &&
+          (contains(github.event_name, 'push') ||
+          contains(github.event_name, 'pull_request')) &&
           !contains(github.ref, env.DEFAULT_BRANCH)
         run: |
           set -x
           docker build -t musica -f docker/Dockerfile.docs .
           id=$(docker create musica)
-          docker cp $id:/build/docs/sphinx tmpdocs
+          docker cp $id:/musica/docs/build/html tmpdocs
           docker rm -v $id
-          brname="${{github.ref}}"
-          brname="${brname##refs/heads/}"
+          # Determine branch name for deployment directory
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            brname="${{ github.head_ref }}"
+          else
+            brname="${{ github.ref }}"
+            brname="${brname##refs/heads/}"
+          fi
           brdir=${brname//\//--}   # replace '/' with '--'
           rm -rf   _gh-pages/branch/${brdir}
+          mkdir -p _gh-pages/branch/${brdir}
           rsync -a tmpdocs/ _gh-pages/branch/${brdir}
 
       # Go through each branch in _gh-pages/branch/, if it's not a


### PR DESCRIPTION
- Removes matrix builds that aren't needed
- Allows pages for the main branch to deploy on each push to main so the documentaiton is up to date