### PR TITLE
CARMA group options

### DIFF
--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -116,7 +116,7 @@ namespace musica
   {
     std::string name = "default_group";
     std::string shortname = "";
-    double rmin = 1e-7;  // minimum radius [m]
+    double rmin = 1e-9;  // minimum radius [m]
     double rmrat = 2.0;  // volume ratio between bins
     double rmassmin = 0.0; // minimum mass [kg] (When rmassmin > 0, rmin is ignored)
     ParticleShape ishape = ParticleShape::SPHERE;

--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -21,6 +21,58 @@ namespace musica
     CYLINDER = 3
   };
 
+  // Enumeration for particle swelling algorithms
+  enum class ParticleSwellingAlgorithm
+  {
+    NONE = 0,
+    FITZGERALD = 1,
+    GERBER = 2,
+    WEIGHT_PERCENT_H2SO4 = 3,
+    PETTERS = 4
+  };
+
+  // Enumeration for particle swelling composition
+  enum class ParticleSwellingComposition
+  {
+    NONE = 0,
+    AMMONIUM_SULFATE = 1,
+    SEA_SALT = 2,
+    URBAN = 3,
+    RURAL = 4
+  };
+
+  // Enumeration for fall velocity algorithms
+  enum class FallVelocityAlgorithm
+  {
+    NONE = 0,
+    STANDARD_SPHERICAL_ONLY = 1, // Standard algorithm for spherical particles only
+    STANDARD_SHAPE_SUPPORT = 2,  // Standard algorithm with support for different shapes
+    HEYMSFIELD_2010 = 3          // Heymsfield and Westbrook 2010
+  };
+
+  // Enumeration for Mie calculation methods
+  enum class MieCalculationAlgorithm
+  {
+    NONE = 0,
+    TOON_1981 = 1,   // Shell/Core Toon & Ackerman 1981 Mie calculation
+    BOHREN_1983 = 2, // Homogeneous Sphere Bohren and Huffman 1983 Mie calculation
+    BOTET_1997 = 3   // Fractal Mean-Field Botet et al. 1997 Mie calculation
+  };
+
+  // Enumeration for optics algorithms
+  enum class OpticsAlgorithm
+  {
+    NONE = 0,
+    FIXED = 1,             // Fixed composition
+    MIXED_YU_2015 = 2,     // Yu (2015) mixed composition
+    SULFATE_YU_2015 = 3,   // Yu (2015) pure sulfate composition
+    MIXED_H2O_YU_2015 = 4, // Yu (2015) mixed composition with water in shell
+    MIXED_CORE_SHELL = 5,  // Core-Shell mixed composition
+    MIXED_VOLUME = 6,      // Volume mixed composition
+    MIXED_MAXWELL = 7,     // Maxwell-Garnett mixed composition
+    SULFATE = 8            // Sulfate, refractive index varies with WTP/RH
+  };
+
   // Enumeration for particle types
   enum class ParticleType
   {
@@ -52,27 +104,41 @@ namespace musica
     bool do_emission = true; // Flag to indicate if emission is considered for this bin
   };
 
+  // Structure defining an approach to particle swelling
+  struct CARMASwellingApproach
+  {
+    ParticleSwellingAlgorithm algorithm = ParticleSwellingAlgorithm::NONE; // Swelling algorithm
+    ParticleSwellingComposition composition = ParticleSwellingComposition::NONE; // Composition for swelling
+  };
+
   // Structure representing a CARMA group configuration
   struct CARMAGroupConfig
   {
-    int id = 1;
     std::string name = "default_group";
     std::string shortname = "";
-    double rmin = 1e-7;  // minimum radius [cm]
+    double rmin = 1e-7;  // minimum radius [m]
     double rmrat = 2.0;  // volume ratio between bins
+    double rmassmin = 0.0; // minimum mass [kg] (When rmassmin > 0, rmin is ignored)
     ParticleShape ishape = ParticleShape::SPHERE;
-    double eshape = 1.0;  // aspect ratio
+    double eshape = 1.0;  // aspect ratio (length/width)
+    CARMASwellingApproach swelling_approach; // Swelling from RH approach
+    FallVelocityAlgorithm fall_velocity_routine = FallVelocityAlgorithm::STANDARD_SPHERICAL_ONLY;
+    MieCalculationAlgorithm mie_calculation_algorithm = MieCalculationAlgorithm::NONE;
+    OpticsAlgorithm optics_algorithm = OpticsAlgorithm::FIXED; // Optics algorithm
     bool is_ice = false;
     bool is_fractal = false;
-    bool do_mie = true;
+    bool is_cloud = false;
+    bool is_sulfate = false;
     bool do_wetdep = false;
     bool do_drydep = false;
     bool do_vtran = true;
-    double solfac = 0.0;
-    double scavcoef = 0.0;
-    double rmon = 0.0;       // monomer radius [cm]
-    std::vector<double> df;  // fractal dimension per bin
-    double falpha = 1.0;     // fractal packing coefficient
+    double solfac = 0.0;        // Solubility factor for wet deposition
+    double scavcoef = 0.0;      // Scavenging coefficient for wet deposition
+    double dpc_threshold = 0.0; // convergence criteria for particle concentration [fraction]
+    double rmon = 0.0;          // monomer radius [m]
+    std::vector<double> df;     // fractal dimension per bin
+    double falpha = 1.0;        // fractal packing coefficient
+    double neutral_volfrc = 0.0; // neutral volume fraction for fractal particles
   };
 
   // Structure representing a CARMA element configuration

--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -94,9 +94,6 @@ namespace musica
 
   struct CARMAParameters
   {
-    int max_bins = 100;
-    int max_groups = 10;
-
     // Model dimensions
     int nz = 1;
     int ny = 1;

--- a/include/musica/carma/carma_c_interface.hpp
+++ b/include/musica/carma/carma_c_interface.hpp
@@ -20,27 +20,35 @@ namespace musica
 
     struct CARMAGroupConfigC
     {
-      int id;
       int name_length;       // length of name string
       char name[256];        // 255 chars + null terminator
       int shortname_length;  // length of shortname string
       char shortname[7];     // 6 chars + null terminator
-      double rmin;
-      double rmrat;
-      int ishape;
-      double eshape;
+      double rmin;           // minimum radius [m]
+      double rmrat;          // volume ratio between bins
+      double rmassmin;       // minimum mass [kg] (When rmassmin > 0, rmin is ignored)
+      int ishape;            // Particle shape (enum value)
+      double eshape;         // aspect ratio
+      int swelling_algorithm; // Swelling algorithm (enum value)
+      int swelling_composition; // Composition for swelling (enum value)
+      int fall_velocity_routine; // Fall velocity algorithm (enum value)
+      int mie_calculation_algorithm; // Mie calculation algorithm (enum value)
+      int optics_algorithm;  // Optics algorithm (enum value)
       bool is_ice;
       bool is_fractal;
-      bool do_mie;
+      bool is_cloud;
+      bool is_sulfate;
       bool do_wetdep;
       bool do_drydep;
       bool do_vtran;
-      double solfac;
-      double scavcoef;
-      double rmon;
+      double solfac; // Solubility factor for wet deposition
+      double scavcoef; // Scavenging coefficient for wet deposition
+      double dpc_threshold; // convergence criteria for particle concentration [fraction]
+      double rmon; // monomer radius [m]
       double* df;   // fractal dimension per bin (allocated separately)
       int df_size;  // size of df array
-      double falpha;
+      double falpha; // fractal packing coefficient
+      double neutral_volfrc; // neutral volume fraction for fractal particles
     };
 
     struct CARMAElementConfigC

--- a/include/musica/carma/carma_c_interface.hpp
+++ b/include/musica/carma/carma_c_interface.hpp
@@ -67,9 +67,6 @@ namespace musica
     // MUST match the exact order and types of the Fortran carma_parameters_t struct
     struct CCARMAParameters
     {
-      int max_bins;
-      int max_groups;
-
       // Model dimensions
       int nz;
       int ny;

--- a/musica/carma.cpp
+++ b/musica/carma.cpp
@@ -60,8 +60,6 @@ void bind_carma(py::module_& carma)
               auto group_dict = group_py.cast<py::dict>();
               musica::CARMAGroupConfig group;
 
-              if (group_dict.contains("id"))
-                group.id = group_dict["id"].cast<int>();
               if (group_dict.contains("name"))
                 group.name = group_dict["name"].cast<std::string>();
               if (group_dict.contains("shortname"))
@@ -70,16 +68,37 @@ void bind_carma(py::module_& carma)
                 group.rmin = group_dict["rmin"].cast<double>();
               if (group_dict.contains("rmrat"))
                 group.rmrat = group_dict["rmrat"].cast<double>();
+              if (group_dict.contains("rmassmin"))
+                group.rmassmin = group_dict["rmassmin"].cast<double>();
               if (group_dict.contains("ishape"))
                 group.ishape = static_cast<musica::ParticleShape>(group_dict["ishape"].cast<int>());
               if (group_dict.contains("eshape"))
                 group.eshape = group_dict["eshape"].cast<double>();
+              if (group_dict.contains("swelling_approach"))
+                if (group_dict["swelling_approach"].contains("algorithm") &&
+                    group_dict["swelling_approach"].contains("composition"))
+                {
+                  group.swelling_approach.algorithm = static_cast<musica::ParticleSwellingAlgorithm>(
+                      group_dict["swelling_approach"]["algorithm"].cast<int>());
+                  group.swelling_approach.composition = static_cast<musica::ParticleSwellingComposition>(
+                      group_dict["swelling_approach"]["composition"].cast<int>());
+                }
+              if (group_dict.contains("fall_velocity_routine"))
+                group.fall_velocity_routine = static_cast<musica::FallVelocityAlgorithm>(
+                    group_dict["fall_velocity_routine"].cast<int>());
+              if (group_dict.contains("mie_calculation_algorithm"))
+                group.mie_calculation_algorithm = static_cast<musica::MieCalculationAlgorithm>(
+                    group_dict["mie_calculation_algorithm"].cast<int>());
+              if (group_dict.contains("optics_algorithm"))
+                group.optics_algorithm = static_cast<musica::OpticsAlgorithm>(group_dict["optics_algorithm"].cast<int>());
               if (group_dict.contains("is_ice"))
                 group.is_ice = group_dict["is_ice"].cast<bool>();
               if (group_dict.contains("is_fractal"))
                 group.is_fractal = group_dict["is_fractal"].cast<bool>();
-              if (group_dict.contains("do_mie"))
-                group.do_mie = group_dict["do_mie"].cast<bool>();
+              if (group_dict.contains("is_cloud"))
+                group.is_cloud = group_dict["is_cloud"].cast<bool>();
+              if (group_dict.contains("is_sulfate"))
+                group.is_sulfate = group_dict["is_sulfate"].cast<bool>();
               if (group_dict.contains("do_wetdep"))
                 group.do_wetdep = group_dict["do_wetdep"].cast<bool>();
               if (group_dict.contains("do_drydep"))
@@ -90,12 +109,16 @@ void bind_carma(py::module_& carma)
                 group.solfac = group_dict["solfac"].cast<double>();
               if (group_dict.contains("scavcoef"))
                 group.scavcoef = group_dict["scavcoef"].cast<double>();
+              if (group_dict.contains("dpc_threshold"))
+                group.dpc_threshold = group_dict["dpc_threshold"].cast<double>();
               if (group_dict.contains("rmon"))
                 group.rmon = group_dict["rmon"].cast<double>();
               if (group_dict.contains("df"))
                 group.df = group_dict["df"].cast<std::vector<double>>();
               if (group_dict.contains("falpha"))
                 group.falpha = group_dict["falpha"].cast<double>();
+              if (group_dict.contains("neutral_volfrc"))
+                group.neutral_volfrc = group_dict["neutral_volfrc"].cast<double>();
 
               params.groups.push_back(group);
             }

--- a/musica/carma.cpp
+++ b/musica/carma.cpp
@@ -21,10 +21,6 @@ void bind_carma(py::module_& carma)
         // Convert Python dict to CARMAParameters
         musica::CARMAParameters params;
 
-        if (params_dict.contains("max_bins"))
-          params.max_bins = params_dict["max_bins"].cast<int>();
-        if (params_dict.contains("max_groups"))
-          params.max_groups = params_dict["max_groups"].cast<int>();
         if (params_dict.contains("nz"))
           params.nz = params_dict["nz"].cast<int>();
         if (params_dict.contains("ny"))

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -33,6 +33,53 @@ class ParticleType:
     CORE_MASS_TWO_MOMENTS = 5
 
 
+class ParticleSwellingAlgorithm:
+    """Enumeration for particle swelling algorithms used in CARMA."""
+    NONE = 0
+    FITZGERALD = 1
+    GERBER = 2
+    WEIGHT_PERCENT_H2SO4 = 3
+    PETTERS = 4
+
+
+class ParticleSwellingComposition:
+    """Enumeration for particle swelling compositions used in CARMA."""
+    NONE = 0
+    AMMONIUM_SULFATE = 1
+    SEA_SALT = 2
+    URBAN = 3
+    RURAL = 4
+
+
+class ParticleFallVelocityAlgorithm:
+    """Enumeration for particle fall velocity algorithms used in CARMA."""
+    NONE = 0
+    STANDARD_SPHERICAL_ONLY = 1
+    STANDARD_SHAPE_SUPPORT = 2
+    HEYMSFIELD_2010 = 3
+
+
+class MieCalculationAlgorithm:
+    """Enumeration for Mie calculation algorithms used in CARMA."""
+    NONE = 0
+    TOON_1981 = 1
+    BOHREN_1983 = 2
+    BOTET_1997 = 3
+
+
+class OpticsAlgorithm:
+    """Enumeration for optics algorithms used in CARMA."""
+    NONE = 0
+    FIXED = 1
+    MIXED_YU_2015 = 2
+    SULFATE_YU_2015 = 3
+    MIXED_H2O_YU_2015 = 4
+    MIXED_CORE_SHELL = 5
+    MIXED_VOLUME = 6
+    MIXED_MAXWELL = 7
+    SULFATE = 8
+
+
 class ParticleComposition:
     """Enumeration for particle compositions used in CARMA."""
     ALUMINUM = 1
@@ -76,65 +123,89 @@ class CARMAGroupConfig:
     """
 
     def __init__(self,
-                 id: int = 1,
                  name: str = "default_group",
                  shortname: str = "",
                  rmin: float = 1e-7,
                  rmrat: float = 2.0,
+                 rmassmin: float = 0.0,
                  ishape: int = ParticleShape.SPHERE,
                  eshape: float = 1.0,
+                 swelling_approach: dict = {
+                    "algorithm": ParticleSwellingAlgorithm.NONE,
+                    "composition": ParticleSwellingComposition.NONE
+                 },
+                 fall_velocity_routine: int = ParticleFallVelocityAlgorithm.STANDARD_SPHERICAL_ONLY,
+                 mie_calculation_algorithm: int = MieCalculationAlgorithm.NONE,
+                 optics_algorithm: int = OpticsAlgorithm.FIXED,
                  is_ice: bool = False,
                  is_fractal: bool = False,
-                 do_mie: bool = True,
+                 is_cloud: bool = False,
+                 is_sulfate: bool = False,
                  do_wetdep: bool = False,
                  do_drydep: bool = False,
                  do_vtran: bool = True,
                  solfac: float = 0.0,
                  scavcoef: float = 0.0,
+                 dpc_threshold: float = 0.0,
                  rmon: float = 0.0,
                  df: Optional[List[float]] = None,
-                 falpha: float = 1.0):
+                 falpha: float = 1.0,
+                 neutral_volfrc: float = 0.0):
         """
         Initialize a CARMA group configuration.
 
         Args:
-            id: Unique identifier for the group (default: 1)
             name: Name of the group (default: "default_group")
             shortname: Short name for the group (default: "")
             rmin: Radius of particles in the first bin [cm] (default: 1e-7)
             rmrat: Ratio of masses of particles in consecutive bins (default: 2.0)
+            rmassmin: Minimum mass of particles [g] (default: 0.0)
             ishape: Shape of the particles (default: ParticleShape.SPHERE)
             eshape: Ratio of particle length / diameter (default: 1.0)
+            swelling_approach: Dictionary specifying swelling algorithm and composition (default: NONE)
+            fall_velocity_routine: Algorithm for fall velocity (default: STANDARD_SPHERICAL_ONLY)
+            mie_calculation_algorithm: Algorithm for Mie calculations (default: NONE)
+            optics_algorithm: Algorithm for optics (default: FIXED)
             is_ice: Whether the particles are ice (default: False)
             is_fractal: Whether the particles are fractal (default: False)
-            do_mie: Whether to do Mie calculations (default: True)
+            is_cloud: Whether the group is a cloud (default: False)
+            is_sulfate: Whether the group is sulfate (default: False)
             do_wetdep: Whether to include wet deposition (default: False)
             do_drydep: Whether to include dry deposition (default: False)
             do_vtran: Whether to include vertical transport (default: True)
             solfac: Solubility factor for wet deposition (default: 0.0)
             scavcoef: Scavenging coefficient for wet deposition [mm-1] (default: 0.0)
+            dpc_threshold: Threshold for dry particle collection (default: 0.0)
             rmon: Monomer radius of fractal particles [cm] (default: 0.0)
             df: List of fractal dimensions for each size bin (default: None)
             falpha: Fractal packing coefficient (default: 1.0)
+            neutral_volfrc: Neutral volume fraction for fractal particles (default: 0.0)
         """
-        self.id = id
         self.name = name
         self.shortname = shortname
         self.rmin = rmin
         self.rmrat = rmrat
+        self.rmassmin = rmassmin
         self.ishape = ishape
         self.eshape = eshape
+        self.swelling_approach = swelling_approach
+        self.fall_velocity_routine = fall_velocity_routine
+        self.mie_calculation_algorithm = mie_calculation_algorithm
+        self.optics_algorithm = optics_algorithm
         self.is_ice = is_ice
         self.is_fractal = is_fractal
-        self.do_mie = do_mie
+        self.is_cloud = is_cloud
+        self.is_sulfate = is_sulfate
         self.do_wetdep = do_wetdep
         self.do_drydep = do_drydep
         self.do_vtran = do_vtran
         self.solfac = solfac
         self.scavcoef = scavcoef
+        self.dpc_threshold = dpc_threshold
         self.rmon = rmon
         self.df = df or []
         self.falpha = falpha
+        self.neutral_volfrc = neutral_volfrc
 
     def to_dict(self) -> Dict:
         """Convert to dictionary."""
@@ -338,16 +409,15 @@ class CARMAParameters:
 
         # Create aluminum group
         group = CARMAGroupConfig(
-            id=1,
             name="aluminum",
             shortname="PRALUM",
             rmin=21.5e-6,
             rmrat=2.0,
             ishape=ParticleShape.SPHERE,
             eshape=1.0,
+            mie_calculation_algorithm=MieCalculationAlgorithm.TOON_1981,
             is_ice=False,
             is_fractal=True,
-            do_mie=True,
             do_wetdep=False,
             do_drydep=True,
             do_vtran=True,

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -157,9 +157,9 @@ class CARMAGroupConfig:
         Args:
             name: Name of the group (default: "default_group")
             shortname: Short name for the group (default: "")
-            rmin: Radius of particles in the first bin [cm] (default: 1e-7)
+            rmin: Radius of particles in the first bin [m] (default: 1e-9)
             rmrat: Ratio of masses of particles in consecutive bins (default: 2.0)
-            rmassmin: Minimum mass of particles [g] (default: 0.0)
+            rmassmin: Minimum mass of particles [kg] (default: 0.0)
             ishape: Shape of the particles (default: ParticleShape.SPHERE)
             eshape: Ratio of particle length / diameter (default: 1.0)
             swelling_approach: Dictionary specifying swelling algorithm and composition (default: NONE)
@@ -174,9 +174,9 @@ class CARMAGroupConfig:
             do_drydep: Whether to include dry deposition (default: False)
             do_vtran: Whether to include vertical transport (default: True)
             solfac: Solubility factor for wet deposition (default: 0.0)
-            scavcoef: Scavenging coefficient for wet deposition [mm-1] (default: 0.0)
+            scavcoef: Scavenging coefficient for wet deposition (default: 0.0)
             dpc_threshold: Threshold for dry particle collection (default: 0.0)
-            rmon: Monomer radius of fractal particles [cm] (default: 0.0)
+            rmon: Monomer radius of fractal particles [m] (default: 0.0)
             df: List of fractal dimensions for each size bin (default: None)
             falpha: Fractal packing coefficient (default: 1.0)
             neutral_volfrc: Neutral volume fraction for fractal particles (default: 0.0)
@@ -411,7 +411,7 @@ class CARMAParameters:
         group = CARMAGroupConfig(
             name="aluminum",
             shortname="PRALUM",
-            rmin=21.5e-6,
+            rmin=21.5e-8,
             rmrat=2.0,
             ishape=ParticleShape.SPHERE,
             eshape=1.0,
@@ -423,7 +423,7 @@ class CARMAParameters:
             do_vtran=True,
             solfac=0.0,
             scavcoef=0.0,
-            rmon=21.5e-6,
+            rmon=21.5e-8,
             df=[1.6] * 5,  # 5 bins with fractal dimension 1.6
             falpha=1.0
         )

--- a/src/carma/carma.cpp
+++ b/src/carma/carma.cpp
@@ -125,7 +125,6 @@ namespace musica
         const auto& group = params.groups[i];
         auto& c_group = c_params->groups[i];
 
-        c_group.id = group.id;
         c_group.name_length = std::min(static_cast<int>(group.name.length()), 255);
         std::strncpy(c_group.name, group.name.c_str(), 255);
         c_group.name[255] = '\0';
@@ -136,18 +135,28 @@ namespace musica
 
         c_group.rmin = group.rmin;
         c_group.rmrat = group.rmrat;
+        c_group.rmassmin = group.rmassmin;
         c_group.ishape = static_cast<int>(group.ishape);
         c_group.eshape = group.eshape;
         c_group.is_ice = group.is_ice;
+        c_group.swelling_algorithm = static_cast<int>(group.swelling_approach.algorithm);
+        c_group.swelling_composition = static_cast<int>(group.swelling_approach.composition);
+        c_group.fall_velocity_routine = static_cast<int>(group.fall_velocity_routine);
+        c_group.mie_calculation_algorithm = static_cast<int>(group.mie_calculation_algorithm);
+        c_group.optics_algorithm = static_cast<int>(group.optics_algorithm);
+        c_group.is_ice = group.is_ice;
         c_group.is_fractal = group.is_fractal;
-        c_group.do_mie = group.do_mie;
+        c_group.is_cloud = group.is_cloud;
+        c_group.is_sulfate = group.is_sulfate;
         c_group.do_wetdep = group.do_wetdep;
         c_group.do_drydep = group.do_drydep;
         c_group.do_vtran = group.do_vtran;
         c_group.solfac = group.solfac;
         c_group.scavcoef = group.scavcoef;
+        c_group.dpc_threshold = group.dpc_threshold;
         c_group.rmon = group.rmon;
         c_group.falpha = group.falpha;
+        c_group.neutral_volfrc = group.neutral_volfrc;
 
         // Handle df array
         if (!group.df.empty())
@@ -305,7 +314,6 @@ namespace musica
 
     // Create a default group
     CARMAGroupConfig group;
-    group.id = 1;
     group.name = "aluminum";
     group.shortname = "PRALUM";
     group.rmin = 21.5e-6;  // minimum radius [cm]
@@ -314,7 +322,7 @@ namespace musica
     group.eshape = 1.0;  // aspect ratio
     group.is_ice = false;
     group.is_fractal = true;
-    group.do_mie = true;
+    group.mie_calculation_algorithm = MieCalculationAlgorithm::TOON_1981; // Toon & Ackerman 1981
     group.do_wetdep = false;
     group.do_drydep = true;
     group.do_vtran = true;

--- a/src/carma/carma.cpp
+++ b/src/carma/carma.cpp
@@ -65,8 +65,6 @@ namespace musica
     CCARMAParameters *c_params = new CCARMAParameters();
 
     // Copy simple scalar values
-    c_params->max_bins = params.max_bins;
-    c_params->max_groups = params.max_groups;
     c_params->nz = params.nz;
     c_params->ny = params.ny;
     c_params->nx = params.nx;
@@ -284,8 +282,6 @@ namespace musica
     CARMAParameters params;
 
     // Set default values for the aluminum test case
-    params.max_bins = 100;
-    params.max_groups = 10;
     params.nz = 1;
     params.ny = 1;
     params.nx = 1;

--- a/src/carma/carma.cpp
+++ b/src/carma/carma.cpp
@@ -138,7 +138,6 @@ namespace musica
         c_group.rmassmin = group.rmassmin;
         c_group.ishape = static_cast<int>(group.ishape);
         c_group.eshape = group.eshape;
-        c_group.is_ice = group.is_ice;
         c_group.swelling_algorithm = static_cast<int>(group.swelling_approach.algorithm);
         c_group.swelling_composition = static_cast<int>(group.swelling_approach.composition);
         c_group.fall_velocity_routine = static_cast<int>(group.fall_velocity_routine);
@@ -316,7 +315,7 @@ namespace musica
     CARMAGroupConfig group;
     group.name = "aluminum";
     group.shortname = "PRALUM";
-    group.rmin = 21.5e-6;  // minimum radius [cm]
+    group.rmin = 21.5e-8;  // minimum radius [m]
     group.rmrat = 2.0;     // volume ratio between bins
     group.ishape = ParticleShape::SPHERE;
     group.eshape = 1.0;  // aspect ratio
@@ -328,7 +327,7 @@ namespace musica
     group.do_vtran = true;
     group.solfac = 0.0;                      // no solvation
     group.scavcoef = 0.0;                    // no scavenging
-    group.rmon = 21.5e-6;                    // monomer radius [cm]
+    group.rmon = 21.5e-8;                    // monomer radius [m]
     group.df = { 1.6, 1.6, 1.6, 1.6, 1.6 };  // fractal dimension per bin
     group.falpha = 1.0;                      // fractal packing coefficient
 

--- a/src/carma/carma_parameters.F90
+++ b/src/carma/carma_parameters.F90
@@ -21,27 +21,35 @@ module carma_parameters_mod
    end type carma_wavelength_bin_t
 
    type, bind(c) :: carma_group_config_t
-      integer(c_int) :: id
       integer(c_int) :: name_length
       character(len=1, kind=c_char) :: name(256)
       integer(c_int) :: shortname_length
       character(len=1, kind=c_char) :: shortname(7)
       real(c_double) :: rmin
       real(c_double) :: rmrat
+      real(c_double) :: rmassmin
       integer(c_int) :: ishape
       real(c_double) :: eshape
+      integer(c_int) :: swelling_algorithm
+      integer(c_int) :: swelling_composition
+      integer(c_int) :: fall_velocity_routine
+      integer(c_int) :: mie_calculation_algorithm
+      integer(c_int) :: optics_algorithm
       logical(c_bool) :: is_ice
       logical(c_bool) :: is_fractal
-      logical(c_bool) :: do_mie
+      logical(c_bool) :: is_cloud
+      logical(c_bool) :: is_sulfate
       logical(c_bool) :: do_wetdep
       logical(c_bool) :: do_drydep
       logical(c_bool) :: do_vtran
       real(c_double) :: solfac
       real(c_double) :: scavcoef
+      real(c_double) :: dpc_threshold
       real(c_double) :: rmon
       type(c_ptr) :: df
       integer(c_int) :: df_size
       real(c_double) :: falpha
+      real(c_double) :: neutral_volfrc
    end type carma_group_config_t
 
    type, bind(c) :: carma_element_config_t

--- a/src/carma/carma_parameters.F90
+++ b/src/carma/carma_parameters.F90
@@ -64,8 +64,6 @@ module carma_parameters_mod
    end type carma_element_config_t
 
    type, bind(c) :: carma_parameters_t
-      integer(c_int) :: max_bins = 100
-      integer(c_int) :: max_groups = 10
 
       ! Model dimensions
       integer(c_int) :: nz = 1

--- a/src/carma/interface.F90
+++ b/src/carma/interface.F90
@@ -318,7 +318,7 @@ contains
                carma, &
                igroup, &
                group_name, &
-               real(group%rmin, kind=real64), &
+               real(group%rmin, kind=real64) * 100.0_real64, & ! Convert m to cm
                real(group%rmrat, kind=real64), &
                int(group%ishape), &
                real(group%eshape, kind=real64), &
@@ -336,12 +336,12 @@ contains
                shortname=group_short_name, &
                ifallrtn=int(group%fall_velocity_routine), &
                is_cloud= logical(group%is_cloud), &
-               rmassmin=real(group%rmassmin, kind=real64), &
+               rmassmin=real(group%rmassmin, kind=real64) * 1000.0_real64, & ! Convert kg to g
                imiertn=int(group%mie_calculation_algorithm), &
                iopticstype=int(group%optics_algorithm), &
                is_sulfate=logical(group%is_sulfate), &
                dpc_threshold=real(group%dpc_threshold, kind=real64), &
-               rmon=real(group%rmon, kind=real64), &
+               rmon=real(group%rmon, kind=real64) * 100.0_real64, & ! Convert m to cm
                df=df, &
                falpha=real(group%falpha, kind=real64), &
                neutral_volfrc=real(group%neutral_volfrc, kind=real64))

--- a/src/carma/interface.F90
+++ b/src/carma/interface.F90
@@ -314,15 +314,37 @@ contains
             group_name = c_to_f_string(group%name, group%name_length)
             group_short_name = c_to_f_string(group%shortname, group%shortname_length)
             call c_f_pointer(group%df, df, [group%df_size])
-            call CARMAGROUP_Create(carma, int(group%id), group_name, real(group%rmin, kind=real64), &
+            call CARMAGROUP_Create( &
+               carma, &
+               igroup, &
+               group_name, &
+               real(group%rmin, kind=real64), &
                real(group%rmrat, kind=real64), &
-               int(group%ishape), real(group%eshape, kind=real64), logical(group%is_ice), rc,&
+               int(group%ishape), &
+               real(group%eshape, kind=real64), &
+               logical(group%is_ice), &
+               rc, &
                is_fractal=logical(group%is_fractal), &
-               irhswell=I_NO_SWELLING, do_mie=logical(group%do_mie), do_wetdep=logical(group%do_wetdep), &
-               do_drydep=logical(group%do_drydep), do_vtran=logical(group%do_vtran), &
-               solfac=real(group%solfac, kind=real64), scavcoef=real(group%scavcoef, kind=real64), &
-               shortname=group_short_name, rmon=real(group%rmon, kind=real64), df=df, falpha=real(group%falpha, kind=real64), &
-               is_sulfate=.false.)
+               irhswell=int(group%swelling_algorithm), &
+               irhswcomp=int(group%swelling_composition), &
+               do_mie=(group%mie_calculation_algorithm /= 0), &
+               do_wetdep=logical(group%do_wetdep), &
+               do_drydep=logical(group%do_drydep), &
+               do_vtran=logical(group%do_vtran), &
+               solfac=real(group%solfac, kind=real64), &
+               scavcoef=real(group%scavcoef, kind=real64), &
+               shortname=group_short_name, &
+               ifallrtn=int(group%fall_velocity_routine), &
+               is_cloud= logical(group%is_cloud), &
+               rmassmin=real(group%rmassmin, kind=real64), &
+               imiertn=int(group%mie_calculation_algorithm), &
+               iopticstype=int(group%optics_algorithm), &
+               is_sulfate=logical(group%is_sulfate), &
+               dpc_threshold=real(group%dpc_threshold, kind=real64), &
+               rmon=real(group%rmon, kind=real64), &
+               df=df, &
+               falpha=real(group%falpha, kind=real64), &
+               neutral_volfrc=real(group%neutral_volfrc, kind=real64))
             if (rc /= 0) return
          end associate
          end do


### PR DESCRIPTION
Updates the MUSICA C and Python APIs to allow setting of all CARMA Group options. Also removes some options that can be inferred from other data (e.g., `id`, `do_mie`)

closes #470 