### PR TITLE
Add CARMA solute and gas options

### DIFF
--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -73,6 +73,16 @@ namespace musica
     SULFATE = 8             // Sulfate, refractive index varies with WTP/RH
   };
 
+  // Enumeration for vaporization algorithms
+  enum class VaporizationAlgorithm
+  {
+    NONE = 0,
+    H2O_BUCK_1981 = 1,    // Buck 1981 for water vaporization
+    H2O_MURPHY_2005 = 2,  // Murphy and Koop 2005 for water vaporization
+    H2O_GOFF_1946 = 3,    // Goff 1946 for water vaporization (used in CAM)
+    H2SO4_AYERS_1980 = 4  // Ayers 1980 & Kumala 1990 for sulfuric acid vaporization
+  };
+
   // Enumeration for particle types
   enum class ParticleType
   {
@@ -81,6 +91,15 @@ namespace musica
     COREMASS = 3,
     VOLCORE = 4,
     CORE2MOM = 5
+  };
+
+  // Enumeration for gas compositions
+  enum GasComposition
+  {
+    OTHER = 0,  // Other gas composition
+    H2O = 1,    // Water vapor
+    H2SO4 = 2,  // Sulfuric acid
+    SO2 = 3,    // Sulfur dioxide
   };
 
   // Enumeration for particle compositions
@@ -109,6 +128,13 @@ namespace musica
   {
     ParticleSwellingAlgorithm algorithm = ParticleSwellingAlgorithm::NONE;        // Swelling algorithm
     ParticleSwellingComposition composition = ParticleSwellingComposition::NONE;  // Composition for swelling
+  };
+
+  // Structure representing a complex number
+  struct CARMAComplex
+  {
+    double real;        // Real part
+    double imaginary;   // Imaginary part
   };
 
   // Structure representing a CARMA group configuration
@@ -158,6 +184,29 @@ namespace musica
     bool isShell = true;         // is this part of shell or core
   };
 
+  // Structure representing a CARMA solute configuration
+  struct CARMASoluteConfig
+  {
+    std::string name = "default_solute";
+    std::string shortname = "";
+    int ions = 0;        // number of ions the solute dissociates into
+    double wtmol = 0.0;  // molar mass of the solute [kg/mol]
+    double rho = 0.0;    // mass density of the solute [kg/m3]
+  };
+
+  // Structure representing a CARMA gas species configuration
+  struct CARMAGasConfig
+  {
+    std::string name = "default_gas";
+    std::string shortname = "";
+    double wtmol = 0.0;                                           // molar mass of the gas [kg/mol]
+    VaporizationAlgorithm ivaprtn = VaporizationAlgorithm::NONE;  // vaporization routine
+    GasComposition icomposition = GasComposition::OTHER;          // composition of the gas
+    double dgc_threshold = 0.0;                                   // convergence criteria for gas concentration [0 : off; > 0 : fraction]
+    double ds_threshold = 0.0;                                    // convergence criteria for gas saturation [0 : off; > 0 : fraction; < 0 : amount past 0 crossing]
+    std::vector<std::vector<CARMAComplex>> refidx;                // wavelength-resolved refractive indices (n_ref_idx, n_wave)
+  };
+
   struct CARMAParameters
   {
     // Model dimensions
@@ -184,6 +233,8 @@ namespace musica
 
     std::vector<CARMAGroupConfig> groups;
     std::vector<CARMAElementConfig> elements;
+    std::vector<CARMASoluteConfig> solutes;
+    std::vector<CARMAGasConfig> gases;
   };
 
   struct CARMAOutput

--- a/include/musica/carma/carma_c_interface.hpp
+++ b/include/musica/carma/carma_c_interface.hpp
@@ -18,6 +18,12 @@ namespace musica
       bool do_emission;  // Flag to indicate if emission is considered for this bin
     };
 
+    struct CARMAComplexC
+    {
+      double real;      // Real part
+      double imaginary; // Imaginary part
+    };
+
     struct CARMAGroupConfigC
     {
       int name_length;                // length of name string
@@ -71,6 +77,35 @@ namespace musica
       bool isShell;
     };
 
+    // C-Compatible structure for CARMA solute configuration
+    struct CARMASoluteConfigC
+    {
+      int name_length;       // length of name string
+      char name[256];        // 255 chars + null terminator
+      int shortname_length;  // length of shortname string
+      char shortname[7];     // 6 chars + null terminator
+      int ions;              // number of ions the solute dissociates into
+      double wtmol;          // molar mass of the solute [kg/mol]
+      double rho;            // mass density of the solute [kg/m3]
+    };
+
+    // C-Compatible structure for CARMA gas species configuration
+    struct CARMAGasConfigC
+    {
+      int name_length;        // length of name string
+      char name[256];         // 255 chars + null terminator
+      int shortname_length;   // length of shortname string
+      char shortname[7];      // 6 chars + null terminator
+      double wtmol;           // molar mass of the gas [kg/mol]
+      int ivaprtn;            // vaporization routine (enum value)
+      int icomposition;       // composition of the gas (enum value)
+      double dgc_threshold;   // convergence criteria for gas concentration [0 : off; > 0 : fraction]
+      double ds_threshold;    // convergence criteria for gas saturation [0 : off; > 0 : fraction; < 0 : amount past 0 crossing]
+      CARMAComplexC* refidx;  // pointer to wavelength-resolved refractive indices (allocated separately)
+      int refidx_dim_1_size;  // size of first dimension
+      int refidx_dim_2_size;  // size of second dimension
+    };
+
     // C-compatible structure for CARMA parameters
     // MUST match the exact order and types of the Fortran carma_parameters_t struct
     struct CCARMAParameters
@@ -96,11 +131,15 @@ namespace musica
       int wavelength_bin_size;               // Size of wavelength bin arrays
       int number_of_refractive_indices;      // Number of refractive indices per wavelength
 
-      // Group and element configurations
+      // Component configurations
       CARMAGroupConfigC* groups;      // Pointer to groups array
       int groups_size;                // Number of groups
       CARMAElementConfigC* elements;  // Pointer to elements array
       int elements_size;              // Number of elements
+      CARMASoluteConfigC* solutes;   // Pointer to solutes array
+      int solutes_size;               // Number of solutes
+      CARMAGasConfigC* gases;        // Pointer to gases array
+      int gases_size;                 // Number of gases
     };
 
     struct CARMAOutputDataC

--- a/musica/carma.cpp
+++ b/musica/carma.cpp
@@ -165,6 +165,93 @@ void bind_carma(py::module_& carma)
           }
         }
 
+        // Handle solutes configuration
+        if (params_dict.contains("solutes"))
+        {
+          auto solutes_py = params_dict["solutes"];
+          if (!solutes_py.is_none() && py::isinstance<py::list>(solutes_py))
+          {
+            auto solutes_list = solutes_py.cast<py::list>();
+            for (auto solute_py : solutes_list)
+            {
+              auto solute_dict = solute_py.cast<py::dict>();
+              musica::CARMASoluteConfig solute;
+
+              if (solute_dict.contains("name"))
+                solute.name = solute_dict["name"].cast<std::string>();
+              if (solute_dict.contains("shortname"))
+                solute.shortname = solute_dict["shortname"].cast<std::string>();
+              if (solute_dict.contains("ions"))
+                solute.ions = solute_dict["ions"].cast<int>();
+              if (solute_dict.contains("wtmol"))
+                solute.wtmol = solute_dict["wtmol"].cast<double>();
+              if (solute_dict.contains("rho"))
+                solute.rho = solute_dict["rho"].cast<double>();
+
+              params.solutes.push_back(solute);
+            }
+          }
+        }
+
+        // Handle gases configuration
+        if (params_dict.contains("gases"))
+        {
+          auto gases_py = params_dict["gases"];
+          if (!gases_py.is_none() && py::isinstance<py::list>(gases_py))
+          {
+            auto gases_list = gases_py.cast<py::list>();
+            for (auto gas_py : gases_list)
+            {
+              auto gas_dict = gas_py.cast<py::dict>();
+              musica::CARMAGasConfig gas;
+
+              if (gas_dict.contains("name"))
+                gas.name = gas_dict["name"].cast<std::string>();
+              if (gas_dict.contains("shortname"))
+                gas.shortname = gas_dict["shortname"].cast<std::string>();
+              if (gas_dict.contains("wtmol"))
+                gas.wtmol = gas_dict["wtmol"].cast<double>();
+              if (gas_dict.contains("ivaprtn"))
+                gas.ivaprtn = static_cast<musica::VaporizationAlgorithm>(gas_dict["ivaprtn"].cast<int>());
+              if (gas_dict.contains("icomposition"))
+                gas.icomposition = static_cast<musica::GasComposition>(gas_dict["icomposition"].cast<int>());
+              if (gas_dict.contains("dgc_threshold"))
+                gas.dgc_threshold = gas_dict["dgc_threshold"].cast<double>();
+              if (gas_dict.contains("ds_threshold"))
+                gas.ds_threshold = gas_dict["ds_threshold"].cast<double>();
+              if (gas_dict.contains("refidx"))
+              {
+                auto refidx_py = gas_dict["refidx"];
+                if (!refidx_py.is_none() && py::isinstance<py::list>(refidx_py))
+                {
+                  auto refidx_outer_list = refidx_py.cast<py::list>();
+                  for (auto refidx_row_py : refidx_outer_list)
+                  {
+                    std::vector<musica::CARMAComplex> refidx_row;
+                    if (!refidx_row_py.is_none() && py::isinstance<py::list>(refidx_row_py))
+                    {
+                      auto refidx_inner_list = refidx_row_py.cast<py::list>();
+                      for (auto refidx_item : refidx_inner_list)
+                      {
+                        auto refidx_dict = refidx_item.cast<py::dict>();
+                        musica::CARMAComplex refidx_value;
+                        if (refidx_dict.contains("real"))
+                          refidx_value.real = refidx_dict["real"].cast<double>();
+                        if (refidx_dict.contains("imaginary"))
+                          refidx_value.imaginary = refidx_dict["imaginary"].cast<double>();
+                        refidx_row.push_back(refidx_value);
+                      }
+                    }
+                    gas.refidx.push_back(refidx_row);
+                  }
+                }
+              }
+
+              params.gases.push_back(gas);
+            }
+          }
+        }
+
         // Handle wavelength bins
         if (params_dict.contains("wavelength_bins"))
         {

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -80,6 +80,23 @@ class OpticsAlgorithm:
     SULFATE = 8
 
 
+class VaporizationAlgorithm:
+    """Enumeration for vaporization algorithms used in CARMA."""
+    NONE = 0
+    H2O_BUCK_1981 = 1
+    H2O_MURPHY_2005 = 2
+    H2O_GOFF_1946 = 3
+    H2SO4_AYERS_1980 = 4
+
+
+class GasComposition:
+    """Enumeration for gas compositions used in CARMA."""
+    NONE = 0
+    H2O = 1
+    H2SO4 = 2
+    SO2 = 3
+
+
 class ParticleComposition:
     """Enumeration for particle compositions used in CARMA."""
     ALUMINUM = 1
@@ -260,6 +277,81 @@ class CARMAElementConfig:
         self.arat = arat or []
         self.kappa = kappa
         self.is_shell = is_shell
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {k: v for k, v in self.__dict__.items()}
+
+
+class CARMASoluteConfig:
+    """Configuration for a CARMA solute.
+
+    A CARMA solute represents a chemical species that can dissolve in water and affect particle properties.
+    """
+
+    def __init__(self,
+                 name: str = "default_solute",
+                 shortname: str = "",
+                 ions: int = 0,
+                 wtmol: float = 0.0,
+                 rho: float = 0.0):
+        """
+        Initialize a CARMA solute configuration.
+
+        Args:
+            name: Name of the solute (default: "default_solute")
+            shortname: Short name for the solute (default: "")
+            ions: Number of ions (default: 0)
+            wtmol: Molecular weight in kg/mol (default: 0.0)
+            rho: Density in kg/cm3 (default: 0.0)
+        """
+        self.name = name
+        self.shortname = shortname
+        self.ions = ions
+        self.wtmol = wtmol
+        self.rho = rho
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {k: v for k, v in self.__dict__.items()}
+
+
+class CARMAGasConfig:
+    """Configuration for a CARMA gas.
+
+    A CARMA gas represents a gaseous species in the atmosphere.
+    """
+
+    def __init__(self,
+                 name: str = "default_gas",
+                 shortname: str = "",
+                 wtmol: float = 0.0,
+                 ivaprtn: VaporizationAlgorithm = VaporizationAlgorithm.NONE,
+                 icomposition: GasComposition = GasComposition.NONE,
+                 dgc_threshold: float = 0.0,
+                 ds_threshold: float = 0.0,
+                 refidx: Optional[List[List[float]]] = None):
+        """
+        Initialize a CARMA gas configuration.
+
+        Args:
+            name: Name of the gas (default: "default_gas")
+            shortname: Short name for the gas (default: "")
+            mw: Molecular weight in kg/mol (default: 0.0)
+            ivaprtn: Vaporization algorithm used for this gas (default: VaporizationAlgorithm.NONE)
+            icomposition: Composition of the gas (default: GasComposition.NONE)
+            dgc_threshold: Threshold for gas density gradient (default: 0.0)
+            ds_threshold: Threshold for gas saturation (default: 0.0)
+            refidx: Reference indices for gas (default: None)
+        """
+        self.name = name
+        self.shortname = shortname
+        self.wtmol = wtmol
+        self.ivaprtn = ivaprtn
+        self.icomposition = icomposition
+        self.dgc_threshold = dgc_threshold
+        self.ds_threshold = ds_threshold
+        self.refidx = refidx or []
 
     def to_dict(self) -> Dict:
         """Convert to dictionary."""

--- a/src/carma/carma_parameters.F90
+++ b/src/carma/carma_parameters.F90
@@ -12,13 +12,19 @@ module carma_parameters_mod
    private
 
    public :: carma_group_config_t, carma_element_config_t, carma_parameters_t, &
-             carma_wavelength_bin_t
+             carma_wavelength_bin_t, carma_complex_t, carma_solute_config_t, carma_gas_config_t
 
    type, bind(c) :: carma_wavelength_bin_t
       real(c_double) :: center       ! Center of the wavelength bin [m]
       real(c_double) :: width        ! Width of the wavelength bin [m]
       logical(c_bool) :: do_emission ! Flag to indicate if emission is considered for this bin
    end type carma_wavelength_bin_t
+
+   ! Complex number type for CARMA
+   type, bind(c) :: carma_complex_t
+      real(c_double) :: real_part    ! Real part of the complex number
+      real(c_double) :: imag_part    ! Imaginary part of the complex number
+   end type carma_complex_t
 
    type, bind(c) :: carma_group_config_t
       integer(c_int) :: name_length
@@ -71,6 +77,31 @@ module carma_parameters_mod
       logical(c_bool) :: isShell
    end type carma_element_config_t
 
+   type, bind(c) :: carma_solute_config_t
+      integer(c_int) :: name_length
+      character(len=1, kind=c_char) :: name(256)
+      integer(c_int) :: shortname_length
+      character(len=1, kind=c_char) :: shortname(7)
+      integer(c_int) :: ions
+      real(c_double) :: wtmol
+      real(c_double) :: rho
+   end type carma_solute_config_t
+
+   type, bind(c) :: carma_gas_config_t
+      integer(c_int) :: name_length
+      character(len=1, kind=c_char) :: name(256)
+      integer(c_int) :: shortname_length
+      character(len=1, kind=c_char) :: shortname(7)
+      real(c_double) :: wtmol          ! Molar mass of the gas [kg/mol]
+      integer(c_int) :: ivaprtn        ! Vaporization routine
+      integer(c_int) :: icomposition   ! Composition of the gas
+      real(c_double) :: dgc_threshold  ! Convergence criteria for gas concentration [0 : off; > 0 : fraction]
+      real(c_double) :: ds_threshold   ! Convergence criteria for gas saturation [0 : off; > 0 : fraction; < 0 : amount past 0 crossing]
+      type(c_ptr) :: refidx            ! Wavelength-resolved refractive indices (n_ref_idx, n_wave)
+      integer(c_int) :: refidx_dim_1_size  ! Size of first dimension
+      integer(c_int) :: refidx_dim_2_size  ! Size of second dimension
+   end type carma_gas_config_t
+
    type, bind(c) :: carma_parameters_t
 
       ! Model dimensions
@@ -94,12 +125,16 @@ module carma_parameters_mod
       integer(c_int) :: wavelength_bin_size = 0
       integer(c_int) :: number_of_refractive_indices = 0  ! Number of refractive indices per wavelength
 
-      ! Group and element configurations (will be handled through C interface)
-      ! Note: groups and elements are managed through C pointers in interface
+      ! Component configurations (will be handled through C interface)
+      ! Note: components are managed through C pointers in interface
       type(c_ptr) :: groups
       integer(c_int) :: groups_size
       type(c_ptr) :: elements
       integer(c_int) :: elements_size
+      type(c_ptr) :: solutes
+      integer(c_int) :: solutes_size
+      type(c_ptr) :: gases
+      integer(c_int) :: gases_size
    end type carma_parameters_t
 
 end module carma_parameters_mod

--- a/src/test/unit/carma/carma_c_api.cpp
+++ b/src/test/unit/carma/carma_c_api.cpp
@@ -39,6 +39,224 @@ TEST_F(CarmaCApiTest, RunCarmaWithDefaultParameters)
   // Test that we can run CARMA with default parameters without throwing
   ASSERT_NO_THROW(carma.Run());
 }
+
+TEST_F(CarmaCApiTest, RunCarmaWithAllComponents)
+{
+  CARMAParameters params;
+  params.nz = 2;
+  params.ny = 1;
+  params.nx = 1;
+  params.nbin = 3;
+  params.ngroup = 3;
+  params.nelem = 4;
+  params.nsolute = 2;
+  params.ngas = 3;
+  params.dtime = 900.0;
+  params.deltaz = 500.0;
+  params.zmin = 1000.0;
+
+  // Set up wavelength bins
+  params.wavelength_bins = {
+    { 550e-9, 50e-9, true },  // 550 nm ± 25 nm
+    { 850e-9, 100e-9, true }  // 850 nm ± 50 nm
+  };
+  params.number_of_refractive_indices = 2;
+
+  // Group 1: Aluminum particles (sphere)
+  CARMAGroupConfig aluminum_group;
+  aluminum_group.name = "aluminum";
+  aluminum_group.shortname = "ALUM";
+  aluminum_group.rmin = 1e-8;
+  aluminum_group.rmrat = 2.0;
+  aluminum_group.ishape = ParticleShape::SPHERE;
+  aluminum_group.eshape = 1.0;
+  aluminum_group.is_fractal = false;
+  aluminum_group.do_vtran = true;
+  aluminum_group.do_drydep = true;
+  aluminum_group.df = { 1.8, 1.8, 1.8 };  // fractal dimension per bin
+  params.groups.push_back(aluminum_group);
+
+  // Group 2: Sulfate particles (sphere, with swelling)
+  CARMAGroupConfig sulfate_group;
+  sulfate_group.name = "sulfate";
+  sulfate_group.shortname = "SULF";
+  sulfate_group.rmin = 5e-9;
+  sulfate_group.rmrat = 2.5;
+  sulfate_group.ishape = ParticleShape::SPHERE;
+  sulfate_group.eshape = 1.0;
+  sulfate_group.swelling_approach.algorithm = ParticleSwellingAlgorithm::FITZGERALD;
+  sulfate_group.swelling_approach.composition = ParticleSwellingComposition::AMMONIUM_SULFATE;
+  sulfate_group.is_sulfate = true;
+  sulfate_group.do_wetdep = true;
+  sulfate_group.do_vtran = true;
+  sulfate_group.solfac = 0.8;
+  sulfate_group.df = { 2.0, 2.0, 2.0 };
+  params.groups.push_back(sulfate_group);
+
+  // Group 3: Ice particles (hexagon)
+  CARMAGroupConfig ice_group;
+  ice_group.name = "ice";
+  ice_group.shortname = "ICE";
+  ice_group.rmin = 2e-8;
+  ice_group.rmrat = 3.0;
+  ice_group.ishape = ParticleShape::HEXAGON;
+  ice_group.eshape = 2.0;  // aspect ratio
+  ice_group.is_ice = true;
+  ice_group.is_cloud = true;
+  ice_group.do_vtran = true;
+  ice_group.df = { 1.5, 1.5, 1.5 };
+  params.groups.push_back(ice_group);
+
+  // Element 1: Aluminum core (Group 1)
+  CARMAElementConfig aluminum_element;
+  aluminum_element.id = 1;
+  aluminum_element.igroup = 1;
+  aluminum_element.name = "Aluminum";
+  aluminum_element.shortname = "AL";
+  aluminum_element.rho = 2.70;  // g/cm³
+  aluminum_element.itype = ParticleType::INVOLATILE;
+  aluminum_element.icomposition = ParticleComposition::ALUMINUM;
+  aluminum_element.kappa = 0.0;
+  aluminum_element.isShell = false;  // core
+  params.elements.push_back(aluminum_element);
+
+  // Element 2: Sulfate (Group 2)
+  CARMAElementConfig sulfate_element;
+  sulfate_element.id = 2;
+  sulfate_element.igroup = 2;
+  sulfate_element.name = "Sulfate";
+  sulfate_element.shortname = "SO4";
+  sulfate_element.rho = 1.84;  // g/cm³
+  sulfate_element.itype = ParticleType::VOLATILE;
+  sulfate_element.icomposition = ParticleComposition::H2SO4;
+  sulfate_element.isolute = 1;   // linked to first solute
+  sulfate_element.kappa = 0.61;  // hygroscopicity
+  sulfate_element.isShell = true;
+  params.elements.push_back(sulfate_element);
+
+  // Element 3: Water on sulfate (Group 2)
+  CARMAElementConfig water_element;
+  water_element.id = 3;
+  water_element.igroup = 2;
+  water_element.name = "Water";
+  water_element.shortname = "H2O";
+  water_element.rho = 1.0;  // g/cm³
+  water_element.itype = ParticleType::VOLATILE;
+  water_element.icomposition = ParticleComposition::H2O;
+  water_element.kappa = 0.0;
+  water_element.isShell = true;
+  params.elements.push_back(water_element);
+
+  // Element 4: Ice (Group 3)
+  CARMAElementConfig ice_element;
+  ice_element.id = 4;
+  ice_element.igroup = 3;
+  ice_element.name = "Ice";
+  ice_element.shortname = "ICE";
+  ice_element.rho = 0.92;  // g/cm³
+  ice_element.itype = ParticleType::INVOLATILE;
+  ice_element.icomposition = ParticleComposition::ICE;
+  ice_element.kappa = 0.0;
+  ice_element.isShell = false;
+  params.elements.push_back(ice_element);
+
+  // Solute 1: Ammonium sulfate
+  CARMASoluteConfig nh4so4_solute;
+  nh4so4_solute.name = "Ammonium Sulfate";
+  nh4so4_solute.shortname = "NH4SO4";
+  nh4so4_solute.ions = 3;           // (NH4)2SO4 dissociates into 3 ions
+  nh4so4_solute.wtmol = 132.14e-3;  // kg/mol
+  nh4so4_solute.rho = 1769.0;       // kg/m³
+  params.solutes.push_back(nh4so4_solute);
+
+  // Solute 2: Sodium chloride
+  CARMASoluteConfig nacl_solute;
+  nacl_solute.name = "Sodium Chloride";
+  nacl_solute.shortname = "NACL";
+  nacl_solute.ions = 2;          // NaCl dissociates into 2 ions
+  nacl_solute.wtmol = 58.44e-3;  // kg/mol
+  nacl_solute.rho = 2165.0;      // kg/m³
+  params.solutes.push_back(nacl_solute);
+
+  // Gas 1: Water vapor
+  CARMAGasConfig h2o_gas;
+  h2o_gas.name = "Water Vapor";
+  h2o_gas.shortname = "H2OV";
+  h2o_gas.wtmol = 18.016e-3;  // kg/mol
+  h2o_gas.ivaprtn = VaporizationAlgorithm::H2O_MURPHY_2005;
+  h2o_gas.icomposition = GasComposition::H2O;
+  h2o_gas.dgc_threshold = 1e-6;
+  h2o_gas.ds_threshold = 1e-4;
+  params.gases.push_back(h2o_gas);
+
+  // Gas 2: Sulfuric acid vapor
+  CARMAGasConfig h2so4_gas;
+  h2so4_gas.name = "Sulfuric Acid";
+  h2so4_gas.shortname = "H2SO4V";
+  h2so4_gas.wtmol = 98.08e-3;  // kg/mol
+  h2so4_gas.ivaprtn = VaporizationAlgorithm::H2SO4_AYERS_1980;
+  h2so4_gas.icomposition = GasComposition::H2SO4;
+  h2so4_gas.dgc_threshold = 1e-8;
+  h2so4_gas.ds_threshold = 1e-6;
+  params.gases.push_back(h2so4_gas);
+
+  // Gas 3: Sulfur dioxide
+  CARMAGasConfig so2_gas;
+  so2_gas.name = "Sulfur Dioxide";
+  so2_gas.shortname = "SO2";
+  so2_gas.wtmol = 64.07e-3;  // kg/mol
+  so2_gas.ivaprtn = VaporizationAlgorithm::NONE;
+  so2_gas.icomposition = GasComposition::SO2;
+  so2_gas.dgc_threshold = 0.0;  // no convergence check
+  so2_gas.ds_threshold = 0.0;
+  params.gases.push_back(so2_gas);
+
+  // Create CARMA instance and run
+  CARMA carma{ params };
+  CARMAOutput output;
+  ASSERT_NO_THROW(output = carma.Run());
+
+  // Verify dimensions match parameters
+  EXPECT_EQ(output.lat.size(), params.ny);
+  EXPECT_EQ(output.lon.size(), params.nx);
+  EXPECT_EQ(output.vertical_center.size(), params.nz);
+  EXPECT_EQ(output.pressure.size(), params.nz);
+  EXPECT_EQ(output.temperature.size(), params.nz);
+  EXPECT_EQ(output.air_density.size(), params.nz);
+
+  // Verify 3D particle arrays (nz x nbin x nelem)
+  EXPECT_EQ(output.particle_concentration.size(), params.nz);
+  EXPECT_EQ(output.mass_mixing_ratio.size(), params.nz);
+  if (!output.particle_concentration.empty())
+  {
+    EXPECT_EQ(output.particle_concentration[0].size(), params.nbin);
+    if (!output.particle_concentration[0].empty())
+    {
+      EXPECT_EQ(output.particle_concentration[0][0].size(), params.nelem);
+    }
+  }
+
+  // Verify 3D group arrays (nz x nbin x ngroup)
+  EXPECT_EQ(output.wet_radius.size(), params.nz);
+  EXPECT_EQ(output.wet_density.size(), params.nz);
+  EXPECT_EQ(output.fall_velocity.size(), params.nz);
+  EXPECT_EQ(output.nucleation_rate.size(), params.nz);
+  EXPECT_EQ(output.deposition_velocity.size(), params.nz);
+
+  // Verify 2D arrays (nbin x ngroup)
+  EXPECT_EQ(output.dry_radius.size(), params.nbin);
+  EXPECT_EQ(output.mass_per_bin.size(), params.nbin);
+  if (!output.dry_radius.empty())
+  {
+    EXPECT_EQ(output.dry_radius[0].size(), params.ngroup);
+  }
+
+  // Verify 1D group arrays
+  EXPECT_EQ(output.group_particle_number_concentration.size(), params.ngroup);
+  EXPECT_EQ(output.constituent_type.size(), params.ngroup);
+  EXPECT_EQ(output.max_prognostic_bin.size(), params.ngroup);
+}
+
 TEST_F(CarmaCApiTest, RunCarmaWithAluminumTestParams)
 {
   CARMAParameters params = CARMA::CreateAluminumTestParams();


### PR DESCRIPTION
Adds the ability to create CARMA solutes and gases via the MUSICA C and Python APIs.

closes #472 
closes #473 