### PR TITLE
Add CARMA initialization options

### DIFF
--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -287,10 +287,10 @@ namespace musica
     int maxretries = 5;             // maximum number of retries
     double conmax = 1.0e-1;         // minimum relative concentration to consider
     double dt_threshold = 0.0;      // convergence criteria for temperature [fraction] (0: off)
-    double cstick = 1.0;            // accomodation coefficient for coagulation
-    double gsticki = 0.93;          // accomodation coefficient for growth of ice
-    double gstickl = 1.0;           // accomodation coefficient for growth of liquid
-    double tstick = 1.0;            // accomodation coefficient temperature
+    double cstick = 1.0;            // accommodation coefficient for coagulation
+    double gsticki = 0.93;          // accommodation coefficient for growth of ice
+    double gstickl = 1.0;           // accommodation coefficient for growth of liquid
+    double tstick = 1.0;            // accommodation coefficient temperature
   };
 
   // Structure representing CARMA parameters

--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -263,6 +263,36 @@ namespace musica
     int ievp2elem = 0;  // element index to evaporate to (if applicable)
   };
 
+  // Structure representing CARMA initialization configuration
+  struct CARMAInitializationConfig
+  {
+    bool do_cnst_rlh = false;       // use constant values for latent heats
+    bool do_detrain = false;        // do detrainment
+    bool do_fixedinit = false;      // use fixed initialization from reference atmosphere
+    bool do_incloud = false;        // do in-cloud processes (growth, coagulation)
+    bool do_explised = false;       // do sedimentation with substepping
+    bool do_substep = false;        // do substepping
+    bool do_thermo = false;          // do thermodynamic processes
+    bool do_vdiff = false;          // do Brownian diffusion
+    bool do_vtran = true;           // do sedimentation
+    bool do_drydep = false;         // do dry deposition
+    bool do_pheat = false;          // do particle heating
+    bool do_pheatatm = false;       // do particle heating of atmosphere
+    bool do_clearsky = false;       // do clear sky growth and coagulation
+    bool do_partialinit = false;    // do initialization of coagulation from reference atmosphere (requires do_fixedinit)
+    bool do_coremasscheck = false;  // check core mass for particles
+    double vf_const = 0.0;          // constant fall velocity [m/s] (0: off)
+    int minsubsteps = 1;            // minimum number of substeps
+    int maxsubsteps = 1;            // maximum number of substeps
+    int maxretries = 5;             // maximum number of retries
+    double conmax = 1.0e-1;         // minimum relative concentration to consider
+    double dt_threshold = 0.0;      // convergence criteria for temperature [fraction] (0: off)
+    double cstick = 1.0;            // accomodation coefficient for coagulation
+    double gsticki = 0.93;          // accomodation coefficient for growth of ice
+    double gstickl = 1.0;           // accomodation coefficient for growth of liquid
+    double tstick = 1.0;            // accomodation coefficient temperature
+  };
+
   // Structure representing CARMA parameters
   struct CARMAParameters
   {
@@ -294,6 +324,9 @@ namespace musica
     std::vector<CARMACoagulationConfig> coagulations;
     std::vector<CARMAGrowthConfig> growths;
     std::vector<CARMANucleationConfig> nucleations;
+
+    // Initialization configuration
+    CARMAInitializationConfig initialization;
   };
 
   struct CARMAOutput

--- a/include/musica/carma/carma_c_interface.hpp
+++ b/include/musica/carma/carma_c_interface.hpp
@@ -139,6 +139,36 @@ namespace musica
       int ievp2elem;   // element index to evaporate to (if applicable)
     };
 
+    // C-Compatible structure for CARMA intialization configuration
+    struct CARMAInitializationConfigC
+    {
+      bool do_cnst_rlh;  // use constant values for latent heats
+      bool do_detrain;  // do detrainment
+      bool do_fixedinit;  // use fixed initialization from reference atmosphere
+      bool do_incloud;  // do in-cloud processes (growth, coagulation)
+      bool do_explised; // do sedimentation with substepping
+      bool do_substep;  // do substepping
+      bool do_thermo; // do thermodynamic processes
+      bool do_vdiff; // do Brownian diffusion
+      bool do_vtran;  // do sedimentation
+      bool do_drydep; // do dry deposition
+      bool do_pheat;  // do particle heating
+      bool do_pheatatm; // do particle heating of atmosphere
+      bool do_clearsky; // do clear sky growth and coagulation
+      bool do_partialinit; // do initialization of coagulation from reference atmosphere (requires do_fixedinit)
+      bool do_coremasscheck; // check core mass for particles
+      double vf_const; // constant fall velocity [m/s] (0: off)
+      int minsubsteps;  // minimum number of substeps
+      int maxsubsteps;  // maximum number of substeps
+      int maxretries;  // maximum number of retries
+      double conmax; // minimum relative concentration to consider
+      double dt_threshold; // convergence criteria for temperature [fraction] (0: off)
+      double cstick; // accomodation coefficient for coagulation
+      double gsticki; // accomodation coefficient for growth of ice
+      double gstickl; // accomodation coefficient for growth of liquid
+      double tstick; // accomodation coefficient temperature
+    };
+
     // C-compatible structure for CARMA parameters
     // MUST match the exact order and types of the Fortran carma_parameters_t struct
     struct CCARMAParameters
@@ -179,6 +209,9 @@ namespace musica
       int growths_size;                       // Number of growths
       CARMANucleationConfigC* nucleations;    // Pointer to nucleations array
       int nucleations_size;                   // Number of nucleations
+
+      // Initialization configuration
+      CARMAInitializationConfigC initialization;  // Initialization configuration
     };
 
     struct CARMAOutputDataC

--- a/include/musica/carma/carma_c_interface.hpp
+++ b/include/musica/carma/carma_c_interface.hpp
@@ -139,7 +139,7 @@ namespace musica
       int ievp2elem;   // element index to evaporate to (if applicable)
     };
 
-    // C-Compatible structure for CARMA intialization configuration
+    // C-Compatible structure for CARMA initialization configuration
     struct CARMAInitializationConfigC
     {
       bool do_cnst_rlh;  // use constant values for latent heats
@@ -163,10 +163,10 @@ namespace musica
       int maxretries;  // maximum number of retries
       double conmax; // minimum relative concentration to consider
       double dt_threshold; // convergence criteria for temperature [fraction] (0: off)
-      double cstick; // accomodation coefficient for coagulation
-      double gsticki; // accomodation coefficient for growth of ice
-      double gstickl; // accomodation coefficient for growth of liquid
-      double tstick; // accomodation coefficient temperature
+      double cstick; // accommodation coefficient for coagulation
+      double gsticki; // accommodation coefficient for growth of ice
+      double gstickl; // accommodation coefficient for growth of liquid
+      double tstick; // accommodation coefficient temperature
     };
 
     // C-compatible structure for CARMA parameters

--- a/musica/carma.cpp
+++ b/musica/carma.cpp
@@ -352,6 +352,67 @@ void bind_carma(py::module_& carma)
           }
         }
 
+        // Handle initialization configuration
+        if (params_dict.contains("initialization"))
+        {
+          auto initialization_py = params_dict["initialization"];
+          if (!initialization_py.is_none() && py::isinstance<py::dict>(initialization_py))
+          {
+            auto initialization_dict = initialization_py.cast<py::dict>();
+
+            if (initialization_dict.contains("do_cnst_rlh"))
+              params.initialization.do_cnst_rlh = initialization_dict["do_cnst_rlh"].cast<bool>();
+            if (initialization_dict.contains("do_detrain"))
+              params.initialization.do_detrain = initialization_dict["do_detrain"].cast<bool>();
+            if (initialization_dict.contains("do_fixedinit"))
+              params.initialization.do_fixedinit = initialization_dict["do_fixedinit"].cast<bool>();
+            if (initialization_dict.contains("do_incloud"))
+              params.initialization.do_incloud = initialization_dict["do_incloud"].cast<bool>();
+            if (initialization_dict.contains("do_explised"))
+              params.initialization.do_explised = initialization_dict["do_explised"].cast<bool>();
+            if (initialization_dict.contains("do_substep"))
+              params.initialization.do_substep = initialization_dict["do_substep"].cast<bool>();
+            if (initialization_dict.contains("do_thermo"))
+              params.initialization.do_thermo = initialization_dict["do_thermo"].cast<bool>();
+            if (initialization_dict.contains("do_vdiff"))
+              params.initialization.do_vdiff = initialization_dict["do_vdiff"].cast<bool>();
+            if (initialization_dict.contains("do_vtran"))
+              params.initialization.do_vtran = initialization_dict["do_vtran"].cast<bool>();
+            if (initialization_dict.contains("do_drydep"))
+              params.initialization.do_drydep = initialization_dict["do_drydep"].cast<bool>();
+            if (initialization_dict.contains("do_pheat"))
+              params.initialization.do_pheat = initialization_dict["do_pheat"].cast<bool>();
+            if (initialization_dict.contains("do_pheatatm"))
+              params.initialization.do_pheatatm = initialization_dict["do_pheatatm"].cast<bool>();
+            if (initialization_dict.contains("do_clearsky"))
+              params.initialization.do_clearsky = initialization_dict["do_clearsky"].cast<bool>();
+            if (initialization_dict.contains("do_partialinit"))
+              params.initialization.do_partialinit = initialization_dict["do_partialinit"].cast<bool>();
+            if (initialization_dict.contains("do_coremasscheck"))
+              params.initialization.do_coremasscheck = initialization_dict["do_coremasscheck"].cast<bool>();
+            if (initialization_dict.contains("vf_const"))
+              params.initialization.vf_const = initialization_dict["vf_const"].cast<double>();
+            if (initialization_dict.contains("minsubsteps"))
+              params.initialization.minsubsteps = initialization_dict["minsubsteps"].cast<int>();
+            if (initialization_dict.contains("maxsubsteps"))
+              params.initialization.maxsubsteps = initialization_dict["maxsubsteps"].cast<int>();
+            if (initialization_dict.contains("maxretries"))
+              params.initialization.maxretries = initialization_dict["maxretries"].cast<int>();
+            if (initialization_dict.contains("conmax"))
+              params.initialization.conmax = initialization_dict["conmax"].cast<double>();
+            if (initialization_dict.contains("dt_threshold"))
+              params.initialization.dt_threshold = initialization_dict["dt_threshold"].cast<double>();
+            if (initialization_dict.contains("cstick"))
+              params.initialization.cstick = initialization_dict["cstick"].cast<double>();
+            if (initialization_dict.contains("gsticki"))
+              params.initialization.gsticki = initialization_dict["gsticki"].cast<double>();
+            if (initialization_dict.contains("gstickl"))
+              params.initialization.gstickl = initialization_dict["gstickl"].cast<double>();
+            if (initialization_dict.contains("tstick"))
+              params.initialization.tstick = initialization_dict["tstick"].cast<double>();
+          }
+        }
+
         // Handle wavelength bins
         if (params_dict.contains("wavelength_bins"))
         {

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -480,6 +480,99 @@ class CARMANucleationConfig:
         return {k: v for k, v in self.__dict__.items()}
 
 
+class CARMAInitializationConfig:
+    """Configuration for CARMA initialization.
+
+    This class defines how the CARMA model is initialized before running simulations.
+    """
+
+    def __init__(self,
+                 do_cnst_rlh: bool = False,
+                 do_detrain: bool = False,
+                 do_fixedinit: bool = False,
+                 do_incloud: bool = False,
+                 do_explised: bool = False,
+                 do_substep: bool = False,
+                 do_thermo: bool = False,
+                 do_vdiff: bool = False,
+                 do_vtran: bool = True,
+                 do_drydep: bool = False,
+                 do_pheat: bool = False,
+                 do_pheatatm: bool = False,
+                 do_clearsky: bool = False,
+                 do_partialinit: bool = False,
+                 do_coremasscheck: bool = False,
+                 vf_const: float = 0.0,
+                 minsubsteps: int = 1,
+                 maxsubsteps: int = 1,
+                 maxretries: int = 5,
+                 conmax: float = 1.0e-1,
+                 dt_threshold: float = 0.0,
+                 cstick: float = 1.0,
+                 gsticki: float = 0.93,
+                 gstickl: float = 1.0,
+                 tstick: float = 1.0):
+        """
+        Initialize a CARMA initialization configuration.
+
+        Args:
+            do_cnst_rlh: Use constant values for latent heats (default: False)
+            do_detrain: Do detrainment (default: False)
+            do_fixedinit: Use fixed initialization from reference atmosphere (default: False)
+            do_incloud: Do in-cloud processes (growth, coagulation) (default: False)
+            do_explised: Do sedimentation with substepping (default: False)
+            do_substep: Do substepping (default: False)
+            do_thermo: Do thermodynamic processes (default: False)
+            do_vdiff: Do Brownian diffusion (default: False)
+            do_vtran: Do sedimentation (default: True)
+            do_drydep: Do dry deposition (default: False)
+            do_pheat: Do particle heating (default: False)
+            do_pheatatm: Do particle heating of atmosphere (default: False)
+            do_clearsky: Do clear sky growth and coagulation (default: False)
+            do_partialinit: Do initialization of coagulation from reference atmosphere (requires do_fixedinit) (default: False)
+            do_coremasscheck: Check core mass for particles (default: False)
+            vf_const: Constant fall velocity [m/s] (0: off) (default: 0.0)
+            minsubsteps: Minimum number of substeps (default: 1)
+            maxsubsteps: Maximum number of substeps (default: 1)
+            maxretries: Maximum number of retries (default: 5)
+            conmax: Minimum relative concentration to consider (default: 1.0e-1)
+            dt_threshold: Convergence criteria for temperature [fraction] (0: off) (default: 0.0)
+            cstick: Accommodation coefficient for coagulation (default: 1.0)
+            gsticki: Accommodation coefficient for growth of ice (default: 0.93)
+            gstickl: Accommodation coefficient for growth of liquid (default: 1.0)
+            tstick: Accommodation coefficient temperature (default: 1.0)
+        """
+        self.do_cnst_rlh = do_cnst_rlh
+        self.do_detrain = do_detrain
+        self.do_fixedinit = do_fixedinit
+        self.do_incloud = do_incloud
+        self.do_explised = do_explised
+        self.do_substep = do_substep
+        self.do_thermo = do_thermo
+        self.do_vdiff = do_vdiff
+        self.do_vtran = do_vtran
+        self.do_drydep = do_drydep
+        self.do_pheat = do_pheat
+        self.do_pheatatm = do_pheatatm
+        self.do_clearsky = do_clearsky
+        self.do_partialinit = do_partialinit
+        self.do_coremasscheck = do_coremasscheck
+        self.vf_const = vf_const
+        self.minsubsteps = minsubsteps
+        self.maxsubsteps = maxsubsteps
+        self.maxretries = maxretries
+        self.conmax = conmax
+        self.dt_threshold = dt_threshold
+        self.cstick = cstick
+        self.gsticki = gsticki
+        self.gstickl = gstickl
+        self.tstick = tstick
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {k: v for k, v in self.__dict__.items()}
+
+
 class CARMAParameters:
     """
     Parameters for CARMA aerosol model simulation.
@@ -505,7 +598,8 @@ class CARMAParameters:
                  gases: Optional[List[CARMAGasConfig]] = None,
                  coagulations: Optional[List[CARMACoagulationConfig]] = None,
                  growths: Optional[List[CARMAGrowthConfig]] = None,
-                 nucleations: Optional[List[CARMANucleationConfig]] = None):
+                 nucleations: Optional[List[CARMANucleationConfig]] = None,
+                 initialization: Optional[CARMAInitializationConfig] = None):
         """
         Initialize CARMA parameters.
 
@@ -526,6 +620,7 @@ class CARMAParameters:
             coagulations: List of coagulation configurations (default: None)
             growths: List of growth configurations (default: None)
             nucleations: List of nucleation configurations (default: None)
+            initialization: Initialization configuration (default: None)
         """
         self.nz = nz
         self.ny = ny
@@ -545,6 +640,7 @@ class CARMAParameters:
         self.coagulations = coagulations or []
         self.growths = growths or []
         self.nucleations = nucleations or []
+        self.initialization = initialization or CARMAInitializationConfig()
 
     def add_wavelength_bin(self, wavelength_bin: CARMAWavelengthBin):
         """Add a wavelength bin configuration."""
@@ -577,6 +673,10 @@ class CARMAParameters:
     def add_nucleation(self, nucleation: CARMANucleationConfig):
         """Add a nucleation configuration."""
         self.nucleations.append(nucleation)
+
+    def set_initialization(self, initialization: CARMAInitializationConfig):
+        """Set the initialization configuration."""
+        self.initialization = initialization
 
     def __repr__(self):
         """String representation of CARMAParameters."""
@@ -613,6 +713,8 @@ class CARMAParameters:
                     params_dict[k] = [nucleation.to_dict() for nucleation in v]
                 elif k == 'wavelength_bins':
                     params_dict[k] = [bin.to_dict() for bin in v]
+                elif k == 'initialization':
+                    params_dict[k] = v.to_dict() if v else None
                 else:
                     params_dict[k] = v
         return params_dict
@@ -668,6 +770,11 @@ class CARMAParameters:
                            for nucleation_dict in params_dict['nucleations']]
             del params_dict['nucleations']
 
+        initialization = None
+        if 'initialization' in params_dict and params_dict['initialization']:
+            initialization = CARMAInitializationConfig(**params_dict['initialization'])
+            del params_dict['initialization']
+
         return cls(
             wavelength_bins=wavelength_bins,
             groups=groups,
@@ -677,6 +784,7 @@ class CARMAParameters:
             coagulations=coagulations,
             growths=growths,
             nucleations=nucleations,
+            initialization=initialization,
             **params_dict)
 
     @classmethod

--- a/src/carma/carma.cpp
+++ b/src/carma/carma.cpp
@@ -394,6 +394,33 @@ namespace musica
       c_params->nucleations_size = 0;
     }
 
+    // Handle initialization configuration
+    c_params->initialization.do_cnst_rlh = params.initialization.do_cnst_rlh;
+    c_params->initialization.do_detrain = params.initialization.do_detrain;
+    c_params->initialization.do_fixedinit = params.initialization.do_fixedinit;
+    c_params->initialization.do_incloud = params.initialization.do_incloud;
+    c_params->initialization.do_explised = params.initialization.do_explised;
+    c_params->initialization.do_substep = params.initialization.do_substep;
+    c_params->initialization.do_thermo = params.initialization.do_thermo;
+    c_params->initialization.do_vdiff = params.initialization.do_vdiff;
+    c_params->initialization.do_vtran = params.initialization.do_vtran;
+    c_params->initialization.do_drydep = params.initialization.do_drydep;
+    c_params->initialization.do_pheat = params.initialization.do_pheat;
+    c_params->initialization.do_pheatatm = params.initialization.do_pheatatm;
+    c_params->initialization.do_clearsky = params.initialization.do_clearsky;
+    c_params->initialization.do_partialinit = params.initialization.do_partialinit;
+    c_params->initialization.do_coremasscheck = params.initialization.do_coremasscheck;
+    c_params->initialization.vf_const = params.initialization.vf_const;
+    c_params->initialization.minsubsteps = params.initialization.minsubsteps;
+    c_params->initialization.maxsubsteps = params.initialization.maxsubsteps;
+    c_params->initialization.maxretries = params.initialization.maxretries;
+    c_params->initialization.conmax = params.initialization.conmax;
+    c_params->initialization.dt_threshold = params.initialization.dt_threshold;
+    c_params->initialization.cstick = params.initialization.cstick;
+    c_params->initialization.gsticki = params.initialization.gsticki;
+    c_params->initialization.gstickl = params.initialization.gstickl;
+    c_params->initialization.tstick = params.initialization.tstick;
+
     return c_params;
   }
 

--- a/src/carma/carma_parameters.F90
+++ b/src/carma/carma_parameters.F90
@@ -13,7 +13,8 @@ module carma_parameters_mod
 
    public :: carma_group_config_t, carma_element_config_t, carma_parameters_t, &
              carma_wavelength_bin_t, carma_complex_t, carma_solute_config_t, carma_gas_config_t, &
-             carma_coagulation_config_t, carma_growth_config_t, carma_nucleation_config_t
+             carma_coagulation_config_t, carma_growth_config_t, carma_nucleation_config_t, &
+             carma_initialization_config_t
 
    type, bind(c) :: carma_wavelength_bin_t
       real(c_double) :: center       ! Center of the wavelength bin [m]
@@ -129,6 +130,34 @@ module carma_parameters_mod
       integer(c_int) :: ievp2elem   ! Element index to evaporate to (if applicable)
    end type carma_nucleation_config_t
 
+   type, bind(c) :: carma_initialization_config_t
+      logical(c_bool) :: do_cnst_rlh
+      logical(c_bool) :: do_detrain
+      logical(c_bool) :: do_fixedinit
+      logical(c_bool) :: do_incloud
+      logical(c_bool) :: do_explised
+      logical(c_bool) :: do_substep
+      logical(c_bool) :: do_thermo
+      logical(c_bool) :: do_vdiff
+      logical(c_bool) :: do_vtran
+      logical(c_bool) :: do_drydep
+      logical(c_bool) :: do_pheat
+      logical(c_bool) :: do_pheatatm
+      logical(c_bool) :: do_clearsky
+      logical(c_bool) :: do_partialinit
+      logical(c_bool) :: do_coremasscheck
+      real(c_double) :: vf_const
+      integer(c_int) :: minsubsteps
+      integer(c_int) :: maxsubsteps
+      integer(c_int) :: maxretries
+      real(c_double) :: conmax
+      real(c_double) :: dt_threshold
+      real(c_double) :: cstick
+      real(c_double) :: gsticki
+      real(c_double) :: gstickl
+      real(c_double) :: tstick
+   end type carma_initialization_config_t
+
    type, bind(c) :: carma_parameters_t
 
       ! Model dimensions
@@ -168,6 +197,9 @@ module carma_parameters_mod
       integer(c_int) :: growths_size  ! Number of growths
       type(c_ptr) :: nucleations     ! Pointer to nucleations array
       integer(c_int) :: nucleations_size  ! Number of nucleations
+
+      ! Initialization configuration
+      type(carma_initialization_config_t) :: initialization
    end type carma_parameters_t
 
 end module carma_parameters_mod

--- a/src/carma/interface.F90
+++ b/src/carma/interface.F90
@@ -581,7 +581,37 @@ contains
       end if
 
       ! Initialize CARMA with coagulation settings matching test_aluminum_simple
-      call CARMA_Initialize(carma, rc, do_grow=.false., do_coag=.true., do_substep=.false., do_vtran=.FALSE.)
+      call CARMA_Initialize( &
+         carma, &
+         rc, &
+         do_cnst_rlh=logical(params%initialization%do_cnst_rlh), &
+         do_coag=params%coagulations_size > 0, &
+         do_detrain=logical(params%initialization%do_detrain), &
+         do_fixedinit=logical(params%initialization%do_fixedinit), &
+         do_grow=params%growths_size > 0 .or. params%nucleations_size > 0, &
+         do_incloud=logical(params%initialization%do_incloud), &
+         do_explised=logical(params%initialization%do_explised), &
+         do_substep=logical(params%initialization%do_substep), &
+         do_thermo=logical(params%initialization%do_thermo), &
+         do_vdiff=logical(params%initialization%do_vdiff), &
+         do_vtran=logical(params%initialization%do_vtran), &
+         do_drydep=logical(params%initialization%do_drydep), &
+         vf_const=real(params%initialization%vf_const, kind=real64) * 100.0_real64, & ! Convert m to cm
+         minsubsteps=int(params%initialization%minsubsteps), &
+         maxsubsteps=int(params%initialization%maxsubsteps), &
+         maxretries=int(params%initialization%maxretries), &
+         conmax=real(params%initialization%conmax, kind=real64), &
+         do_pheat=logical(params%initialization%do_pheat), &
+         do_pheatatm=logical(params%initialization%do_pheatatm), &
+         dt_threshold=real(params%initialization%dt_threshold, kind=real64), &
+         cstick=real(params%initialization%cstick, kind=real64), &
+         gsticki=real(params%initialization%gsticki, kind=real64), &
+         gstickl=real(params%initialization%gstickl, kind=real64), &
+         tstick=real(params%initialization%tstick, kind=real64), &
+         do_clearsky=logical(params%initialization%do_clearsky), &
+         do_partialinit=logical(params%initialization%do_partialinit), &
+         do_coremasscheck=logical(params%initialization%do_coremasscheck) &
+         )
       if (rc /= 0) then
          print *, "Error initializing CARMA"
          return
@@ -742,6 +772,15 @@ contains
                   return
                end if
             end do
+         end do
+
+         ! Set the gas mixing ratios if applicable
+         do igas = 1, NGAS
+            call CARMASTATE_SetGas(cstate, igas, mmr_gas(:,igas), rc)
+            if (rc /= 0) then
+               print *, "Error setting CARMA state gas"
+               return
+            end if
          end do
 
          ! Execute the time step

--- a/src/test/unit/carma/carma_c_api.cpp
+++ b/src/test/unit/carma/carma_c_api.cpp
@@ -162,18 +162,7 @@ TEST_F(CarmaCApiTest, RunCarmaWithAllComponents)
   sulfate_solute.rho = 1769.0;       // kg/m³
   params.solutes.push_back(sulfate_solute);
 
-  // Gas 1: Water vapor
-  CARMAGasConfig h2o_gas;
-  h2o_gas.name = "Water Vapor";
-  h2o_gas.shortname = "H2OV";
-  h2o_gas.wtmol = 18.016e-3;  // kg/mol
-  h2o_gas.ivaprtn = VaporizationAlgorithm::H2O_MURPHY_2005;
-  h2o_gas.icomposition = GasComposition::H2O;
-  h2o_gas.dgc_threshold = 1e-6;
-  h2o_gas.ds_threshold = 1e-4;
-  params.gases.push_back(h2o_gas);
-
-  // Gas 2: Sulfuric acid vapor
+  // Gas 1: Sulfuric acid vapor
   CARMAGasConfig h2so4_gas;
   h2so4_gas.name = "Sulfuric Acid";
   h2so4_gas.shortname = "H2SO4V";
@@ -183,17 +172,6 @@ TEST_F(CarmaCApiTest, RunCarmaWithAllComponents)
   h2so4_gas.dgc_threshold = 1e-8;
   h2so4_gas.ds_threshold = 1e-6;
   params.gases.push_back(h2so4_gas);
-
-  // Gas 3: Sulfur dioxide
-  CARMAGasConfig so2_gas;
-  so2_gas.name = "Sulfur Dioxide";
-  so2_gas.shortname = "SO2";
-  so2_gas.wtmol = 64.07e-3;  // kg/mol
-  so2_gas.ivaprtn = VaporizationAlgorithm::H2O_BUCK_1981;
-  so2_gas.icomposition = GasComposition::SO2;
-  so2_gas.dgc_threshold = 0.0;  // no convergence check
-  so2_gas.ds_threshold = 0.0;
-  params.gases.push_back(so2_gas);
 
   // Coagulation configuration
   CARMACoagulationConfig coagulation_config;
@@ -209,7 +187,7 @@ TEST_F(CarmaCApiTest, RunCarmaWithAllComponents)
   // Growth configuration
   CARMAGrowthConfig growth_config;
   growth_config.ielem = 2;  // Sulfate element
-  growth_config.igas = 2;   // Sulfuric acid gas
+  growth_config.igas = 1;   // Sulfuric acid gas
   params.growths.push_back(growth_config);
 
   // Nucleation configuration
@@ -218,8 +196,12 @@ TEST_F(CarmaCApiTest, RunCarmaWithAllComponents)
   nucleation_config.ielemto = 2;    // To sulfate element
   nucleation_config.algorithm = ParticleNucleationAlgorithm::HOMOGENEOUS_NUCLEATION;
   nucleation_config.rlh_nuc = 1.0e6;  // Latent heat of nucleation [m² s⁻²]
-  nucleation_config.igas = 2;         // Sulfuric acid gas
+  nucleation_config.igas = 1;         // Sulfuric acid gas
   params.nucleations.push_back(nucleation_config);
+
+  // Initialization configuration
+  params.initialization.do_thermo = true;          // Enable thermodynamic processes
+  params.initialization.do_vdiff = true;           // Enable Brownian diffusion
 
   // Create CARMA instance and run
   CARMA carma{ params };

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -58,7 +58,7 @@
 }
 
 {
-   <print_unitialized>
+   <print_uninitialized>
    Memcheck:Cond
    ...
    fun:formatted_transfer_scalar_write

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -40,6 +40,22 @@
 }
 
 {
+   <gsolve_value8>
+   Memcheck:Value8
+   ...
+   fun:gsolve_
+   ...
+}
+
+{
+   <gsolve_value8>
+   Memcheck:Value8
+   ...
+   fun:snprintf
+   ...
+}
+
+{
    <step_param_write>
    Memcheck:Param
    write(buf)
@@ -71,8 +87,6 @@
    <print_value8>
    Memcheck:Value8
    ...
-   fun:formatted_transfer_scalar_write
-   fun:formatted_transfer
    fun:gsolve_
    ...
 }

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -56,6 +56,14 @@
 }
 
 {
+   <gsolve_conditional_jump>
+   Memcheck:Cond
+   ...
+   fun:snprintf
+   ...
+}
+
+{
    <step_param_write>
    Memcheck:Param
    write(buf)

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -13,3 +13,85 @@
    fun:InternalRunTuvx
    ...
 }
+
+##############################################################
+#
+# CARMA suppressions
+#
+# Review these after all the CARMASTATE_* functions have been wrapped
+##############################################################
+
+{
+   <invalid_read_step>
+   Memcheck:Addr8
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   fun:__carma_interface_MOD_run_carma_simulation
+   ...
+}
+
+{
+   <step_value8>
+   Memcheck:Value8
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   fun:__carma_interface_MOD_run_carma_simulation
+   ...
+}
+
+{
+   <step_param_write>
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   ...
+}
+
+{
+   <conditional_jump_getbin>
+   Memcheck:Cond
+   ...
+   fun:__carmastate_mod_MOD_carmastate_getbin
+   fun:__carma_interface_MOD_run_carma_simulation
+   ...
+}
+
+{
+   <print_unitialized>
+   Memcheck:Cond
+   ...
+   fun:formatted_transfer_scalar_write
+   fun:formatted_transfer
+   fun:gsolve_
+   ...
+}
+
+{
+   <print_value8>
+   Memcheck:Value8
+   ...
+   fun:formatted_transfer_scalar_write
+   fun:formatted_transfer
+   fun:gsolve_
+   ...
+}
+
+{
+   <conditional_jump_several>
+   Memcheck:Cond
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   fun:__carma_interface_MOD_run_carma_simulation
+   ...
+}
+
+{
+   <uninitialized_carma_f_pc>
+   Memcheck:Cond
+   fun:__carmastate_mod_MOD_carmastate_getbin
+   fun:__carma_interface_MOD_extract_carma_fundamental_data
+   fun:__carma_interface_MOD_transfer_carma_output_data
+   fun:__carma_interface_MOD_run_carma_simulation
+   ...
+}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -73,6 +73,38 @@
 }
 
 {
+   <cond_getbin>
+   Memcheck:Cond
+   ...
+   fun:__carmastate_mod_MOD_carmastate_getbin
+   ...
+}
+
+{
+   <cond_step>
+   Memcheck:Cond
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   ...
+}
+
+{
+   <cond_fixcorecol>
+   Memcheck:Cond
+   ...
+   fun:fixcorecol_
+   ...
+}
+
+{
+   <cond_coremasscheck>
+   Memcheck:Cond
+   ...
+   fun:coremasscheck_
+   ...
+}
+
+{
    <step_param_write>
    Memcheck:Param
    write(buf)

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -77,8 +77,6 @@
    <print_uninitialized>
    Memcheck:Cond
    ...
-   fun:formatted_transfer_scalar_write
-   fun:formatted_transfer
    fun:gsolve_
    ...
 }

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -64,6 +64,15 @@
 }
 
 {
+   <param_write_gsolve>
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:gsolve_
+   ...
+}
+
+{
    <step_param_write>
    Memcheck:Param
    write(buf)

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -48,6 +48,22 @@
 }
 
 {
+   <value8_step>
+   Memcheck:Value8
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   ...
+}
+
+{
+   <addr8_step>
+   Memcheck:Addr8
+   ...
+   fun:__carmastate_mod_MOD_carmastate_step
+   ...
+}
+
+{
    <gsolve_value8>
    Memcheck:Value8
    ...


### PR DESCRIPTION
Wraps the `CARMA_Initialize()` function for the C and Python APIs. Also adds a few valgrind suppressions that should be removed after the `CARMASTATE_*` functions are finished.

closes #483 