### PR TITLE
update Binder to reference main

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI version](https://badge.fury.io/py/musica.svg)](https://pypi.org/p/musica)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 [![codecov](https://codecov.io/gh/NCAR/musica/branch/main/graph/badge.svg)](https://codecov.io/gh/NCAR/musica)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/ce286ed880191d958fca89b35b126e743b3ed26b?urlpath=lab%2Ftree%2Ftutorials)
 
 
 Multi-Scale Infrastructure for Chemistry and Aerosols

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI version](https://badge.fury.io/py/musica.svg)](https://pypi.org/p/musica)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 [![codecov](https://codecov.io/gh/NCAR/musica/branch/main/graph/badge.svg)](https://codecov.io/gh/NCAR/musica)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/ce286ed880191d958fca89b35b126e743b3ed26b?urlpath=lab%2Ftree%2Ftutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials)
 
 
 Multi-Scale Infrastructure for Chemistry and Aerosols

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,2 @@
+gfortran
+

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,4 @@
 gfortran
-netcdf-fortran
+libnetcdf-dev
+libnetcdf-fortran-dev
+netcdf-bin

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
 gfortran
-netcdf-fortran-devel
+netcdff

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -2,3 +2,4 @@ gfortran
 libnetcdf-dev
 libnetcdff-dev
 libblas-dev
+liblapack-dev

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,3 @@
 gfortran
 libnetcdf-dev
+libnetcdff-dev

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
 gfortran
-libnetcdf-fortran
+netcdf-fortran-devel

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,4 +1,3 @@
 gfortran
 libnetcdf-dev
-libnetcdf-fortran-dev
 netcdf-bin

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
 gfortran
-
+netcdf-fortran

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,3 +1,2 @@
 gfortran
-libnetcdf-dev
-netcdf-bin
+libnetcdf-fortran

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,2 @@
 gfortran
-netcdff
+libnetcdf-dev

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,3 +1,4 @@
 gfortran
 libnetcdf-dev
 libnetcdff-dev
+libblas-dev

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/NCAR/musica.git@main
+-e git+https://github.com/NCAR/musica.git@main#egg=musica
 pandas
 matplotlib
 numpy

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
-musica
+-e git+https://github.com/NCAR/musica.git@main#egg=musica
 pandas
 matplotlib
 numpy

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/NCAR/musica.git@main#egg=musica
+git+https://github.com/NCAR/musica.git@main
 pandas
 matplotlib
 numpy


### PR DESCRIPTION
Binder has been updated to use an editable installation of MUSICA after cloning from main rather than a pip install so that tutorials can stay up-to-date without waiting for new release.