### PR TITLE
change binder link and add directions to navigate to tutorials folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI version](https://badge.fury.io/py/musica.svg)](https://pypi.org/p/musica)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 [![codecov](https://codecov.io/gh/NCAR/musica/branch/main/graph/badge.svg)](https://codecov.io/gh/NCAR/musica)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/HEAD)
 
 
 Multi-Scale Infrastructure for Chemistry and Aerosols

--- a/docs/source/tutorials/tutorials.rst
+++ b/docs/source/tutorials/tutorials.rst
@@ -21,7 +21,7 @@ The Python tutorials are written in `Jupyter <https://jupyter.org>`_ Notebooks a
 Interactive Notebooks
 ----------------------
 The MUSICA repository utilizes `Binder <https://mybinder.readthedocs.io/en/latest/index.html#>`_ to allow users to interact with the tutorial notebooks on a `JupyterHub <https://jupyter.org/hub>`_.
-Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
+To use the latest version MUSICA, please launch our `Binder page <https://mybinder.org/v2/gh/NCAR/musica/HEAD>`_ and navigate to the `tutorials` folder. Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
 
 1. `working with multiple grid cells <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F1.%20multiple_grid_cells.ipynb>`_
 2. `latin hypercube sampling <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F2.%20hypercube.ipynb>`_


### PR DESCRIPTION
original binder links did not actually update with pushes to main. Users will have to navigate to the /tutorials folder for now. 