### PR TITLE
change all binder links to reference latest push to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI version](https://badge.fury.io/py/musica.svg)](https://pypi.org/p/musica)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 [![codecov](https://codecov.io/gh/NCAR/musica/branch/main/graph/badge.svg)](https://codecov.io/gh/NCAR/musica)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/HEAD)
 
 
 Multi-Scale Infrastructure for Chemistry and Aerosols

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI version](https://badge.fury.io/py/musica.svg)](https://pypi.org/p/musica)
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=22322&r=123)
 [![codecov](https://codecov.io/gh/NCAR/musica/branch/main/graph/badge.svg)](https://codecov.io/gh/NCAR/musica)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/HEAD)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials)
 
 
 Multi-Scale Infrastructure for Chemistry and Aerosols

--- a/docs/source/tutorials/tutorials.rst
+++ b/docs/source/tutorials/tutorials.rst
@@ -21,14 +21,15 @@ The Python tutorials are written in `Jupyter <https://jupyter.org>`_ Notebooks a
 Interactive Notebooks
 ----------------------
 The MUSICA repository utilizes `Binder <https://mybinder.readthedocs.io/en/latest/index.html#>`_ to allow users to interact with the tutorial notebooks on a `JupyterHub <https://jupyter.org/hub>`_.
-To use the latest version MUSICA, please launch our `Binder page <https://mybinder.org/v2/gh/NCAR/musica/HEAD>`_ and navigate to the `tutorials` folder. Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
+Please note that our `Binder page <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials>`_ uses the latest version of MUSICA pushed to main as opposed to the latest release.
+Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
 
-1. `working with multiple grid cells <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F1.%20multiple_grid_cells.ipynb>`_
-2. `latin hypercube sampling <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F2.%20hypercube.ipynb>`_
-3. `user-defined reactions <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F3.%20user_defined_reactions.ipynb>`_
-4. `local paralellization <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F4.%20local_parallelization.ipynb>`_
-5. `HPC parallelization <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F5.%20hpc_parallelization.ipynb>`_
-6. `using GPU solvers <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F6.%20gpu_solver.ipynb>`_
+1. `working with multiple grid cells <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials/1.%20multiple_grid_cells.ipynb>`_
+2. `latin hypercube sampling <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials/2.%20hypercube.ipynb>`_
+3. `user-defined reactions <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials/3.%20user_defined_reactions.ipynb>`_
+4. `local paralellization <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials/4.%20local_parallelization.ipynb>`_
+5. `HPC parallelization <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials/5.%20hpc_parallelization.ipynb>`_
+6. `using GPU solvers <https://mybinder.org/v2/gh/NCAR/musica/HEAD?filepath=tutorials/6.%20gpu_solver.ipynb>`_
 
 GitHub
 --------

--- a/docs/source/tutorials/tutorials.rst
+++ b/docs/source/tutorials/tutorials.rst
@@ -21,7 +21,7 @@ The Python tutorials are written in `Jupyter <https://jupyter.org>`_ Notebooks a
 Interactive Notebooks
 ----------------------
 The MUSICA repository utilizes `Binder <https://mybinder.readthedocs.io/en/latest/index.html#>`_ to allow users to interact with the tutorial notebooks on a `JupyterHub <https://jupyter.org/hub>`_.
-Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
+To use the latest version MUSICA, please launch our `Binder page <https://mybinder.org/v2/gh/NCAR/musica/HEAD>`_ and navigate to the `tutorials` folder. Each of the links below will open a JupyterHub set up with all necessary dependencies to run each tutorial:
 
 1. `working with multiple grid cells <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F1.%20multiple_grid_cells.ipynb>`_
 2. `latin hypercube sampling <https://mybinder.org/v2/gh/NCAR/musica/2821e3b4703a49a7ac7ff75748bf50ad6fd9fecf?urlpath=lab%2Ftree%2Ftutorials%2F2.%20hypercube.ipynb>`_


### PR DESCRIPTION
previous Binder links were tagged with a specific commit in the GitHub repository which meant that they weren't updating with pushes to main. New links should updated with pushes to main for README badge and Tutorials page. 