### PR TITLE
Add remaining CARMA set functions

### DIFF
--- a/include/musica/carma/carma_c_interface.hpp
+++ b/include/musica/carma/carma_c_interface.hpp
@@ -321,6 +321,7 @@ namespace musica
         int element_index,
         const double* values,
         int values_size,
+        double surface_mass,
         int* rc);
     void InternalSetDetrain(
         void* carma_state_instance,
@@ -340,6 +341,18 @@ namespace musica
         int gas_saturation_wrt_ice_size,
         const double* gas_saturation_wrt_liquid,
         int gas_saturation_wrt_liquid_size,
+        int* rc);
+
+    void InternalSetTemperature(
+        void* carma_state_instance,
+        const double* temperature,
+        int temperature_size,
+        int* rc);
+
+    void InternalSetAirDensity(
+        void* carma_state_instance,
+        const double* air_density,
+        int air_density_size,
         int* rc);
 
     void InternalStepCarmaState(void* carma_state_instance, const CARMAStateStepConfigC step_config, int* rc);

--- a/include/musica/carma/carma_state.hpp
+++ b/include/musica/carma/carma_state.hpp
@@ -77,7 +77,7 @@ namespace musica
     /// @param surface_mass Element mass on the surface [kg m-2] (0: off)
     void SetBin(int bin_index, int element_index, const std::vector<double>& values, const double surface_mass);
 
-    /// @brief Set the mass of the detrtrained condensate for the bin for each particle element
+    /// @brief Set the mass of the detrained condensate for the bin for each particle element
     /// @param bin_index The index of the bin
     /// @param element_index The index of the particle element
     /// @param values Bin mixing ratio at vertical centers [kg/kg]

--- a/include/musica/carma/carma_state.hpp
+++ b/include/musica/carma/carma_state.hpp
@@ -70,14 +70,39 @@ namespace musica
 
     ~CARMAState();
 
-    void SetBin(int bin_index, int element_index, const std::vector<double>& values);
+    /// @brief Set the values for a specific bin and element
+    /// @param bin_index The index of the bin
+    /// @param element_index The index of the particle element
+    /// @param values Bin mixing ratio at vertical centers [kg/kg]
+    /// @param surface_mass Element mass on the surface [kg m-2] (0: off)
+    void SetBin(int bin_index, int element_index, const std::vector<double>& values, const double surface_mass);
+
+    /// @brief Set the mass of the detrtrained condensate for the bin for each particle element
+    /// @param bin_index The index of the bin
+    /// @param element_index The index of the particle element
+    /// @param values Bin mixing ratio at vertical centers [kg/kg]
     void SetDetrain(int bin_index, int element_index, const std::vector<double>& values);
+
+    /// @brief Set the gas profile
+    /// @param gas_index The index of the gas
+    /// @param values Mass mixing ratios at vertical centers [kg/kg]
+    /// @param old_mmr Original mass mixing ratios at vertical centers [kg/kg]
+    /// @param gas_saturation_wrt_ice The gas saturation with respect to ice [fraction]
+    /// @param gas_saturation_wrt_liquid The gas saturation with respect to liquid [fraction]
     void SetGas(
         int gas_index,
         const std::vector<double>& values,
         const std::vector<double>& old_mmr,
         const std::vector<double>& gas_saturation_wrt_ice,
         const std::vector<double>& gas_saturation_wrt_liquid);
+
+    /// @brief Set the temperature profile
+    /// @param temperature The temperature profile [K] (number of vertical centers)
+    void SetTemperature(const std::vector<double>& temperature);
+
+    /// @brief Set the air density profile
+    /// @param air_density The air density profile [kg/m3] (number of vertical centers)
+    void SetAirDensity(const std::vector<double>& air_density);
     void Step(CARMAStateStepConfig& step_config);
 
    private:

--- a/musica/carma.cpp
+++ b/musica/carma.cpp
@@ -612,10 +612,10 @@ void bind_carma(py::module_& carma)
 
   carma.def(
       "_set_bin",
-      [](std::uintptr_t carma_state_ptr, int bin_index, int element_index, py::object value)
+      [](std::uintptr_t carma_state_ptr, int bin_index, int element_index, py::object value, double surface_mass)
       {
         auto carma_state = reinterpret_cast<musica::CARMAState*>(carma_state_ptr);
-        carma_state->SetBin(bin_index, element_index, to_vector_double(value));
+        carma_state->SetBin(bin_index, element_index, to_vector_double(value), surface_mass);
       },
       "Set values for a specific bin and element in the CARMA state");
   
@@ -624,7 +624,7 @@ void bind_carma(py::module_& carma)
       [](std::uintptr_t carma_state_ptr, int bin_index, int element_index, py::object value)
       {
         auto carma_state = reinterpret_cast<musica::CARMAState*>(carma_state_ptr);
-        carma_state->SetBin(bin_index, element_index, to_vector_double(value));
+        carma_state->SetDetrain(bin_index, element_index, to_vector_double(value));
       },
       "Set the mass of the detrained condensate for the bin");
   
@@ -636,6 +636,24 @@ void bind_carma(py::module_& carma)
         carma_state->SetGas(gas_index, to_vector_double(value), to_vector_double(old_mmr), to_vector_double(gas_saturation_wrt_ice), to_vector_double(gas_saturation_wrt_liquid));
       },
       "Set the gas mass mixing ratio for a specific gas index in the CARMA state");
+
+  carma.def(
+      "_set_temperature",
+      [](std::uintptr_t carma_state_ptr, py::object temperature)
+      {
+        auto carma_state = reinterpret_cast<musica::CARMAState*>(carma_state_ptr);
+        carma_state->SetTemperature(to_vector_double(temperature));
+      },
+      "Set the temperature profile [K] for the CARMA state");
+
+  carma.def(
+      "_set_air_density",
+      [](std::uintptr_t carma_state_ptr, py::object air_density)
+      {
+        auto carma_state = reinterpret_cast<musica::CARMAState*>(carma_state_ptr);
+        carma_state->SetAirDensity(to_vector_double(air_density));
+      },
+      "Set the air density profile [kg/m³] for the CARMA state");
 
   carma.def(
       "_step",

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -1162,7 +1162,11 @@ class CARMAState:
         """Convert CARMAState to dictionary."""
         return {k: v for k, v in self.__dict__.items() if not k.startswith('__') and not callable(v)}
 
-    def set_bin(self, bin_index: int, element_index: int, value: Union[float, List[float]]):
+    def set_bin(self,
+                bin_index: int,
+                element_index: int,
+                value: Union[float, List[float]],
+                surface_mass: Optional[float] = 0.0):
         """
         Set the value for a specific bin and element.
 
@@ -1170,12 +1174,13 @@ class CARMAState:
             bin_index: Index of the size bin (1-indexed)
             element_index: Index of the element (1-indexed)
             value: Value to set, can be a single float or a list of floats
+            surface_mass: Optional surface mass for the bin [kg m-2] (default: 0.0)
         """
         if np.isscalar(value):
             value = np.repeat(value, self.n_levels).tolist()
         elif not isinstance(value, list):
             value = list(value)
-        _backend._carma._set_bin(self._carma_state_instance, bin_index, element_index, value)
+        _backend._carma._set_bin(self._carma_state_instance, bin_index, element_index, value, surface_mass)
 
     def set_detrain(self, bin_index: int, element_index: int, value: float):
         """
@@ -1232,6 +1237,32 @@ class CARMAState:
             old_mmr,
             gas_saturation_wrt_ice,
             gas_saturation_wrt_liquid)
+
+    def set_temperature(self, temperature: Union[float, List[float]]):
+        """
+        Set the temperature for the vertical levels.
+
+        Args:
+            temperature: Temperature value to set, can be a single float or a list of floats
+        """
+        if np.isscalar(temperature):
+            temperature = np.repeat(temperature, self.n_levels).tolist()
+        elif not isinstance(temperature, list):
+            temperature = list(temperature)
+        _backend._carma._set_temperature(self._carma_state_instance, temperature)
+
+    def set_air_density(self, air_density: Union[float, List[float]]):
+        """
+        Set the air density for the vertical levels.
+
+        Args:
+            air_density: Air density value to set, can be a single float or a list of floats
+        """
+        if np.isscalar(air_density):
+            air_density = np.repeat(air_density, self.n_levels).tolist()
+        elif not isinstance(air_density, list):
+            air_density = list(air_density)
+        _backend._carma._set_air_density(self._carma_state_instance, air_density)
 
     def step(
         self,

--- a/musica/test/test_carma.py
+++ b/musica/test/test_carma.py
@@ -16,19 +16,41 @@ def test_carma_version():
 def test_carma_instance():
     # Test CARMA instance creation
     test_params = musica.CARMAParameters.create_aluminum_test_config()
-    test_params.nstep = 560
+    
+    # Add a gas to the parameters
+    test_params.gases.append(
+        musica.carma.CARMAGasConfig(
+            name="Test Gas",
+            shortname="TG",
+            wtmol=0.018,  # kg mol-1
+            ivaprtn=musica.carma.VaporizationAlgorithm.H2O_BUCK_1981,
+            icomposition=musica.carma.GasComposition.H2O,
+            dgc_threshold=1.0e-8,
+            ds_threshold=1.0e-6
+        )
+    )
 
     carma = musica.CARMA(test_params)
     assert carma is not None
     assert isinstance(carma, musica.CARMA)
 
-    state = carma.create_state()
+    state = carma.create_state(
+        longitude=0.0,
+        latitude=0.0,
+        temperature=[300.0, 280.0],
+        pressure=[101335.0, 90000.0],
+        pressure_levels=[101325.0, 90050.0, 80000.0],
+        coordinates=musica.carma.CarmaCoordinates.CARTESIAN
+    )
 
     assert state is not None
     assert isinstance(state, musica.CARMAState)
 
     state.set_bin(1, 1, 1.0)
     state.set_detrain(1, 1, 1.0)
+    state.set_gas(1, 1.4e-3)
+    state.set_temperature(300.0)
+    state.set_air_density(1.2)
     state.step(land=musica.carma.CARMASurfaceProperties(surface_friction_velocity=0.42, area_fraction=0.3),
                ocean=musica.carma.CARMASurfaceProperties(aerodynamic_resistance=0.1),
                ice=musica.carma.CARMASurfaceProperties(area_fraction=0.2))

--- a/src/carma/carma_state.cpp
+++ b/src/carma/carma_state.cpp
@@ -68,7 +68,7 @@ namespace musica
     }
   }
 
-  void CARMAState::SetBin(int bin_index, int element_index, const std::vector<double>& values)
+  void CARMAState::SetBin(int bin_index, int element_index, const std::vector<double>& values, const double surface_mass)
   {
     if (f_carma_state_ == nullptr)
     {
@@ -81,7 +81,7 @@ namespace musica
     }
 
     int rc;
-    InternalSetBin(f_carma_state_, bin_index, element_index, values.data(), static_cast<int>(values.size()), &rc);
+    InternalSetBin(f_carma_state_, bin_index, element_index, values.data(), static_cast<int>(values.size()), surface_mass, &rc);
     if (rc != 0)
     {
       throw std::runtime_error("Failed to set bin values with return code: " + std::to_string(rc));
@@ -141,6 +141,46 @@ namespace musica
     if (rc != 0)
     {
       throw std::runtime_error("Failed to set gas values with return code: " + std::to_string(rc));
+    }
+  }
+
+  void CARMAState::SetTemperature(const std::vector<double>& temperature)
+  {
+    if (f_carma_state_ == nullptr)
+    {
+      throw std::runtime_error("CARMA state instance is not initialized.");
+    }
+
+    if (temperature.empty())
+    {
+      throw std::invalid_argument("Temperature vector cannot be empty.");
+    }
+
+    int rc;
+    InternalSetTemperature(f_carma_state_, temperature.data(), static_cast<int>(temperature.size()), &rc);
+    if (rc != 0)
+    {
+      throw std::runtime_error("Failed to set temperature with return code: " + std::to_string(rc));
+    }
+  }
+
+  void CARMAState::SetAirDensity(const std::vector<double>& air_density)
+  {
+    if (f_carma_state_ == nullptr)
+    {
+      throw std::runtime_error("CARMA state instance is not initialized.");
+    }
+
+    if (air_density.empty())
+    {
+      throw std::invalid_argument("Air density vector cannot be empty.");
+    }
+
+    int rc;
+    InternalSetAirDensity(f_carma_state_, air_density.data(), static_cast<int>(air_density.size()), &rc);
+    if (rc != 0)
+    {
+      throw std::runtime_error("Failed to set air density with return code: " + std::to_string(rc));
     }
   }
 

--- a/src/carma/interface.F90
+++ b/src/carma/interface.F90
@@ -233,20 +233,21 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-   subroutine internal_set_bin(carma_state_cptr, bin_index, element_index, values_ptr, values_size, rc) &
-      bind(C, name="InternalSetBin")
+   subroutine internal_set_bin(carma_state_cptr, bin_index, element_index, &
+      values_ptr, values_size, surface_mass, rc) bind(C, name="InternalSetBin")
       use iso_c_binding, only: c_ptr, c_int, c_double
       use carmastate_mod, only: CARMASTATE_SetBin
       use carma_types_mod, only: carmastate_type
       use iso_fortran_env, only: real64
 
       ! Arguments
-      type(c_ptr),    value, intent(in)  :: carma_state_cptr
-      integer(c_int), value, intent(in)  :: bin_index
-      integer(c_int), value, intent(in)  :: element_index
-      type(c_ptr),    value              :: values_ptr
-      integer(c_int), value, intent(in)  :: values_size
-      integer(c_int), intent(out)        :: rc
+      type(c_ptr),       value, intent(in)  :: carma_state_cptr
+      integer(c_int),    value, intent(in)  :: bin_index
+      integer(c_int),    value, intent(in)  :: element_index
+      type(c_ptr),       value              :: values_ptr
+      integer(c_int),    value, intent(in)  :: values_size
+      real(kind=real64), value, intent(in)  :: surface_mass
+      integer(c_int),           intent(out) :: rc
 
       ! Local variables
       real(kind=real64), pointer :: values(:)
@@ -269,7 +270,13 @@ contains
          call c_f_pointer(carma_state_cptr, cstate)
          call c_f_pointer(values_ptr, values, [values_size])
 
-         call CARMASTATE_SetBin(cstate, bin_index, element_index, values, rc)
+         call CARMASTATE_SetBin( &
+            cstate, &
+            bin_index, &
+            element_index, &
+            values, &
+            rc, &
+            surface=surface_mass)
       end if
 
    end subroutine internal_set_bin
@@ -382,6 +389,70 @@ contains
       end if
 
    end subroutine internal_set_gas
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine internal_set_temperature(carma_state_cptr, temperature_ptr, &
+      temperature_size, rc) bind(C, name="InternalSetTemperature")
+      use iso_c_binding, only: c_ptr, c_int, c_double
+      use carmastate_mod, only: CARMASTATE_SetState
+      use carma_types_mod, only: carmastate_type
+      use iso_fortran_env, only: real64
+
+      ! Arguments
+      type(c_ptr),    value, intent(in)  :: carma_state_cptr
+      type(c_ptr),    value              :: temperature_ptr
+      integer(c_int), value, intent(in)  :: temperature_size
+      integer(c_int), intent(out)        :: rc
+
+      ! Local variables
+      real(kind=real64), pointer :: temperature(:)
+      type(carmastate_type), pointer :: cstate
+
+      ! Check if carma_state_cptr is associated
+      if (c_associated(carma_state_cptr)) then
+         call c_f_pointer(carma_state_cptr, cstate)
+         call c_f_pointer(temperature_ptr, temperature, [temperature_size])
+
+         call CARMASTATE_SetState(cstate, rc, t=temperature)
+      else
+         rc = 1
+         print *, "CARMA state pointer is not associated"
+      end if
+
+   end subroutine internal_set_temperature
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  subroutine internal_set_air_density(carma_state_cptr, air_density_ptr, &
+      air_density_size, rc) bind(C, name="InternalSetAirDensity")
+      use iso_c_binding, only: c_ptr, c_int, c_double
+      use carmastate_mod, only: CARMASTATE_SetState
+      use carma_types_mod, only: carmastate_type
+      use iso_fortran_env, only: real64
+
+      ! Arguments
+      type(c_ptr),    value, intent(in)  :: carma_state_cptr
+      type(c_ptr),    value              :: air_density_ptr
+      integer(c_int), value, intent(in)  :: air_density_size
+      integer(c_int), intent(out)        :: rc
+
+      ! Local variables
+      real(kind=real64), pointer :: air_density(:)
+      type(carmastate_type), pointer :: cstate
+
+      ! Check if carma_state_cptr is associated
+      if (c_associated(carma_state_cptr)) then
+         call c_f_pointer(carma_state_cptr, cstate)
+         call c_f_pointer(air_density_ptr, air_density, [air_density_size])
+
+         call CARMASTATE_SetState(cstate, rc, rhoa_wet=air_density)
+      else
+         rc = 1
+         print *, "CARMA state pointer is not associated"
+      end if
+
+   end subroutine internal_set_air_density
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/test/unit/carma/carma_c_api.cpp
+++ b/src/test/unit/carma/carma_c_api.cpp
@@ -305,6 +305,18 @@ TEST_F(CarmaCApiTest, RunCarmaWithAluminumTestParams)
 TEST_F(CarmaCApiTest, CanSetBinValues)
 {
   CARMAParameters params = CARMA::CreateAluminumTestParams();
+
+  // Add a gas to the parameters
+  CARMAGasConfig gas_config;
+  gas_config.name = "TestGas";
+  gas_config.shortname = "TG";
+  gas_config.wtmol = 0.018;  // Water vapor
+  gas_config.ivaprtn = VaporizationAlgorithm::H2O_BUCK_1981;
+  gas_config.icomposition = GasComposition::H2O;
+  gas_config.dgc_threshold = 1e-8;
+  gas_config.ds_threshold = 1e-6;
+  params.gases.push_back(gas_config);
+
   CARMA carma{ params };
   CARMAStateParameters state_params;
   state_params.longitude = 0.0;
@@ -317,8 +329,11 @@ TEST_F(CarmaCApiTest, CanSetBinValues)
   state_params.coordinates = CarmaCoordinates::CARTESIAN;
 
   CARMAState state = CARMAState(carma, state_params);
-  ASSERT_NO_THROW(state.SetBin(1, 1, std::vector<double>{ 1.0 }));
+  ASSERT_NO_THROW(state.SetBin(1, 1, std::vector<double>{ 1.0 }, 0.0001));
   ASSERT_NO_THROW(state.SetDetrain(1, 1, std::vector<double>{ 1.0 }));
+  ASSERT_NO_THROW(state.SetGas(1, std::vector<double>(params.nz, 1.4e-3), std::vector<double>(params.nz, 2.3e-4), std::vector<double>(params.nz, 0.3), std::vector<double>(params.nz, 0.5)));
+  ASSERT_NO_THROW(state.SetTemperature(std::vector<double>(params.nz, 273.15)));
+  ASSERT_NO_THROW(state.SetAirDensity(std::vector<double>(params.nz, 1.225)));
 
   CARMAStateStepConfig step_config;
   step_config.cloud_fraction = std::vector<double>(params.nz, 0.5);


### PR DESCRIPTION
Adds the remaining CARMA state set functions.

Also updates the python tests to more closely mimic the C++ tests, and fixes an incorrect call to `SetBin` in the python wrapper