### PR TITLE
get solute

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           find include -type f \( -name '*.hpp' -or -name '*.h' \) -exec clang-format -i --style=file --verbose {} +
           find src -type f \( -name '*.cpp' -or -name '*.c' \) -exec clang-format -i --style=file --verbose {} +
+          find musica -type f \( -name '*.cpp' -or -name '*.c' \) -exec clang-format -i --style=file --verbose {} +
+          find musica -type f \( -name '*.hpp' -or -name '*.h' \) -exec clang-format -i --style=file --verbose {} +
 
       - name: Check for changes
         id: check-changes

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -1451,7 +1451,7 @@ class CARMA:
             solute_index: Index of the solute (1-indexed)
 
         Returns:
-            Tuple[CARMASoluteConfig, Dict[str, Any]]: The solute configuration and its properties
+            CARMASoluteConfig: The solute configuration
         """
         if solute_index < 1 or solute_index > len(self.__parameters.solutes):
             raise IndexError("Solute index out of range.")

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -1443,7 +1443,7 @@ class CARMA:
         return (group, props)
     
 
-    def get_solute(self, solute_index: int) -> CARMASoluteConfig
+    def get_solute(self, solute_index: int) -> CARMASoluteConfig:
         """
         Get the solute properties for a specific solute index.
 

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -1441,3 +1441,18 @@ class CARMA:
         group = self.__parameters.groups[group_index - 1]
         props = _backend._carma._get_group(self._carma_instance, group_index)
         return (group, props)
+    
+
+    def get_solute(self, solute_index: int) -> CARMASoluteConfig
+        """
+        Get the solute properties for a specific solute index.
+
+        Args:
+            solute_index: Index of the solute (1-indexed)
+
+        Returns:
+            Tuple[CARMASoluteConfig, Dict[str, Any]]: The solute configuration and its properties
+        """
+        if solute_index < 1 or solute_index > len(self.__parameters.solutes):
+            raise IndexError("Solute index out of range.")
+        return self.__parameters.solutes[solute_index - 1]


### PR DESCRIPTION
Closes #543 

- No need to wrap `CARMASOLUTE_Get`, all of that information is specified in the solute configuration and can be returned from python directly
- Added logic to the format action to format the c++ code in the musica python library