### PR TITLE
get gas config

### DIFF
--- a/musica/carma.py
+++ b/musica/carma.py
@@ -1441,3 +1441,17 @@ class CARMA:
         group = self.__parameters.groups[group_index - 1]
         props = _backend._carma._get_group(self._carma_instance, group_index)
         return (group, props)
+
+    def get_gas_properties(self, gas_index: int) -> CARMAGasConfig:
+        """
+        Get the gas properties for a specific gas index.
+
+        Args:
+            gas_index: Index of the gas (1-indexed)
+
+        Returns:
+            CARMAGasConfig: The gas configuration
+        """
+        if gas_index < 1 or gas_index > len(self.__parameters.gases):
+            raise IndexError("Gas index out of range.")
+        return self.__parameters.gases[gas_index - 1]

--- a/musica/test/test_carma.py
+++ b/musica/test/test_carma.py
@@ -61,6 +61,7 @@ def test_carma_instance():
     print(state.get_environmental_values())
     print(state.get_gas(1))
     print(carma.get_group(1))
+    print(carma.get_gas_properties(1))
 
 
 def test_carma_with_default_parameters():


### PR DESCRIPTION
closes #544 

No need to go into fortran, the information provided in the gas configuration can be returned directly