### PR TITLE
Add CARMA sulfate test

### DIFF
--- a/include/musica/carma/carma.hpp
+++ b/include/musica/carma/carma.hpp
@@ -53,7 +53,6 @@ namespace musica
   // Enumeration for Mie calculation methods
   enum class MieCalculationAlgorithm
   {
-    NONE = 0,
     TOON_1981 = 1,    // Shell/Core Toon & Ackerman 1981 Mie calculation
     BOHREN_1983 = 2,  // Homogeneous Sphere Bohren and Huffman 1983 Mie calculation
     BOTET_1997 = 3    // Fractal Mean-Field Botet et al. 1997 Mie calculation
@@ -181,7 +180,7 @@ namespace musica
     double eshape = 1.0;                      // aspect ratio (length/width)
     CARMASwellingApproach swelling_approach;  // Swelling from RH approach
     FallVelocityAlgorithm fall_velocity_routine = FallVelocityAlgorithm::STANDARD_SPHERICAL_ONLY;
-    MieCalculationAlgorithm mie_calculation_algorithm = MieCalculationAlgorithm::NONE;
+    MieCalculationAlgorithm mie_calculation_algorithm = MieCalculationAlgorithm::TOON_1981;  // Mie calculation algorithm
     OpticsAlgorithm optics_algorithm = OpticsAlgorithm::FIXED;  // Optics algorithm
     bool is_ice = false;
     bool is_fractal = false;
@@ -190,8 +189,8 @@ namespace musica
     bool do_wetdep = false;
     bool do_drydep = false;
     bool do_vtran = true;
-    double solfac = 0.0;          // Solubility factor for wet deposition
-    double scavcoef = 0.0;        // Scavenging coefficient for wet deposition
+    double solfac = 0.3;          // Solubility factor for wet deposition
+    double scavcoef = 0.1;        // Scavenging coefficient for wet deposition
     double dpc_threshold = 0.0;   // convergence criteria for particle concentration [fraction]
     double rmon = 0.0;            // monomer radius [m]
     std::vector<double> df;       // fractal dimension per bin

--- a/musica/carma.cpp
+++ b/musica/carma.cpp
@@ -648,15 +648,15 @@ void bind_carma(py::module_& carma)
         params.original_temperature = to_vector_double(kwargs["original_temperature"]);
         params.pressure = to_vector_double(kwargs["pressure"]);
         params.pressure_levels = to_vector_double(kwargs["pressure_levels"]);
-        if (kwargs.contains("relative_humidity"))
+        if (kwargs.contains("relative_humidity") && !kwargs["relative_humidity"].is_none())
         {
           params.relative_humidity = to_vector_double(kwargs["relative_humidity"]);
         }
-        if (kwargs.contains("specific_humidity"))
+        if (kwargs.contains("specific_humidity") && !kwargs["specific_humidity"].is_none())
         {
           params.specific_humidity = to_vector_double(kwargs["specific_humidity"]);
         }
-        if (kwargs.contains("radiative_intensity"))
+        if (kwargs.contains("radiative_intensity") && !kwargs["radiative_intensity"].is_none())
         {
           auto array_2d = array_2d_to_vector_double(kwargs["radiative_intensity"]);
           params.radiative_intensity = std::get<0>(array_2d);

--- a/musica/carma.py
+++ b/musica/carma.py
@@ -63,7 +63,6 @@ class ParticleFallVelocityAlgorithm(Enum):
 
 class MieCalculationAlgorithm(Enum):
     """Enumeration for Mie calculation algorithms used in CARMA."""
-    NONE = 0
     TOON_1981 = 1
     BOHREN_1983 = 2
     BOTET_1997 = 3
@@ -195,7 +194,7 @@ class CARMAGroupConfig:
                      "composition": ParticleSwellingComposition.NONE
                  },
                  fall_velocity_routine: int = ParticleFallVelocityAlgorithm.STANDARD_SPHERICAL_ONLY,
-                 mie_calculation_algorithm: int = MieCalculationAlgorithm.NONE,
+                 mie_calculation_algorithm: int = MieCalculationAlgorithm.TOON_1981,
                  optics_algorithm: int = OpticsAlgorithm.FIXED,
                  is_ice: bool = False,
                  is_fractal: bool = False,
@@ -204,8 +203,8 @@ class CARMAGroupConfig:
                  do_wetdep: bool = False,
                  do_drydep: bool = False,
                  do_vtran: bool = True,
-                 solfac: float = 0.0,
-                 scavcoef: float = 0.0,
+                 solfac: float = 0.3,
+                 scavcoef: float = 0.1,
                  dpc_threshold: float = 0.0,
                  rmon: float = 0.0,
                  df: Optional[List[float]] = None,
@@ -224,7 +223,7 @@ class CARMAGroupConfig:
             eshape: Ratio of particle length / diameter (default: 1.0)
             swelling_approach: Dictionary specifying swelling algorithm and composition (default: NONE)
             fall_velocity_routine: Algorithm for fall velocity (default: STANDARD_SPHERICAL_ONLY)
-            mie_calculation_algorithm: Algorithm for Mie calculations (default: NONE)
+            mie_calculation_algorithm: Algorithm for Mie calculations (default: TOON_1981)
             optics_algorithm: Algorithm for optics (default: FIXED)
             is_ice: Whether the particles are ice (default: False)
             is_fractal: Whether the particles are fractal (default: False)
@@ -233,8 +232,8 @@ class CARMAGroupConfig:
             do_wetdep: Whether to include wet deposition (default: False)
             do_drydep: Whether to include dry deposition (default: False)
             do_vtran: Whether to include vertical transport (default: True)
-            solfac: Solubility factor for wet deposition (default: 0.0)
-            scavcoef: Scavenging coefficient for wet deposition (default: 0.0)
+            solfac: Solubility factor for wet deposition (default: 0.3)
+            scavcoef: Scavenging coefficient for wet deposition (default: 0.1)
             dpc_threshold: Threshold for dry particle collection (default: 0.0)
             rmon: Monomer radius of fractal particles [m] (default: 0.0)
             df: List of fractal dimensions for each size bin (default: None)
@@ -967,6 +966,12 @@ class CARMAState:
         self.n_levels = len(vertical_center)
         if original_temperature is None:
             original_temperature = temperature
+        if relative_humidity is None:
+            relative_humidity = None
+        if specific_humidity is None:
+            specific_humidity = None
+        if radiative_intensity is None:
+            radiative_intensity = None
 
         self._carma_state_instance = _backend._carma._create_carma_state(
             carma_pointer=carma_pointer,
@@ -981,6 +986,9 @@ class CARMAState:
             pressure_levels=pressure_levels,
             vertical_center=vertical_center,
             vertical_levels=vertical_levels,
+            relative_humidity=relative_humidity,
+            specific_humidity=specific_humidity,
+            radiative_intensity=radiative_intensity
         )
 
     def __del__(self):

--- a/musica/test/integration/test_carma_sulfate.py
+++ b/musica/test/integration/test_carma_sulfate.py
@@ -1,0 +1,237 @@
+"""
+Python test for CARMA sulfate that mimics the logic of the Fortran test.
+
+This test creates one grid box with an initial concentration of sulfate particles
+at the smallest size, then allows that to grow using H2SO4 gas. The total mass 
+of particles + gas should be conserved.
+
+Based on carma_sulfatetest.F90
+"""
+
+import xarray as xr
+import numpy as np
+import pytest
+import musica
+from musica.constants import GAS_CONSTANT
+
+
+available = musica.backend.carma_available()
+pytestmark = pytest.mark.skipif(
+    not available, reason="CARMA backend is not available")
+
+
+def test_carma_sulfate():
+    """Test CARMA sulfate growth from gas condensation in a simple single grid box."""
+
+    GRAVITY = 9.806  # Acceleration due to gravity in m/s^2
+
+    # Simplified constants for debugging
+    NZ = 1
+    NELEM = 1
+    NBIN = 38
+    
+    dtime = 1800.0  # Time step in seconds
+    deltaz = 10000.0  # Grid box height in meters
+    nsteps = int(180000 / dtime)
+
+    # Sulfate density
+    rho_sulfate_kg_m3 = 1923.0  # kg/m³
+    
+    # Grid setup
+    latitude = -40.0
+    longitude = -105.0
+    vertical_center = [17000.0]
+    vertical_levels = [vertical_center[0] - deltaz, vertical_center[0] + deltaz]
+
+    # Standard atmosphere
+    pressure_centers = np.array([9000.0])
+    temperature_centers = np.array([250.0])
+    # this is directly from the original CARMA test, but it seems like there are some unit conversion issues
+    air_mass_density_centers = pressure_centers * 10.0 / (8.31430e07 / 28.966 * temperature_centers) * (1.0e-3 * 1.0e6)
+    pressure_levels = np.zeros(2)
+    pressure_levels[0] = pressure_centers[0] - (vertical_levels[0] - vertical_center[0]) * air_mass_density_centers[0] * GRAVITY
+    pressure_levels[1] = pressure_centers[0] - (vertical_levels[1] - vertical_center[0]) * air_mass_density_centers[0] * GRAVITY
+
+    # Initial mass mixing ratios
+    mass_mixing_ratios = {
+        "H2O": [1.0e-4],
+        "H2SO4": [0.1e-9 * (98.0/29.0)],
+        "SULFATE": [[0.0 for _ in range(NBIN)]]
+    }
+    satliq = {
+      "H2O": [-1.0],
+      "H2SO4": [-1.0]
+    }
+    satice = {
+      "H2O": [-1.0],
+      "H2SO4": [-1.0]
+    }
+
+    # Set up CARMA parameters
+    params = musica.CARMAParameters()
+    params.nz = NZ
+    params.nbin = NBIN
+    
+    # Create sulfate group - simplified
+    sulfate_group = musica.carma.CARMAGroupConfig(
+        name="sulfate",
+        shortname="SULF",
+        rmin=2.e-10,  # Minimum radius in m
+        rmrat=2.0,   # Mass ratio between bins
+        swelling_approach={
+          "algorithm": musica.carma.ParticleSwellingAlgorithm.WEIGHT_PERCENT_H2SO4,
+          "composition": musica.carma.ParticleSwellingComposition.NONE
+        },
+        do_drydep=True,
+        is_sulfate=True
+    )
+    params.add_group(sulfate_group)
+    
+    # Create sulfate element
+    sulfate_element = musica.carma.CARMAElementConfig(
+        igroup=1,
+        name="Sulfate",
+        shortname="SULF", 
+        rho=rho_sulfate_kg_m3,
+        itype=musica.carma.ParticleType.VOLATILE,
+        icomposition=musica.carma.ParticleComposition.SULFURIC_ACID
+    )
+    params.add_element(sulfate_element)
+    
+    # Create gases - simplified to match successful test_carma.py pattern
+    water_gas = musica.carma.CARMAGasConfig(
+        name="Water Vapor",
+        shortname="H2O",
+        wtmol=0.018015,  # kg/mol
+        ivaprtn=musica.carma.VaporizationAlgorithm.H2O_MURPHY_2005,
+        icomposition=musica.carma.GasComposition.H2O,
+        dgc_threshold=0.1,
+        ds_threshold=0.1
+    )
+    params.add_gas(water_gas)
+    
+    # Create H2SO4 gas
+    h2so4_gas = musica.carma.CARMAGasConfig(
+        name="Sulfuric Acid",
+        shortname="H2SO4",
+        wtmol=0.098079,  # kg/mol
+        ivaprtn=musica.carma.VaporizationAlgorithm.H2SO4_AYERS_1980,
+        icomposition=musica.carma.GasComposition.H2SO4,
+        dgc_threshold=0.1,
+        ds_threshold=0.1
+    )
+    params.add_gas(h2so4_gas)
+    
+    # Add growth process
+    growth = musica.carma.CARMAGrowthConfig(
+        ielem=1,  # Sulfate element
+        igas=2    # H2SO4 gas
+    )
+    params.add_growth(growth)
+    
+    # Add nucleation process
+    nucleation = musica.carma.CARMANucleationConfig(
+        ielemfrom=1,
+        ielemto=1,
+        algorithm=musica.carma.ParticleNucleationAlgorithm.HOMOGENEOUS_NUCLEATION,
+        rlh_nuc=0.0,
+        igas=2  # H2SO4 gas
+    )
+    params.add_nucleation(nucleation)
+    
+    # Add coagulation
+    coagulation = musica.carma.CARMACoagulationConfig(
+        igroup1=1,
+        igroup2=1,
+        igroup3=1,
+        algorithm=musica.carma.ParticleCollectionAlgorithm.FUCHS
+    )
+    params.add_coagulation(coagulation)
+    
+    # Initialization
+    params.initialization.do_substep=True
+    params.initialization.do_thermo=True
+    params.initialization.maxretries=16
+    params.initialization.maxsubsteps=32
+    params.initialization.dt_threshold=1.0
+    params.initialization.sulfnucl_method=musica.carma.SulfateNucleationMethod.ZHAO_TURCO.value
+
+    # Create CARMA instance
+    carma = musica.CARMA(params)
+    
+    # Output group properties
+    group_props = carma.get_group_properties(group_index=1)[1]
+    for i_bin in range(NBIN):
+        print(f"Bin {i_bin+1}: bin radius = {group_props['bin_radius'][i_bin]}; bin mass = {group_props['bin_mass'][i_bin]}")
+
+    for i_step in range(nsteps):
+
+        # Create state
+        state = carma.create_state(
+            time_step=dtime,
+            temperature=temperature_centers,
+            original_temperature=temperature_centers,
+            pressure=pressure_centers,
+            pressure_levels=pressure_levels,
+            vertical_center=vertical_center,
+            vertical_levels=vertical_levels,
+            longitude=longitude,
+            latitude=latitude,
+            coordinates=musica.carma.CarmaCoordinates.CARTESIAN,
+            specific_humidity=mass_mixing_ratios["H2O"],
+        )
+        
+        # Initialize particle concentrations to zero
+        for ibin in range(1, NBIN + 1):
+            for ielem in range(1, NELEM + 1):
+                state.set_bin(ibin, ielem, mass_mixing_ratios["SULFATE"][0][ibin-1])
+        
+        # Set H2O concentration
+        state.set_gas(
+          gas_index=1,
+          value=mass_mixing_ratios["H2O"],
+          old_mmr=mass_mixing_ratios["H2O"],
+          gas_saturation_wrt_ice=satice["H2O"],
+          gas_saturation_wrt_liquid=satliq["H2O"],
+        )
+
+        # Set H2SO4 concentration
+        state.set_gas(
+          gas_index=2,
+          value=[ mmr * 1.05 for mmr in mass_mixing_ratios["H2SO4"] ],
+          old_mmr=mass_mixing_ratios["H2SO4"],
+          gas_saturation_wrt_ice=satice["H2SO4"],
+          gas_saturation_wrt_liquid=satliq["H2SO4"],
+        )
+        
+        # Perform model step
+        state.step()
+        stats = state.get_step_statistics()
+
+        # Get updated state values
+        conditions = state.get_environmental_values()
+        mass_mixing_ratios['H2O'] = state.get_gas(gas_index=1)["mass_mixing_ratio"]
+        mass_mixing_ratios['H2SO4'] = state.get_gas(gas_index=2)["mass_mixing_ratio"]
+        satice['H2O'] = state.get_gas(gas_index=1)["gas_saturation_wrt_ice"]
+        satice['H2SO4'] = state.get_gas(gas_index=2)["gas_saturation_wrt_ice"]
+        satliq['H2O'] = state.get_gas(gas_index=1)["gas_saturation_wrt_liquid"]
+        satliq['H2SO4'] = state.get_gas(gas_index=2)["gas_saturation_wrt_liquid"]
+        for i_bin in range(1, NBIN + 1):
+            mass_mixing_ratios['SULFATE'][0][i_bin-1] = state.get_bin(i_bin, 1)["mass_mixing_ratio"]
+
+        print(f"CARMA State at timestep {i_step}:")
+        print(f"  Solver statistics: {stats}")
+        print(f"  Conditions: {conditions}")
+        for key, value in mass_mixing_ratios.items():
+            print(f"  {key} mass mixing ratio: {value}")
+        for key, value in satice.items():
+            print(f"  {key} saturation wrt ice: {value}")
+        for key, value in satliq.items():
+            print(f"  {key} saturation wrt liquid: {value}")
+
+    print(f"\nTest completed!")
+    return True
+
+
+if __name__ == '__main__':
+    test_carma_sulfate()

--- a/musica/test/integration/test_sulfate_box_model.py
+++ b/musica/test/integration/test_sulfate_box_model.py
@@ -145,7 +145,7 @@ def create_carma_solver():
     # Set up gases for water and sulfuric acid
     water = musica.carma.CARMAGasConfig(
         name="Water Vapor",
-        shortname="Q",
+        shortname="H2O",
         wtmol=MOLECULAR_MASS_H2O,  # Molar mass of water in kg/mol
         ivaprtn=musica.carma.VaporizationAlgorithm.H2O_MURPHY_2005,
         icomposition=musica.carma.GasComposition.H2O,
@@ -251,14 +251,7 @@ def run_box_model():
     solver = musica.MICM(mechanism=mechanism, solver_type=musica.SolverType.rosenbrock_standard_order)
     state = solver.create_state(number_of_grid_cells=NUMBER_OF_GRID_CELLS)
 
-    carma = None
-    try:
-        carma = create_carma_solver()
-    except Exception as e:
-        print(f"Error creating CARMA solver: {e}")
-        print(f'Error type: {type(e)}')
-        import traceback
-        traceback.print_exc()
+    carma = create_carma_solver()
 
     # Set initial conditions
     grid, environmental_conditions, initial_concentrations = get_initial_conditions()
@@ -271,24 +264,21 @@ def run_box_model():
     dt = np.float64(30.0)
     num_steps = int(time_seconds / dt)
 
-    # Initialize state arrays
+    # Initialize combined state arrays
     sulfate_mmr = np.full((NUMBER_OF_AEROSOL_SECTIONS, NUMBER_OF_GRID_CELLS), 1.0e-10, dtype=np.float64)
-    carma_h2o_conc = np.zeros(NUMBER_OF_GRID_CELLS, dtype=np.float64)
-    carma_h2so4_conc = np.zeros(NUMBER_OF_GRID_CELLS, dtype=np.float64)
-    output_state = state.get_concentrations()
-    output_state["SULFATE"] = sulfate_mmr
-    concentrations = [output_state.copy()]
-    temperatures = [environmental_conditions["temperature"]]
-    pressures = [environmental_conditions["pressure"]]
+    concentrations = [state.get_concentrations()]
+    concentrations[0]["SULFATE"] = sulfate_mmr
     current_temperature = environmental_conditions["temperature"].copy()
-    current_pressure = environmental_conditions["pressure"].copy()
+
+    # Set up additional CARMA state arrays
     satliq_h2o = np.full(NUMBER_OF_GRID_CELLS, -1.0, dtype=np.float64)
     satice_h2o = np.full(NUMBER_OF_GRID_CELLS, -1.0, dtype=np.float64)
     satliq_h2so4 = np.full(NUMBER_OF_GRID_CELLS, -1.0, dtype=np.float64)
     satice_h2so4 = np.full(NUMBER_OF_GRID_CELLS, -1.0, dtype=np.float64)
+    last_h2so4_mmr = np.zeros(NUMBER_OF_GRID_CELLS, dtype=np.float64)
 
     for i_time in range(num_steps):
-        state.set_conditions(temperatures=current_temperature, pressures=current_pressure)
+        state.set_conditions(temperatures=current_temperature, pressures=environmental_conditions["pressure"])
         solver.solve(state, dt)
         micm_output = state.get_concentrations()
 
@@ -305,7 +295,7 @@ def run_box_model():
             time_step=dt,
             latitude=-40.0,
             longitude=-105.0,
-            relative_humidity=h2o_mmr,
+            specific_humidity=h2o_mmr,
         )
 
         for i_bin in range(NUMBER_OF_AEROSOL_SECTIONS):
@@ -325,42 +315,39 @@ def run_box_model():
         carma_state.set_gas(
             gas_index=2,  # Sulfuric acid gas index
             value=h2so4_mmr,
-            old_mmr=h2so4_mmr,
+            old_mmr=last_h2so4_mmr,
             gas_saturation_wrt_liquid=satliq_h2so4,
             gas_saturation_wrt_ice=satice_h2so4
         )
+        last_h2so4_mmr = h2so4_mmr
 
         carma_state.step()
 
-        carma_env = carma_state.get_environmental_values()
-        current_temperature = carma_env["temperature"]
-        current_pressure = carma_env["pressure"]
-
+        # Get updated state data from CARMA
         for i_bin in range(NUMBER_OF_AEROSOL_SECTIONS):
             sulfate_mmr[i_bin, :] = carma_state.get_bin(
                 bin_index=i_bin+1,
                 element_index=1  # Sulfate element index
             )["mass_mixing_ratio"]
         micm_output["SULFATE"] = sulfate_mmr
-        carma_h2o_conc = np.array(carma_state.get_gas(
+
+        micm_output["H2O"] = np.array(carma_state.get_gas(
             gas_index=1  # Water vapor gas index
         )["mass_mixing_ratio"], dtype=np.float64) * environmental_conditions["air density"] * MOLECULAR_MASS_H2O / MOLECULAR_MASS_H2O
-        carma_h2so4_conc = np.array(carma_state.get_gas(
+        
+        micm_output["H2SO4"] = np.array(carma_state.get_gas(
             gas_index=2  # Sulfuric acid gas index
         )["mass_mixing_ratio"], dtype=np.float64) * environmental_conditions["air density"] * MOLECULAR_MASS_H2SO4  / MOLECULAR_MASS_AIR
-        conditions = carma_state.get_environmental_values()
-        current_temperature = conditions["temperature"]
-
-        micm_output["H2O"] = carma_h2o_conc
-        micm_output["H2SO4"] = carma_h2so4_conc
-        state.set_concentrations({
-            "H2O": carma_h2o_conc,
-            "H2SO4": carma_h2so4_conc
-        })
-
-        temperatures.append(current_temperature)
-        pressures.append(current_pressure)
+        
+        # save concentrations for output
         concentrations.append(micm_output)
+
+        # prepare for next time step
+        current_temperature = carma_state.get_environmental_values()["temperature"]
+        state.set_concentrations({
+            "H2O": micm_output["H2O"],
+            "H2SO4": micm_output["H2SO4"]
+        })
 
 
     # Collect output data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ cmake.define.MUSICA_ENABLE_TESTS = "OFF"
 cmake.define.CMAKE_POLICY_VERSION_MINIMUM = "3.5"
 cmake.define.MUSICA_SET_MICM_DEFAULT_VECTOR_SIZE = "1"
 cmake.define.CMAKE_VERBOSE_MAKEFILE = "ON"
-cmake.verbose = true
+build.verbose = true
 
 [[tool.scikit-build.overrides]]
 if.platform-system = "linux"

--- a/src/carma/interface.F90
+++ b/src/carma/interface.F90
@@ -1393,7 +1393,7 @@ contains
                   carma, &
                   igas, &
                   gas_name, &
-                  real(gas%wtmol, kind=real64), &
+                  real(gas%wtmol, kind=real64) * 1000.0_real64, & ! convert to g/mol
                   int(gas%ivaprtn), &
                   int(gas%icomposition), &
                   rc, &
@@ -1532,6 +1532,10 @@ contains
          rc = MUSICA_CARMA_ERROR_CODE_INITIALIZATION_FAILED
          return
       end if
+
+      ! turn off printing
+      carma%f_do_print = .false.
+      carma%f_lunoprt = 6
 
       carma_cptr = c_loc(carma)
 


### PR DESCRIPTION
This PR adds an integration test to the CARMA test suite that mimics an existing test in the base CARMA model.

Also, fixes some problems with unit conversions and incorrect default values in the CARMA wrapper and updates the sulfate box model to remove unneeded variables and fix incorrect setting of relative humidity.