### PR TITLE
Delete a TODO comment for GetSpeciesProperty function

### DIFF
--- a/include/musica/micm/micm.hpp
+++ b/include/musica/micm/micm.hpp
@@ -163,9 +163,6 @@ namespace musica
           return species.GetProperty<T>(property_name);
         }
       }
-      // TODO - This function GetProperty<T>(property_name) can throw an exception
-      // if the property is not found; the error needs to be fixed.
-      // Issue: https://github.com/NCAR/musica/issues/617
       throw std::system_error(make_error_code(MusicaErrCode::SpeciesNotFound), "Species '" + species_name + "' not found");
     }
 


### PR DESCRIPTION
Looks like not an issue anymore after the surface reaction in micm code has been updated.
Closes #617 