### PR TITLE
Correct the directory name 

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           find include -type f \( -name '*.hpp' -or -name '*.h' \) -exec clang-format -i --style=file --verbose {} +
           find src -type f \( -name '*.cpp' -or -name '*.c' \) -exec clang-format -i --style=file --verbose {} +
-          find musica -type f \( -name '*.cpp' -or -name '*.c' \) -exec clang-format -i --style=file --verbose {} +
-          find musica -type f \( -name '*.hpp' -or -name '*.h' \) -exec clang-format -i --style=file --verbose {} +
+          find python -type f \( -name '*.cpp' -or -name '*.c' \) -exec clang-format -i --style=file --verbose {} +
+          find python -type f \( -name '*.hpp' -or -name '*.h' \) -exec clang-format -i --style=file --verbose {} +
 
       - name: Check for changes
         id: check-changes


### PR DESCRIPTION
The Github action for auto formatting was failing due to recent directory name changes. This PR addresses that.