### PR TITLE
attempting to free up some disk space

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Delete huge unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
-
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/fetch_content_integration.yml
+++ b/.github/workflows/fetch_content_integration.yml
@@ -34,8 +34,12 @@ jobs:
       - name: Print branch name
         run: echo "Branch name is $BRANCH_NAME"
 
-      - name: Delete huge unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
 
       - name: Build Docker image
         run: docker build -t musica --build-arg MUSICA_GIT_TAG=${BRANCH_NAME} -f docker/${{ matrix.dockerfile }} .


### PR DESCRIPTION
For some reason the docker tests were running out of memory for anything with nvidia, when they weren't before.

I added an [action step](https://github.com/jlumbroso/free-disk-space) to free the disk space for these tests to fix this, it drops disk usage from ~70% ~25% and the actions should have more space to run now

The other failing tests will be addressed when we do #678