### PR TITLE
upping supported python versions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest,  macos-14-large, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest,  macos-15-intel, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -52,7 +52,7 @@ jobs:
             cibw_archs: "AMD64"
 
           # macOS Intel
-          - os: macos-14-large
+          - os: macos-15-intel
             python-version: "3.14"
             cibw_archs: "x86_64"
             fc: gfortran-15


### PR DESCRIPTION
Python now only [officially supports python 3.10, 3.11, 3.12, 3.13, and 3.14](https://devguide.python.org/versions/).

This PR makes us test all of these versions and make wheels for these while dropping support for python 3.9

Removes use of 'large' image runners which cost money