### PR TITLE
removing manual add of c++ library versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,37 +63,6 @@ elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES "PGI")
   list(APPEND musica_compile_definitions MUSICA_USING_PGI)
 endif()
 
-# Set the C++ standard library if it is not already set
-if(NOT CMAKE_CXX_STANDARD_LIBRARIES)
-  if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-    set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++")
-  elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
-    set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++")
-  elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "IBM")
-    set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++")
-  elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "NVHPC")
-    set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++")
-  elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++") # use GNU standard library
-  else()
-    set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++") # default to most common name
-  endif()
-endif()
-
-if(MUSICA_BUILD_C_CXX_INTERFACE)
-  # must be global so that it also applies to dependencies like google test, unless we want
-  # to set it for each target
-  # on ubuntu with clang, an incorrect version of the c++ standard library was being linked
-  if (${CMAKE_HOST_SYSTEM_NAME} MATCHES "Linux" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-      # If the compiler is Clang and the Linux version is Ubuntu 20.04 or 22.04, use libc++ explicitly
-      if (${CMAKE_HOST_SYSTEM_VERSION} MATCHES "20.04" OR ${CMAKE_HOST_SYSTEM_VERSION} MATCHES "22.04")
-          message(STATUS "Using libc++ explicitly with Clang on Ubuntu 20.04 or 22.04")
-          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-          set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++")
-      endif()
-  endif()
-endif()
-
 # since sources are collected so that python libraries can target them directly,
 # we need to know if we are targeting Fortran before we collect the sources
 # otherwise cmake freaks out, and I don't know why, but this fixes it


### PR DESCRIPTION
In #331 we added explicit links to standard libraries. This introduces duplicate libraries and causes the linker to emit a warning. Removing this cmake prevents that warning. I don't know why this was added or needed