### PR TITLE
Add Fortran Chapman column-model examples and CMake test wiring

### DIFF
--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -59,6 +59,9 @@ endif()
 
 if(MUSICA_ENABLE_TESTS)
   add_subdirectory(test)
+  if (MUSICA_ENABLE_TUVX)
+    add_subdirectory(examples)
+  endif()
 endif()
 
 ################################################################################

--- a/fortran/examples/CMakeLists.txt
+++ b/fortran/examples/CMakeLists.txt
@@ -1,0 +1,36 @@
+include(test_util)
+
+# TUV-x v5.4 example / integration test
+add_library(tuvx_v54_setup_lib OBJECT tuvx_v54_setup.F90)
+target_link_libraries(tuvx_v54_setup_lib PUBLIC musica::musica-fortran)
+set_target_properties(tuvx_v54_setup_lib
+  PROPERTIES
+    Fortran_MODULE_DIRECTORY ${MUSICA_MOD_DIR}
+)
+
+add_executable(test_tuvx_v54 tuvx_v54.F90)
+target_link_libraries(test_tuvx_v54 PUBLIC musica::musica-fortran tuvx_v54_setup_lib)
+
+# TUV-x v5.4 config uses relative data paths resolved from CWD
+add_test(NAME tuvx_v54
+         COMMAND ${CMAKE_BINARY_DIR}/test_tuvx_v54
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/configs/tuvx)
+set_tests_properties(tuvx_v54 PROPERTIES TIMEOUT 120)
+
+# Coupled TUV-x + MICM column model
+add_library(column_model_setup_lib OBJECT column_model_setup.F90)
+target_link_libraries(column_model_setup_lib PUBLIC musica::musica-fortran)
+set_target_properties(column_model_setup_lib
+  PROPERTIES
+    Fortran_MODULE_DIRECTORY ${MUSICA_MOD_DIR}
+)
+
+add_executable(test_column_model column_model.F90)
+target_link_libraries(test_column_model PUBLIC
+  musica::musica-fortran tuvx_v54_setup_lib column_model_setup_lib)
+
+# CWD = configs/tuvx for TUV-x data paths; MICM config uses ../v1/chapman/
+add_test(NAME column_model
+         COMMAND ${CMAKE_BINARY_DIR}/test_column_model
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/configs/tuvx)
+set_tests_properties(column_model PROPERTIES TIMEOUT 600)

--- a/fortran/examples/column_model.F90
+++ b/fortran/examples/column_model.F90
@@ -1,0 +1,263 @@
+! Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+! Coupled TUV-x + MICM 1D Column Model
+!
+! Runs Chapman stratospheric O3 photochemistry in a 120-cell vertical column
+! (0-120 km, 1 km resolution) with diurnal photolysis rate updates from
+! TUV-x v5.4.
+!
+! The model simulates a 24-hour period at Boulder, CO on the summer solstice.
+! Each grid cell is an independent box (no transport). TUV-x computes
+! photolysis rate constants as a function of solar zenith angle, and MICM
+! integrates the Chapman mechanism chemistry.
+!
+program column_model
+  use iso_fortran_env, only: real64
+  use musica_util, only: dk => musica_dk, error_t, string_t, mappings_t
+  use musica_tuvx, only: tuvx_t
+  use musica_micm, only: micm_t, solver_stats_t, RosenbrockStandardOrder
+  use musica_state, only: state_t
+  use tuvx_v54_setup, only: get_tuvx_calculator
+  use column_model_setup
+
+  implicit none
+
+  integer, parameter :: DAY_OF_YEAR = 172  ! June 21
+  real(dk), parameter :: DT_PHOTO = 900.0_dk  ! 15 minutes in seconds
+  real(dk), parameter :: SIM_LENGTH = 86400.0_dk  ! 24 hours in seconds
+  real(dk), parameter :: START_UTC = 6.0_dk  ! midnight MDT = 06:00 UTC
+
+  type(tuvx_t), pointer :: tuvx
+  type(micm_t), pointer :: micm
+  type(state_t), pointer :: state
+  type(error_t) :: error
+  type(string_t) :: solver_state
+  type(solver_stats_t) :: solver_stats
+  type(mappings_t), pointer :: photo_mappings
+
+  ! Indices
+  integer :: jo2_tuvx_idx, jo3a_tuvx_idx, jo3b_tuvx_idx
+  integer :: jo2_micm_idx, jo3a_micm_idx, jo3b_micm_idx
+  integer :: O2_idx, O_idx, O1D_idx, O3_idx, N2_idx
+  integer :: num_photo, num_heat
+  integer :: cell_stride, var_stride
+
+  ! Arrays
+  real(dk) :: height_mid(NUM_CELLS)
+  real(dk) :: temperature(NUM_CELLS), pressure(NUM_CELLS)
+  real(dk) :: air_density(NUM_CELLS)
+  real(dk) :: o3_init(NUM_CELLS), o2_init(NUM_CELLS), n2_init(NUM_CELLS)
+  real(dk), allocatable :: photo_rates(:,:), heating_rates(:,:)
+  real(dk) :: jo3a_vals(NUM_CELLS), jo3b_vals(NUM_CELLS), jo2_vals(NUM_CELLS)
+
+  ! Time stepping
+  integer :: n_steps, step, i
+  real(dk) :: hour_utc, sza, local_hr, current_sec
+  real(dk) :: elapsed, remaining, pct
+  logical :: is_day
+
+  ! CSV output
+  integer :: csv_unit
+
+  write(*,*) "======================================"
+  write(*,*) "Coupled TUV-x + MICM Column Model"
+  write(*,*) "======================================"
+  write(*,*)
+
+  ! --- Set up TUV-x v5.4 ---
+  write(*,*) "Setting up TUV-x v5.4..."
+  tuvx => get_tuvx_calculator(error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error creating TUV-x: ", error%message()
+    stop 1
+  end if
+
+  ! Get TUV-x reaction indices
+  photo_mappings => tuvx%get_photolysis_rate_constants_ordering(error)
+  if (.not. error%is_success()) stop 1
+  num_photo = photo_mappings%size()
+
+  jo2_tuvx_idx = photo_mappings%index("O2+hv->O+O", error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error finding O2+hv->O+O: ", error%message()
+    stop 1
+  end if
+  jo3a_tuvx_idx = photo_mappings%index("O3+hv->O2+O(3P)", error)
+  if (.not. error%is_success()) stop 1
+  jo3b_tuvx_idx = photo_mappings%index("O3+hv->O2+O(1D)", error)
+  if (.not. error%is_success()) stop 1
+
+  ! Get heating rate count for allocation
+  block
+    type(mappings_t), pointer :: heat_mappings
+    heat_mappings => tuvx%get_heating_rates_ordering(error)
+    if (.not. error%is_success()) stop 1
+    num_heat = heat_mappings%size()
+    deallocate(heat_mappings)
+  end block
+
+  ! Allocate TUV-x output arrays
+  allocate(photo_rates(NUM_CELLS + 1, num_photo))
+  allocate(heating_rates(NUM_CELLS + 1, num_heat))
+
+  ! Get initial atmospheric profiles
+  write(*,*) "Extracting atmospheric profiles..."
+  call get_initial_profiles(tuvx, height_mid, temperature, pressure, &
+                            o3_init, o2_init, n2_init, error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error getting profiles: ", error%message()
+    stop 1
+  end if
+
+  ! --- Set up MICM Chapman solver (v1 config) ---
+  write(*,*) "Setting up MICM Chapman solver..."
+  micm => micm_t("../v1/chapman/config.json", RosenbrockStandardOrder, error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error creating MICM: ", error%message()
+    stop 1
+  end if
+
+  state => micm%get_state(NUM_CELLS, error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error creating state: ", error%message()
+    stop 1
+  end if
+
+  ! Get MICM species indices
+  O2_idx = state%species_ordering%index("O2", error)
+  if (.not. error%is_success()) stop 1
+  O_idx = state%species_ordering%index("O", error)
+  if (.not. error%is_success()) stop 1
+  O1D_idx = state%species_ordering%index("O1D", error)
+  if (.not. error%is_success()) stop 1
+  O3_idx = state%species_ordering%index("O3", error)
+  if (.not. error%is_success()) stop 1
+  N2_idx = state%species_ordering%index("N2", error)
+  if (.not. error%is_success()) stop 1
+
+  ! Get MICM photolysis rate parameter indices
+  jo2_micm_idx = state%rate_parameters_ordering%index("PHOTO.jo2_b", error)
+  if (.not. error%is_success()) stop 1
+  jo3a_micm_idx = state%rate_parameters_ordering%index("PHOTO.jo3_a", error)
+  if (.not. error%is_success()) stop 1
+  jo3b_micm_idx = state%rate_parameters_ordering%index("PHOTO.jo3_b", error)
+  if (.not. error%is_success()) stop 1
+
+  ! Set environmental conditions and initial concentrations
+  cell_stride = state%species_strides%grid_cell
+  var_stride = state%species_strides%variable
+  do i = 1, NUM_CELLS
+    state%conditions(i)%temperature = temperature(i)
+    state%conditions(i)%pressure = pressure(i)
+    air_density(i) = pressure(i) / (R_GAS * temperature(i))
+    state%conditions(i)%air_density = air_density(i)
+
+    state%concentrations(1 + (i-1)*cell_stride + (O2_idx-1)*var_stride)  = o2_init(i)
+    state%concentrations(1 + (i-1)*cell_stride + (O_idx-1)*var_stride)   = 0.0_dk
+    state%concentrations(1 + (i-1)*cell_stride + (O1D_idx-1)*var_stride) = 0.0_dk
+    state%concentrations(1 + (i-1)*cell_stride + (O3_idx-1)*var_stride)  = o3_init(i)
+    state%concentrations(1 + (i-1)*cell_stride + (N2_idx-1)*var_stride)  = n2_init(i)
+  end do
+
+  ! Initialize photolysis rates to zero (starting at midnight)
+  jo3a_vals = 0.0_dk
+  jo3b_vals = 0.0_dk
+  jo2_vals = 0.0_dk
+  call set_photolysis_rates(state, photo_rates, &
+      jo2_tuvx_idx, jo3a_tuvx_idx, jo3b_tuvx_idx, &
+      jo2_micm_idx, jo3a_micm_idx, jo3b_micm_idx, &
+      .false., jo3a_vals, jo3b_vals, jo2_vals)
+
+  ! --- Open CSV output ---
+  open(newunit=csv_unit, file='column_model_fortran.csv', &
+      status='replace', action='write')
+  write(csv_unit,'(A)') 'time_hr,height_km,air_density,O3,O,O1D,jO3a,jO3b,jO2'
+
+  ! Write initial state (t = 0)
+  do i = 1, NUM_CELLS
+    write(csv_unit,'(F8.3,",",F6.1,7(",",ES16.8E3))') &
+        0.0_dk, height_mid(i), air_density(i), &
+        state%concentrations(1 + (i-1)*cell_stride + (O3_idx-1)*var_stride), &
+        state%concentrations(1 + (i-1)*cell_stride + (O_idx-1)*var_stride), &
+        state%concentrations(1 + (i-1)*cell_stride + (O1D_idx-1)*var_stride), &
+        jo3a_vals(i), jo3b_vals(i), jo2_vals(i)
+  end do
+
+  ! --- Time loop ---
+  n_steps = nint(SIM_LENGTH / DT_PHOTO)
+  write(*,'(A,I0,A,F5.1,A)') " Running ", n_steps, " steps of ", &
+      DT_PHOTO / 60.0_dk, " min..."
+  write(*,*)
+
+  do step = 1, n_steps
+    current_sec = real(step - 1, dk) * DT_PHOTO
+    hour_utc = START_UTC + current_sec / 3600.0_dk
+    sza = compute_sza(hour_utc, DAY_OF_YEAR)
+    is_day = (sza < PI / 2.0_dk)
+
+    ! Update photolysis rates
+    if (is_day) then
+      photo_rates = 0.0_dk
+      heating_rates = 0.0_dk
+      call tuvx%run(sza, 1.0_dk, photo_rates, heating_rates, error)
+      if (.not. error%is_success()) then
+        write(*,*) "TUV-x error at step ", step, ": ", error%message()
+        stop 1
+      end if
+    end if
+
+    call set_photolysis_rates(state, photo_rates, &
+        jo2_tuvx_idx, jo3a_tuvx_idx, jo3b_tuvx_idx, &
+        jo2_micm_idx, jo3a_micm_idx, jo3b_micm_idx, &
+        is_day, jo3a_vals, jo3b_vals, jo2_vals)
+
+    ! Integrate chemistry
+    elapsed = 0.0_dk
+    do while (elapsed < DT_PHOTO)
+      remaining = DT_PHOTO - elapsed
+      call micm%solve(remaining, state, solver_state, solver_stats, error)
+      if (.not. error%is_success()) then
+        write(*,*) "MICM error at step ", step, ": ", error%message()
+        stop 1
+      end if
+      elapsed = elapsed + solver_stats%final_time()
+      if (solver_state%get_char_array() /= "Converged") then
+        write(*,*) "  Warning: solver ", solver_state%get_char_array(), &
+            " at step ", step
+      end if
+    end do
+
+    ! Write state to CSV
+    local_hr = (current_sec + DT_PHOTO) / 3600.0_dk
+    do i = 1, NUM_CELLS
+      write(csv_unit,'(F8.3,",",F6.1,7(",",ES16.8E3))') &
+          local_hr, height_mid(i), air_density(i), &
+          state%concentrations(1 + (i-1)*cell_stride + (O3_idx-1)*var_stride), &
+          state%concentrations(1 + (i-1)*cell_stride + (O_idx-1)*var_stride), &
+          state%concentrations(1 + (i-1)*cell_stride + (O1D_idx-1)*var_stride), &
+          jo3a_vals(i), jo3b_vals(i), jo2_vals(i)
+    end do
+
+    ! Progress
+    pct = real(step, dk) / real(n_steps, dk) * 100.0_dk
+    if (mod(step, n_steps / 10) == 0) then
+      write(*,'(F6.1,A,F6.1,A,F6.1,A)') pct, "%  local time ", &
+          local_hr, " hr  SZA = ", sza / DEG2RAD, " deg"
+    end if
+  end do
+
+  close(csv_unit)
+  write(*,*)
+  write(*,*) "Results written to column_model_fortran.csv"
+
+  ! Clean up
+  deallocate(photo_rates, heating_rates)
+  deallocate(photo_mappings)
+  deallocate(state)
+  deallocate(micm)
+  deallocate(tuvx)
+
+  write(*,*) "Done."
+
+end program column_model

--- a/fortran/examples/column_model_setup.F90
+++ b/fortran/examples/column_model_setup.F90
@@ -1,0 +1,182 @@
+! Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+! Column model setup module
+!
+! Provides SZA calculation, initial condition extraction from TUV-x profiles,
+! and photolysis rate mapping between TUV-x and MICM.
+!
+module column_model_setup
+  use musica_util, only: dk => musica_dk, error_t, mappings_t
+  use musica_tuvx, only: tuvx_t
+  use musica_tuvx_grid, only: grid_t
+  use musica_tuvx_grid_map, only: grid_map_t
+  use musica_tuvx_profile, only: profile_t
+  use musica_tuvx_profile_map, only: profile_map_t
+  use musica_micm, only: micm_t
+  use musica_state, only: state_t
+
+  implicit none
+  private
+  public :: compute_sza, get_initial_profiles, set_photolysis_rates
+
+  real(dk), parameter, public :: PI = 3.14159265358979323846_dk
+  real(dk), parameter, public :: DEG2RAD = PI / 180.0_dk
+  real(dk), parameter, public :: AVOGADRO = 6.02214076e23_dk
+  real(dk), parameter, public :: BOLTZMANN = 1.380649e-23_dk
+  real(dk), parameter, public :: R_GAS = 8.31446261815324_dk
+
+  integer, parameter, public :: NUM_CELLS = 120
+
+  ! Boulder, CO
+  real(dk), parameter, public :: LATITUDE  = 40.015_dk
+  real(dk), parameter, public :: LONGITUDE = -105.27_dk
+
+contains
+
+  ! Compute solar zenith angle using Spencer (1971) declination formula
+  function compute_sza(hour_utc, day_of_year) result(sza)
+    real(dk), intent(in) :: hour_utc
+    integer, intent(in) :: day_of_year
+    real(dk) :: sza
+
+    real(dk) :: lat, gamma, dec, solar_hour, ha, cos_sza
+
+    lat = LATITUDE * DEG2RAD
+    gamma = 2.0_dk * PI * real(day_of_year - 1, dk) / 365.0_dk
+    dec = 0.006918_dk &
+        - 0.399912_dk * cos(gamma) + 0.070257_dk * sin(gamma) &
+        - 0.006758_dk * cos(2.0_dk * gamma) + 0.000907_dk * sin(2.0_dk * gamma) &
+        - 0.002697_dk * cos(3.0_dk * gamma) + 0.00148_dk * sin(3.0_dk * gamma)
+    solar_hour = hour_utc + LONGITUDE / 15.0_dk
+    ha = (solar_hour - 12.0_dk) * 15.0_dk * DEG2RAD
+    cos_sza = sin(lat) * sin(dec) + cos(lat) * cos(dec) * cos(ha)
+    cos_sza = max(-1.0_dk, min(1.0_dk, cos_sza))
+    sza = acos(cos_sza)
+  end function compute_sza
+
+  ! Extract initial atmospheric profiles from TUV-x
+  subroutine get_initial_profiles(tuvx, height_mid, temperature, pressure, &
+                                   o3_mol_m3, o2_mol_m3, n2_mol_m3, error)
+    type(tuvx_t), intent(inout) :: tuvx
+    real(dk), intent(out) :: height_mid(NUM_CELLS)
+    real(dk), intent(out) :: temperature(NUM_CELLS)
+    real(dk), intent(out) :: pressure(NUM_CELLS)
+    real(dk), intent(out) :: o3_mol_m3(NUM_CELLS)
+    real(dk), intent(out) :: o2_mol_m3(NUM_CELLS)
+    real(dk), intent(out) :: n2_mol_m3(NUM_CELLS)
+    type(error_t), intent(inout) :: error
+
+    type(grid_map_t), pointer :: grids
+    type(profile_map_t), pointer :: profiles
+    type(grid_t), pointer :: heights
+    type(profile_t), pointer :: air_prof, o3_prof, o2_prof, temp_prof
+
+    real(dk) :: air_mid(NUM_CELLS), o3_mid(NUM_CELLS), o2_mid(NUM_CELLS)
+    real(dk) :: temp_mid(NUM_CELLS), height_edges(NUM_CELLS + 1)
+    real(dk) :: air_mol_m3(NUM_CELLS)
+    real(dk) :: conv
+    integer :: i
+
+    conv = 1.0e6_dk / AVOGADRO  ! molecule/cm³ → mol/m³
+
+    grids => tuvx%get_grids(error)
+    if (.not. error%is_success()) return
+    profiles => tuvx%get_profiles(error)
+    if (.not. error%is_success()) return
+
+    heights => grids%get("height", "km", error)
+    if (.not. error%is_success()) return
+    call heights%get_midpoints(height_mid, error)
+    if (.not. error%is_success()) return
+    call heights%get_edges(height_edges, error)
+    if (.not. error%is_success()) return
+
+    ! Air density
+    air_prof => profiles%get("air", "molecule cm-3", error)
+    if (.not. error%is_success()) return
+    call air_prof%get_midpoint_values(air_mid, error)
+    if (.not. error%is_success()) return
+
+    ! Temperature
+    temp_prof => profiles%get("temperature", "K", error)
+    if (.not. error%is_success()) return
+    call temp_prof%get_midpoint_values(temp_mid, error)
+    if (.not. error%is_success()) return
+
+    ! O3
+    o3_prof => profiles%get("O3", "molecule cm-3", error)
+    if (.not. error%is_success()) return
+    call o3_prof%get_midpoint_values(o3_mid, error)
+    if (.not. error%is_success()) return
+
+    ! O2
+    o2_prof => profiles%get("O2", "molecule cm-3", error)
+    if (.not. error%is_success()) return
+    call o2_prof%get_midpoint_values(o2_mid, error)
+    if (.not. error%is_success()) return
+
+    ! Convert units and compute derived quantities
+    temperature = temp_mid
+    do i = 1, NUM_CELLS
+      ! P = n * k_B * T, where n is in molecules/m³
+      pressure(i) = air_mid(i) * 1.0e6_dk * BOLTZMANN * temp_mid(i)
+      air_mol_m3(i) = air_mid(i) * conv
+      o3_mol_m3(i) = o3_mid(i) * conv
+      o2_mol_m3(i) = o2_mid(i) * conv
+      n2_mol_m3(i) = air_mol_m3(i) * 0.78084_dk / (0.78084_dk + 0.20946_dk)
+    end do
+
+    deallocate(heights, air_prof, temp_prof, o3_prof, o2_prof)
+    deallocate(profiles, grids)
+  end subroutine get_initial_profiles
+
+  ! Map TUV-x photolysis rates to MICM state rate parameters
+  !
+  ! photo_rates: (NUM_CELLS+1, num_photo_rxns) from TUV-x run
+  ! For nighttime, pass is_day = .false. and rates will be zeroed.
+  subroutine set_photolysis_rates(state, photo_rates, &
+      jo2_tuvx_idx, jo3a_tuvx_idx, jo3b_tuvx_idx, &
+      jo2_micm_idx, jo3a_micm_idx, jo3b_micm_idx, &
+      is_day, jo3a_out, jo3b_out, jo2_out)
+    type(state_t), intent(inout) :: state
+    real(dk), intent(in) :: photo_rates(:,:)
+    integer, intent(in) :: jo2_tuvx_idx, jo3a_tuvx_idx, jo3b_tuvx_idx
+    integer, intent(in) :: jo2_micm_idx, jo3a_micm_idx, jo3b_micm_idx
+    logical, intent(in) :: is_day
+    real(dk), intent(out) :: jo3a_out(NUM_CELLS)
+    real(dk), intent(out) :: jo3b_out(NUM_CELLS)
+    real(dk), intent(out) :: jo2_out(NUM_CELLS)
+
+    integer :: i, cell_stride, var_stride
+
+    cell_stride = state%rate_parameters_strides%grid_cell
+    var_stride = state%rate_parameters_strides%variable
+
+    if (is_day) then
+      ! Average adjacent edges to get midpoint rates
+      do i = 1, NUM_CELLS
+        jo3a_out(i) = 0.5_dk * (photo_rates(i, jo3a_tuvx_idx) &
+                               + photo_rates(i + 1, jo3a_tuvx_idx))
+        jo3b_out(i) = 0.5_dk * (photo_rates(i, jo3b_tuvx_idx) &
+                               + photo_rates(i + 1, jo3b_tuvx_idx))
+        jo2_out(i)  = 0.5_dk * (photo_rates(i, jo2_tuvx_idx) &
+                               + photo_rates(i + 1, jo2_tuvx_idx))
+      end do
+    else
+      jo3a_out = 0.0_dk
+      jo3b_out = 0.0_dk
+      jo2_out  = 0.0_dk
+    end if
+
+    do i = 1, NUM_CELLS
+      state%rate_parameters(1 + (i - 1) * cell_stride &
+          + (jo2_micm_idx - 1) * var_stride) = jo2_out(i)
+      state%rate_parameters(1 + (i - 1) * cell_stride &
+          + (jo3a_micm_idx - 1) * var_stride) = jo3a_out(i)
+      state%rate_parameters(1 + (i - 1) * cell_stride &
+          + (jo3b_micm_idx - 1) * var_stride) = jo3b_out(i)
+    end do
+  end subroutine set_photolysis_rates
+
+end module column_model_setup

--- a/fortran/examples/tuvx_v54.F90
+++ b/fortran/examples/tuvx_v54.F90
@@ -1,0 +1,199 @@
+! Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+! Fortran example for TUV-x v5.4 photolysis configuration
+!
+! This program mirrors the Python example in python/musica/examples/tuvx_5_4.py.
+! It sets up a 120 km vertical column, runs TUV-x twice (standard and doubled O3),
+! and prints the O3 photolysis rates at each level.
+!
+program tuvx_v54_example
+  use musica_util, only: dk => musica_dk, error_t, mappings_t
+  use musica_tuvx, only: tuvx_t
+  use musica_tuvx_grid, only: grid_t
+  use musica_tuvx_grid_map, only: grid_map_t
+  use musica_tuvx_profile, only: profile_t
+  use musica_tuvx_profile_map, only: profile_map_t
+  use tuvx_v54_setup, only: get_tuvx_calculator
+
+  implicit none
+
+  integer, parameter :: NUM_HEIGHTS = 120
+
+  type(tuvx_t), pointer :: tuvx
+  type(error_t) :: error
+  type(mappings_t), pointer :: photo_mappings, heat_mappings
+  type(grid_map_t), pointer :: grids
+  type(profile_map_t), pointer :: profiles
+  type(grid_t), pointer :: heights
+  type(profile_t), pointer :: o3_profile
+
+  integer :: num_photo, num_heat, jo3a_idx, jo3b_idx, i
+  real(dk), allocatable :: photo_rates(:,:), heating_rates(:,:)
+  real(dk), allocatable :: photo_rates_mod(:,:), heating_rates_mod(:,:)
+  real(dk) :: edge_vals(NUM_HEIGHTS + 1), mid_vals(NUM_HEIGHTS)
+  real(dk) :: layer_dens(NUM_HEIGHTS)
+  real(dk) :: height_edges(NUM_HEIGHTS + 1)
+  real(dk) :: conv
+
+  character(len=:), allocatable :: rxn_name
+  integer :: csv_unit
+
+  write(*,*) "TUV-x v5.4 Fortran Example"
+  write(*,*) "=========================="
+
+  ! Create TUV-x calculator
+  tuvx => get_tuvx_calculator(error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error creating TUV-x: ", error%message()
+    stop 1
+  end if
+
+  ! Get reaction ordering
+  photo_mappings => tuvx%get_photolysis_rate_constants_ordering(error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error getting photo ordering: ", error%message()
+    stop 1
+  end if
+  heat_mappings => tuvx%get_heating_rates_ordering(error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error getting heating ordering: ", error%message()
+    stop 1
+  end if
+
+  num_photo = photo_mappings%size()
+  num_heat = heat_mappings%size()
+
+  write(*,'(A,I0,A)') " Found ", num_photo, " photolysis reactions"
+  write(*,'(A,I0,A)') " Found ", num_heat, " heating rates"
+  write(*,*)
+
+  ! Print reaction names
+  write(*,*) "Photolysis reactions:"
+  do i = 1, num_photo
+    rxn_name = photo_mappings%name(i)
+    write(*,'(A,I3,A,A)') "  ", i, ": ", rxn_name
+  end do
+  write(*,*)
+
+  ! Find O3 photolysis reaction indices
+  jo3a_idx = photo_mappings%index("O3+hv->O2+O(1D)", error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error finding O3+hv->O2+O(1D): ", error%message()
+    stop 1
+  end if
+  jo3b_idx = photo_mappings%index("O3+hv->O2+O(3P)", error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error finding O3+hv->O2+O(3P): ", error%message()
+    stop 1
+  end if
+
+  write(*,'(A,I0)') " O3+hv->O2+O(1D) index: ", jo3a_idx
+  write(*,'(A,I0)') " O3+hv->O2+O(3P) index: ", jo3b_idx
+  write(*,*)
+
+  ! Allocate output arrays: (n_layers+1, n_reactions)
+  allocate(photo_rates(NUM_HEIGHTS + 1, num_photo))
+  allocate(heating_rates(NUM_HEIGHTS + 1, num_heat))
+  allocate(photo_rates_mod(NUM_HEIGHTS + 1, num_photo))
+  allocate(heating_rates_mod(NUM_HEIGHTS + 1, num_heat))
+
+  photo_rates = 0.0_dk
+  heating_rates = 0.0_dk
+
+  ! Run 1: Standard conditions, SZA=0 degrees, earth-sun distance=1.0 AU
+  write(*,*) "Running TUV-x with standard conditions..."
+  call tuvx%run(0.0_dk, 1.0_dk, photo_rates, heating_rates, error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error running TUV-x: ", error%message()
+    stop 1
+  end if
+  write(*,*) "Standard run complete."
+
+  ! Double the O3 concentrations
+  grids => tuvx%get_grids(error)
+  if (.not. error%is_success()) stop 1
+  profiles => tuvx%get_profiles(error)
+  if (.not. error%is_success()) stop 1
+  heights => grids%get("height", "km", error)
+  if (.not. error%is_success()) stop 1
+  o3_profile => profiles%get("O3", "molecule cm-3", error)
+  if (.not. error%is_success()) stop 1
+
+  ! Get current O3 values
+  call o3_profile%get_edge_values(edge_vals, error)
+  if (.not. error%is_success()) stop 1
+  call o3_profile%get_midpoint_values(mid_vals, error)
+  if (.not. error%is_success()) stop 1
+
+  ! Double edge and midpoint values
+  edge_vals = edge_vals * 2.0_dk
+  mid_vals = mid_vals * 2.0_dk
+
+  call o3_profile%set_edge_values(edge_vals, error)
+  if (.not. error%is_success()) stop 1
+  call o3_profile%set_midpoint_values(mid_vals, error)
+  if (.not. error%is_success()) stop 1
+
+  ! Recalculate layer densities (midpoint * delta_height * 1e5)
+  call heights%get_edges(height_edges, error)
+  if (.not. error%is_success()) stop 1
+  conv = 1.0e5_dk
+  do i = 1, NUM_HEIGHTS
+    layer_dens(i) = mid_vals(i) * (height_edges(i+1) - height_edges(i)) * conv
+  end do
+  call o3_profile%set_layer_densities(layer_dens, error)
+  if (.not. error%is_success()) stop 1
+
+  ! Run 2: With doubled O3
+  photo_rates_mod = 0.0_dk
+  heating_rates_mod = 0.0_dk
+
+  write(*,*) "Running TUV-x with doubled O3..."
+  call tuvx%run(0.0_dk, 1.0_dk, photo_rates_mod, heating_rates_mod, error)
+  if (.not. error%is_success()) then
+    write(*,*) "Error running TUV-x (modified): ", error%message()
+    stop 1
+  end if
+  write(*,*) "Modified run complete."
+  write(*,*)
+
+  ! Print O3 photolysis rates at each level
+  write(*,*) "O3 photolysis rates comparison:"
+  write(*,'(A6,4A26)') "Level", &
+      "O(1D) std", "O(1D) 2xO3", &
+      "O(3P) std", "O(3P) 2xO3"
+  write(*,*) repeat('-', 110)
+  do i = 1, NUM_HEIGHTS + 1
+    write(*,'(I6,4ES26.16)') i, &
+        photo_rates(i, jo3a_idx), photo_rates_mod(i, jo3a_idx), &
+        photo_rates(i, jo3b_idx), photo_rates_mod(i, jo3b_idx)
+  end do
+
+  ! Write CSV file for comparison with Python output
+  open(newunit=csv_unit, file='tuvx_v54_fortran_results.csv', &
+      status='replace', action='write')
+  write(csv_unit,'(A)') 'level,height_km,' // &
+      'jo3a_std,jo3a_2xO3,jo3b_std,jo3b_2xO3'
+  do i = 1, NUM_HEIGHTS + 1
+    write(csv_unit,'(I0,",",F8.1,4(",",ES26.16))') i, &
+        real(i - 1, dk), &
+        photo_rates(i, jo3a_idx), photo_rates_mod(i, jo3a_idx), &
+        photo_rates(i, jo3b_idx), photo_rates_mod(i, jo3b_idx)
+  end do
+  close(csv_unit)
+  write(*,*)
+  write(*,*) "Results written to tuvx_v54_fortran_results.csv"
+
+  ! Clean up
+  deallocate(photo_rates, heating_rates)
+  deallocate(photo_rates_mod, heating_rates_mod)
+  deallocate(photo_mappings)
+  deallocate(heat_mappings)
+  deallocate(heights)
+  deallocate(o3_profile)
+  deallocate(profiles)
+  deallocate(grids)
+  deallocate(tuvx)
+
+end program tuvx_v54_example

--- a/fortran/examples/tuvx_v54_setup.F90
+++ b/fortran/examples/tuvx_v54_setup.F90
@@ -1,0 +1,564 @@
+! Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+! TUV-x v5.4 configuration setup module
+!
+! This module mirrors the Python setup in python/musica/tuvx/v54.py,
+! providing grid, profile, and radiator initialization for TUV-x v5.4.
+!
+module tuvx_v54_setup
+  use musica_util, only: dk => musica_dk, error_t
+  use musica_tuvx, only: tuvx_t
+  use musica_tuvx_grid, only: grid_t
+  use musica_tuvx_grid_map, only: grid_map_t
+  use musica_tuvx_profile, only: profile_t
+  use musica_tuvx_profile_map, only: profile_map_t
+  use musica_tuvx_radiator, only: radiator_t
+  use musica_tuvx_radiator_map, only: radiator_map_t
+
+  implicit none
+  private
+  public :: get_tuvx_calculator
+
+  integer, parameter :: NUM_HEIGHT_SECTIONS = 120
+  integer, parameter :: NUM_WAVELENGTH_SECTIONS = 156
+
+  character(len=*), parameter :: CONFIG_PATH = "tuv_5_4.json"
+
+contains
+
+  function get_tuvx_calculator(error) result(tuvx)
+    type(error_t), intent(inout) :: error
+    type(tuvx_t), pointer :: tuvx
+
+    type(grid_t), pointer :: heights, wavelengths
+    type(grid_map_t), pointer :: grids
+    type(profile_t), pointer :: prof
+    type(profile_map_t), pointer :: profiles
+    type(radiator_t), pointer :: aer
+    type(radiator_map_t), pointer :: radiators
+
+    ! Create grids
+    heights => setup_height_grid(error)
+    if (.not. error%is_success()) return
+    wavelengths => setup_wavelength_grid(error)
+    if (.not. error%is_success()) return
+
+    grids => grid_map_t(error)
+    if (.not. error%is_success()) return
+    call grids%add(heights, error)
+    if (.not. error%is_success()) return
+    call grids%add(wavelengths, error)
+    if (.not. error%is_success()) return
+
+    ! Create profiles
+    profiles => profile_map_t(error)
+    if (.not. error%is_success()) return
+
+    prof => load_profile("air", "molecule cm-3", heights, &
+        "data/profiles/atmosphere/air.v54.dat", error)
+    if (.not. error%is_success()) return
+    call profiles%add(prof, error)
+    if (.not. error%is_success()) return
+    deallocate(prof)
+
+    prof => load_profile("O3", "molecule cm-3", heights, &
+        "data/profiles/atmosphere/o3.v54.dat", error)
+    if (.not. error%is_success()) return
+    call profiles%add(prof, error)
+    if (.not. error%is_success()) return
+    deallocate(prof)
+
+    prof => load_profile("O2", "molecule cm-3", heights, &
+        "data/profiles/atmosphere/o2.v54.dat", error)
+    if (.not. error%is_success()) return
+    call profiles%add(prof, error)
+    if (.not. error%is_success()) return
+    deallocate(prof)
+
+    prof => load_profile("temperature", "K", heights, &
+        "data/profiles/atmosphere/temperature.v54.dat", error)
+    if (.not. error%is_success()) return
+    call profiles%add(prof, error)
+    if (.not. error%is_success()) return
+    deallocate(prof)
+
+    prof => load_profile("surface albedo", "none", wavelengths, &
+        "data/profiles/solar/surface_albedo.v54.dat", error)
+    if (.not. error%is_success()) return
+    call profiles%add(prof, error)
+    if (.not. error%is_success()) return
+    deallocate(prof)
+
+    prof => load_profile("extraterrestrial flux", "photon cm-2 s-1", &
+        wavelengths, &
+        "data/profiles/solar/extraterrestrial_flux.v54.dat", &
+        error)
+    if (.not. error%is_success()) return
+    call profiles%add(prof, error)
+    if (.not. error%is_success()) return
+    deallocate(prof)
+
+    ! Create radiators
+    radiators => radiator_map_t(error)
+    if (.not. error%is_success()) return
+    aer => load_aerosol_radiator(heights, wavelengths, error)
+    if (.not. error%is_success()) return
+    call radiators%add(aer, error)
+    if (.not. error%is_success()) return
+    deallocate(aer)
+
+    ! Create TUV-x instance
+    tuvx => tuvx_t(CONFIG_PATH, grids, profiles, radiators, error)
+
+    ! Clean up construction-time maps (TUV-x owns internal copies)
+    deallocate(heights)
+    deallocate(wavelengths)
+    deallocate(grids)
+    deallocate(profiles)
+    deallocate(radiators)
+
+  end function get_tuvx_calculator
+
+  !> Create 120-section height grid: 0–120 km, 1 km resolution
+  function setup_height_grid(error) result(grid)
+    type(error_t), intent(inout) :: error
+    type(grid_t), pointer :: grid
+
+    real(dk) :: edges(NUM_HEIGHT_SECTIONS + 1)
+    real(dk) :: midpoints(NUM_HEIGHT_SECTIONS)
+    integer :: i
+
+    grid => grid_t("height", "km", NUM_HEIGHT_SECTIONS, error)
+    if (.not. error%is_success()) return
+
+    do i = 1, NUM_HEIGHT_SECTIONS + 1
+      edges(i) = real(i - 1, dk)
+    end do
+    do i = 1, NUM_HEIGHT_SECTIONS
+      midpoints(i) = 0.5_dk * (edges(i) + edges(i + 1))
+    end do
+
+    call grid%set_edges(edges, error)
+    if (.not. error%is_success()) return
+    call grid%set_midpoints(midpoints, error)
+
+  end function setup_height_grid
+
+  !> Create 156-section wavelength grid with exact v5.4 edges
+  function setup_wavelength_grid(error) result(grid)
+    type(error_t), intent(inout) :: error
+    type(grid_t), pointer :: grid
+
+    real(dk) :: edges(NUM_WAVELENGTH_SECTIONS + 1)
+    real(dk) :: midpoints(NUM_WAVELENGTH_SECTIONS)
+    integer :: i
+
+    grid => grid_t("wavelength", "nm", NUM_WAVELENGTH_SECTIONS, error)
+    if (.not. error%is_success()) return
+
+    edges = [ &
+        120.0000_dk, 121.4000_dk, 121.9000_dk, 122.3000_dk, 123.1000_dk, &
+        123.8000_dk, 124.6000_dk, 125.4000_dk, 126.2000_dk, 127.0000_dk, &
+        128.6000_dk, 129.4000_dk, 130.3000_dk, 132.0000_dk, 135.0000_dk, &
+        137.0000_dk, 145.0000_dk, 155.0000_dk, 165.0000_dk, 170.0000_dk, &
+        175.4000_dk, 177.0000_dk, 178.6000_dk, 180.2000_dk, 181.8000_dk, &
+        183.5000_dk, 185.2000_dk, 186.9000_dk, 188.7000_dk, 190.5000_dk, &
+        192.3000_dk, 194.2000_dk, 196.1000_dk, 198.0000_dk, 200.0000_dk, &
+        202.0000_dk, 204.1000_dk, 206.2000_dk, 208.3330_dk, 210.5260_dk, &
+        212.7660_dk, 215.0540_dk, 217.3910_dk, 219.7800_dk, 222.2220_dk, &
+        224.7190_dk, 227.2730_dk, 229.8850_dk, 232.5580_dk, 235.2940_dk, &
+        238.0950_dk, 240.9640_dk, 243.9020_dk, 246.9140_dk, 250.0000_dk, &
+        253.1650_dk, 256.4100_dk, 259.7400_dk, 263.1580_dk, 266.6670_dk, &
+        270.2700_dk, 273.9730_dk, 277.7780_dk, 281.6900_dk, 285.7140_dk, &
+        289.8550_dk, 294.1180_dk, 298.5000_dk, 302.5000_dk, 303.5000_dk, &
+        304.5000_dk, 305.5000_dk, 306.5000_dk, 307.5000_dk, 308.5000_dk, &
+        309.5000_dk, 310.5000_dk, 311.5000_dk, 312.5000_dk, 313.5000_dk, &
+        314.5000_dk, 317.5000_dk, 322.5000_dk, 327.5000_dk, 332.5000_dk, &
+        337.5000_dk, 342.5000_dk, 347.5000_dk, 352.5000_dk, 357.5000_dk, &
+        362.5000_dk, 367.5000_dk, 372.5000_dk, 377.5000_dk, 382.5000_dk, &
+        387.5000_dk, 392.5000_dk, 397.5000_dk, 402.5000_dk, 407.5000_dk, &
+        412.5000_dk, 417.5000_dk, 422.5000_dk, 427.5000_dk, 432.5000_dk, &
+        437.5000_dk, 442.5000_dk, 447.5000_dk, 452.5000_dk, 457.5000_dk, &
+        462.5000_dk, 467.5000_dk, 472.5000_dk, 477.5000_dk, 482.5000_dk, &
+        487.5000_dk, 492.5000_dk, 497.5000_dk, 502.5000_dk, 507.5000_dk, &
+        512.5000_dk, 517.5000_dk, 522.5000_dk, 527.5000_dk, 532.5000_dk, &
+        537.5000_dk, 542.5000_dk, 547.5000_dk, 552.5000_dk, 557.5000_dk, &
+        562.5000_dk, 567.5000_dk, 572.5000_dk, 577.5000_dk, 582.5000_dk, &
+        587.5000_dk, 592.5000_dk, 597.5000_dk, 602.5000_dk, 607.5000_dk, &
+        612.5000_dk, 617.5000_dk, 622.5000_dk, 627.5000_dk, 632.5000_dk, &
+        637.5000_dk, 642.5000_dk, 647.1000_dk, 655.0000_dk, 665.0000_dk, &
+        675.0000_dk, 685.0000_dk, 695.0000_dk, 705.0000_dk, 715.0000_dk, &
+        725.0000_dk, 735.0000_dk ]
+
+    do i = 1, NUM_WAVELENGTH_SECTIONS
+      midpoints(i) = 0.5_dk * (edges(i) + edges(i + 1))
+    end do
+
+    call grid%set_edges(edges, error)
+    if (.not. error%is_success()) return
+    call grid%set_midpoints(midpoints, error)
+
+  end function setup_wavelength_grid
+
+  !> Load a profile from a .dat file and set it up on the given grid
+  function load_profile(prof_name, prof_units, grid, filepath, error) &
+      result(prof)
+    character(len=*), intent(in) :: prof_name
+    character(len=*), intent(in) :: prof_units
+    type(grid_t), intent(in) :: grid
+    character(len=*), intent(in) :: filepath
+    type(error_t), intent(inout) :: error
+    type(profile_t), pointer :: prof
+
+    integer :: unit_num, ios, num_sections, i
+    character(len=1024) :: line
+    logical :: in_midpoint, in_edge
+    real(dk) :: exo_layer_density
+
+    ! File data arrays (max 200 entries)
+    real(dk) :: file_mid_coords(200), file_mid_values(200)
+    real(dk) :: file_layer_dens(200)
+    real(dk) :: file_edge_coords(300), file_edge_values(300)
+    integer :: n_mid, n_edge
+
+    ! Grid arrays
+    real(dk), allocatable :: grid_edges(:), grid_midpoints(:)
+
+    ! Interpolated arrays
+    real(dk), allocatable :: interp_edges(:), interp_midpoints(:)
+    real(dk), allocatable :: interp_layer_dens(:)
+
+    ! Parse file columns
+    real(dk) :: col1, col2, col3, col4, col5
+    character(len=64) :: s1, s2, s3, s4, s5, s6
+
+    num_sections = grid%number_of_sections(error)
+    if (.not. error%is_success()) return
+
+    allocate(grid_edges(num_sections + 1))
+    allocate(grid_midpoints(num_sections))
+    allocate(interp_edges(num_sections + 1))
+    allocate(interp_midpoints(num_sections))
+    allocate(interp_layer_dens(num_sections))
+
+    call grid%get_edges(grid_edges, error)
+    if (.not. error%is_success()) return
+    call grid%get_midpoints(grid_midpoints, error)
+    if (.not. error%is_success()) return
+
+    ! Parse the data file
+    in_midpoint = .false.
+    in_edge = .false.
+    n_mid = 0
+    n_edge = 0
+    exo_layer_density = 0.0_dk
+
+    open(newunit=unit_num, file=filepath, status='old', action='read', &
+        iostat=ios)
+    if (ios /= 0) then
+      write(*,*) "ERROR: Could not open file: ", trim(filepath)
+      stop 1
+    end if
+
+    do
+      read(unit_num, '(A)', iostat=ios) line
+      if (ios /= 0) exit
+
+      line = adjustl(line)
+
+      ! Check for section headers
+      if (line(1:1) == '#' .or. len_trim(line) == 0) then
+        if (index(line, 'mid-point') > 0 .and. &
+            (index(line, 'height (km)') > 0 .or. &
+             index(line, 'wavelength (nm)') > 0)) then
+          in_midpoint = .true.
+          in_edge = .false.
+        else if (index(line, 'edge') > 0 .and. &
+            (index(line, 'height (km)') > 0 .or. &
+             index(line, 'wavelength (nm)') > 0)) then
+          in_edge = .true.
+          in_midpoint = .false.
+        end if
+        cycle
+      end if
+
+      if (in_midpoint) then
+        ! Check for exo row (all --- entries)
+        if (index(line, '---,---,---') > 0 .and. &
+            line(1:3) == '---') then
+          ! Parse exo_layer_density from column 5 if present
+          call parse_exo_row(line, exo_layer_density)
+          cycle
+        end if
+        ! Parse: coord, value, delta, layer_density, ...
+        call parse_midpoint_line(line, col1, col2, col4, ios)
+        if (ios == 0) then
+          n_mid = n_mid + 1
+          file_mid_coords(n_mid) = col1
+          file_mid_values(n_mid) = col2
+          file_layer_dens(n_mid) = col4
+        end if
+      else if (in_edge) then
+        ! Parse: coord, value
+        call parse_edge_line(line, col1, col2, ios)
+        if (ios == 0) then
+          n_edge = n_edge + 1
+          file_edge_coords(n_edge) = col1
+          file_edge_values(n_edge) = col2
+        end if
+      end if
+    end do
+
+    close(unit_num)
+
+    ! Interpolate onto the target grid
+    call linear_interp(file_mid_coords(1:n_mid), file_mid_values(1:n_mid), &
+        grid_midpoints, interp_midpoints)
+    call linear_interp(file_edge_coords(1:n_edge), file_edge_values(1:n_edge),&
+        grid_edges, interp_edges)
+    call linear_interp(file_mid_coords(1:n_mid), file_layer_dens(1:n_mid), &
+        grid_midpoints, interp_layer_dens)
+
+    ! Remove exo layer density from the top layer density if present
+    ! (it will be added back by set_exo_layer_density)
+    if (exo_layer_density > 0.0_dk) then
+      interp_layer_dens(num_sections) = &
+          interp_layer_dens(num_sections) - exo_layer_density
+    end if
+
+    ! Create and configure the profile
+    prof => profile_t(prof_name, prof_units, grid, error)
+    if (.not. error%is_success()) return
+
+    call prof%set_edge_values(interp_edges, error)
+    if (.not. error%is_success()) return
+    call prof%set_midpoint_values(interp_midpoints, error)
+    if (.not. error%is_success()) return
+    call prof%set_layer_densities(interp_layer_dens, error)
+    if (.not. error%is_success()) return
+
+    if (exo_layer_density > 0.0_dk) then
+      call prof%set_exo_layer_density(exo_layer_density, error)
+      if (.not. error%is_success()) return
+    end if
+
+    deallocate(grid_edges, grid_midpoints)
+    deallocate(interp_edges, interp_midpoints, interp_layer_dens)
+
+  end function load_profile
+
+  !> Parse a midpoint data line (comma-separated)
+  subroutine parse_midpoint_line(line, coord, value, layer_dens, ios)
+    character(len=*), intent(in) :: line
+    real(dk), intent(out) :: coord, value, layer_dens
+    integer, intent(out) :: ios
+
+    character(len=64) :: fields(6)
+    integer :: nf
+
+    call split_csv(line, fields, nf)
+    if (nf < 4) then
+      ios = 1
+      return
+    end if
+
+    read(fields(1), *, iostat=ios) coord
+    if (ios /= 0) return
+    read(fields(2), *, iostat=ios) value
+    if (ios /= 0) return
+    read(fields(4), *, iostat=ios) layer_dens
+    if (ios /= 0) layer_dens = 0.0_dk
+
+    ios = 0
+  end subroutine parse_midpoint_line
+
+  !> Parse an edge data line (comma-separated)
+  subroutine parse_edge_line(line, coord, value, ios)
+    character(len=*), intent(in) :: line
+    real(dk), intent(out) :: coord, value
+    integer, intent(out) :: ios
+
+    character(len=64) :: fields(6)
+    integer :: nf
+
+    call split_csv(line, fields, nf)
+    if (nf < 2) then
+      ios = 1
+      return
+    end if
+
+    read(fields(1), *, iostat=ios) coord
+    if (ios /= 0) return
+    read(fields(2), *, iostat=ios) value
+  end subroutine parse_edge_line
+
+  !> Parse the exo row to extract exo_layer_density
+  subroutine parse_exo_row(line, exo_layer_density)
+    character(len=*), intent(in) :: line
+    real(dk), intent(inout) :: exo_layer_density
+
+    character(len=64) :: fields(6)
+    integer :: nf, ios
+
+    call split_csv(line, fields, nf)
+    if (nf >= 5) then
+      if (trim(adjustl(fields(5))) /= '---') then
+        read(fields(5), *, iostat=ios) exo_layer_density
+      end if
+    end if
+  end subroutine parse_exo_row
+
+  !> Split a comma-separated line into fields
+  subroutine split_csv(line, fields, nf)
+    character(len=*), intent(in) :: line
+    character(len=64), intent(out) :: fields(:)
+    integer, intent(out) :: nf
+
+    integer :: pos, start, flen
+
+    nf = 0
+    start = 1
+    flen = len_trim(line)
+
+    do while (start <= flen .and. nf < size(fields))
+      pos = index(line(start:flen), ',')
+      nf = nf + 1
+      if (pos == 0) then
+        fields(nf) = adjustl(line(start:flen))
+        exit
+      else
+        fields(nf) = adjustl(line(start:start + pos - 2))
+        start = start + pos
+      end if
+    end do
+  end subroutine split_csv
+
+  !> Linear interpolation: numpy.interp equivalent
+  subroutine linear_interp(xp, fp, x, result)
+    real(dk), intent(in) :: xp(:), fp(:), x(:)
+    real(dk), intent(out) :: result(:)
+
+    integer :: i, j, np
+    real(dk) :: t
+
+    np = size(xp)
+
+    do i = 1, size(x)
+      if (x(i) <= xp(1)) then
+        result(i) = fp(1)
+      else if (x(i) >= xp(np)) then
+        result(i) = fp(np)
+      else
+        ! Find the bracketing interval
+        do j = 1, np - 1
+          if (x(i) >= xp(j) .and. x(i) <= xp(j + 1)) then
+            t = (x(i) - xp(j)) / (xp(j + 1) - xp(j))
+            result(i) = fp(j) + t * (fp(j + 1) - fp(j))
+            exit
+          end if
+        end do
+      end if
+    end do
+  end subroutine linear_interp
+
+  !> Load aerosol radiator from the v5.4 data file
+  function load_aerosol_radiator(heights, wavelengths, error) result(rad)
+    type(grid_t), intent(in) :: heights
+    type(grid_t), intent(in) :: wavelengths
+    type(error_t), intent(inout) :: error
+    type(radiator_t), pointer :: rad
+
+    character(len=*), parameter :: filepath = &
+        "data/radiators/aerosol.v54.dat"
+
+    integer :: nh, nw, unit_num, ios, hi, wi, i
+    real(dk), allocatable :: h_mid(:), w_mid(:)
+    real(dk), allocatable :: optical_depths(:,:)
+    real(dk), allocatable :: ssa(:,:)
+    real(dk), allocatable :: asym(:,:,:)
+
+    real(dk) :: file_h, file_w, file_od, file_ssa, file_g
+    real(dk) :: min_dist
+    character(len=1024) :: line
+
+    nh = heights%number_of_sections(error)
+    if (.not. error%is_success()) return
+    nw = wavelengths%number_of_sections(error)
+    if (.not. error%is_success()) return
+
+    allocate(h_mid(nh))
+    allocate(w_mid(nw))
+    allocate(optical_depths(nh, nw))
+    allocate(ssa(nh, nw))
+    allocate(asym(nh, nw, 1))
+
+    call heights%get_midpoints(h_mid, error)
+    if (.not. error%is_success()) return
+    call wavelengths%get_midpoints(w_mid, error)
+    if (.not. error%is_success()) return
+
+    optical_depths = 0.0_dk
+    ssa = 0.0_dk
+    asym = 0.0_dk
+
+    open(newunit=unit_num, file=filepath, status='old', action='read', &
+        iostat=ios)
+    if (ios /= 0) then
+      write(*,*) "ERROR: Could not open file: ", trim(filepath)
+      stop 1
+    end if
+
+    do
+      read(unit_num, '(A)', iostat=ios) line
+      if (ios /= 0) exit
+
+      line = adjustl(line)
+      if (len_trim(line) == 0 .or. line(1:1) == '#') cycle
+
+      read(line, *, iostat=ios) file_h, file_w, file_od, file_ssa, file_g
+      if (ios /= 0) cycle
+
+      ! Find closest height midpoint
+      hi = 1
+      min_dist = abs(h_mid(1) - file_h)
+      do i = 2, nh
+        if (abs(h_mid(i) - file_h) < min_dist) then
+          min_dist = abs(h_mid(i) - file_h)
+          hi = i
+        end if
+      end do
+
+      ! Find closest wavelength midpoint
+      wi = 1
+      min_dist = abs(w_mid(1) - file_w)
+      do i = 2, nw
+        if (abs(w_mid(i) - file_w) < min_dist) then
+          min_dist = abs(w_mid(i) - file_w)
+          wi = i
+        end if
+      end do
+
+      optical_depths(hi, wi) = file_od
+      ssa(hi, wi) = file_ssa
+      asym(hi, wi, 1) = file_g
+    end do
+
+    close(unit_num)
+
+    ! Create radiator and set arrays
+    rad => radiator_t("aerosol", heights, wavelengths, error)
+    if (.not. error%is_success()) return
+
+    call rad%set_optical_depths(optical_depths, error)
+    if (.not. error%is_success()) return
+    call rad%set_single_scattering_albedos(ssa, error)
+    if (.not. error%is_success()) return
+    call rad%set_asymmetry_factors(asym, error)
+    if (.not. error%is_success()) return
+
+    deallocate(h_mid, w_mid, optical_depths, ssa, asym)
+
+  end function load_aerosol_radiator
+
+end module tuvx_v54_setup


### PR DESCRIPTION
- Adapted python Chapman TUV-x example to Fortran.

- Fortran program writes data to CSV files for further plotting.

- Results should be within numerical round-off of the Python results.