### PR TITLE
Add severity classification to musica Error struct (#795)

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -73,7 +73,7 @@ endif()
 
 if (MUSICA_ENABLE_MICM AND MUSICA_BUILD_C_CXX_INTERFACE AND NOT MUSICA_USE_PREBUILT)
   set_git_default(MICM_GIT_REPOSITORY https://github.com/NCAR/micm.git)
-  set_git_default(MICM_GIT_TAG e854d2cf4d0abc7c6fb243e5406e751c462f3679)
+  set_git_default(MICM_GIT_TAG 032b30e796f5242aeceb2afd2e39c3622fff8a6d)
 
   FetchContent_Declare(micm
       GIT_REPOSITORY ${MICM_GIT_REPOSITORY}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:latest
 
 ARG MUSICA_GIT_TAG=main
-ARG BUILD_TYPE=Release
+ARG BUILD_TYPE=Debug
 
 RUN dnf -y update \
     && dnf -y install \
@@ -27,6 +27,7 @@ RUN cd musica \
     && cmake -S . \
              -B build \
              -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
+             -D MUSICA_BUILD_FORTRAN_INTERFACE=ON \
              -D MUSICA_GIT_TAG=${MUSICA_GIT_TAG} \
     && cd build \
     && make install -j 8

--- a/fortran/micm/state.F90
+++ b/fortran/micm/state.F90
@@ -117,7 +117,6 @@ module musica_state
     real(c_double) :: temperature
     real(c_double) :: pressure
     real(c_double) :: air_density
-    real(c_double) :: pH
   end type conditions_t
 
   type :: strides_t

--- a/include/musica/error.hpp
+++ b/include/musica/error.hpp
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #endif
 
+#define MUSICA_SEVERITY_OK   -1
+#define MUSICA_SEVERITY_WARN  0
+#define MUSICA_SEVERITY_ERR   1
+#define MUSICA_SEVERITY_CRIT  2
+
 #define MUSICA_ERROR_CATEGORY                           "MUSICA Error"
 #define MUSICA_ERROR_CODE_SPECIES_NOT_FOUND             1
 #define MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND         2

--- a/include/musica/util.hpp
+++ b/include/musica/util.hpp
@@ -6,6 +6,7 @@
 #include <musica/error.hpp>
 #ifdef MUSICA_USE_MICM
   #include <micm/util/vector_matrix.hpp>
+  #include <micm/util/micm_exception.hpp>
 #endif
 
 #include <cstddef>
@@ -46,6 +47,7 @@ const size_t MUSICA_VECTOR_SIZE = 0;
     struct Error
     {
       int code_ = 0;
+      int severity_ = MUSICA_SEVERITY_OK;
       String category_;
       String message_;
     };
@@ -98,12 +100,13 @@ const size_t MUSICA_VECTOR_SIZE = 0;
     /// @param error The Error [output]
     void NoError(Error* error);
 
-    /// @brief Creates an Error from a category, code, and message
+    /// @brief Creates an Error from a category, code, message, and severity
     /// @param category The category of the Error [input]
     /// @param code The code of the Error [input]
     /// @param message The message of the Error [input]
+    /// @param severity The severity of the Error (MUSICA_SEVERITY_WARN/ERR/CRIT) [input]
     /// @param error The Error [output]
-    void ToError(const char* category, int code, const char* message, Error* error);
+    void ToError(const char* category, int code, const char* message, int severity, Error* error);
 
     /// @brief Loads a set of configuration data from a string
     /// @param data The string to load [input]
@@ -190,16 +193,25 @@ const size_t MUSICA_VECTOR_SIZE = 0;
 
 #ifdef __cplusplus
   }
-  /// @brief Creates an Error from a category and code
+  /// @brief Creates an Error from a category, code, and severity
   /// @param category The category of the Error [input]
   /// @param code The code of the Error [input]
+  /// @param severity The severity of the Error (MUSICA_SEVERITY_WARN/ERR/CRIT) [input]
   /// @param error The Error [output]
-  void ToError(const char* category, int code, Error* error);
+  void ToError(const char* category, int code, int severity, Error* error);
 
-  /// @brief Creates an Error from syd::system_error
+  /// @brief Creates an Error from std::system_error
   /// @param e The std::system_error to convert [input]
+  /// @param severity The severity of the Error (MUSICA_SEVERITY_WARN/ERR/CRIT) [input]
   /// @param error The Error [output]
-  void ToError(const std::system_error& e, Error* error);
+  void ToError(const std::system_error& e, int severity, Error* error);
+
+#ifdef MUSICA_USE_MICM
+  /// @brief Creates an Error from a micm::MicmException, mapping MicmSeverity to musica severity
+  /// @param e The micm::MicmException to convert [input]
+  /// @param error The Error [output]
+  void ToError(const micm::MicmException& e, Error* error);
+#endif
 
   /// @brief Checks for success
   /// @param error The Error to check

--- a/src/micm/micm_c_interface.cpp
+++ b/src/micm/micm_c_interface.cpp
@@ -12,17 +12,21 @@ namespace musica
     {
       return func();
     }
-    catch (const std::system_error& e)
+    catch (const micm::MicmException& e)
     {
       ToError(e, error);
     }
+    catch (const std::system_error& e)
+    {
+      ToError(e, MUSICA_SEVERITY_ERR, error);
+    }
     catch (const std::exception& e)
     {
-      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_UNKNOWN, e.what(), error);
+      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_UNKNOWN, e.what(), MUSICA_SEVERITY_ERR, error);
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_UNKNOWN, "Unknown error", error);
+      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_UNKNOWN, "Unknown error", MUSICA_SEVERITY_CRIT, error);
     }
     return decltype(func())();
   }

--- a/src/micm/state_c_interface.cpp
+++ b/src/micm/state_c_interface.cpp
@@ -16,13 +16,17 @@ namespace musica
     {
       return func();
     }
-    catch (const std::system_error& e)
+    catch (const micm::MicmException& e)
     {
       ToError(e, error);
     }
+    catch (const std::system_error& e)
+    {
+      ToError(e, MUSICA_SEVERITY_ERR, error);
+    }
     catch (const std::exception& e)
     {
-      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_UNKNOWN, e.what(), error);
+      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_UNKNOWN, e.what(), MUSICA_SEVERITY_ERR, error);
     }
     return decltype(func())();
   }
@@ -35,7 +39,7 @@ namespace musica
           if (!micm)
           {
             std::string const msg = "MICM pointer is null, cannot create state.";
-            ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND, msg.c_str(), error);
+            ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND, msg.c_str(), MUSICA_SEVERITY_CRIT, error);
             return nullptr;
           }
 
@@ -54,7 +58,7 @@ namespace musica
           if (state == nullptr)
           {
             std::string const msg = "State pointer is null, cannot delete state.";
-            ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND, msg.c_str(), error);
+            ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_SOLVER_TYPE_NOT_FOUND, msg.c_str(), MUSICA_SEVERITY_CRIT, error);
             return;
           }
 

--- a/src/test/unit/util.cpp
+++ b/src/test/unit/util.cpp
@@ -22,6 +22,7 @@ TEST(Util, NoError)
 {
   Error error;
   NoError(&error);
+  EXPECT_EQ(error.severity_, MUSICA_SEVERITY_OK);
   EXPECT_EQ(error.code_, 0);
   EXPECT_EQ(error.category_.size_, 0);
   EXPECT_STREQ(error.category_.value_, "");
@@ -37,7 +38,8 @@ TEST(Util, NoError)
 TEST(Util, ToError)
 {
   Error error;
-  ToError("Test", 1, "Test Error", &error);
+  ToError("Test", 1, "Test Error", MUSICA_SEVERITY_ERR, &error);
+  EXPECT_EQ(error.severity_, MUSICA_SEVERITY_ERR);
   EXPECT_EQ(error.code_, 1);
   EXPECT_EQ(error.category_.size_, 4);
   EXPECT_STREQ(error.category_.value_, "Test");
@@ -48,6 +50,24 @@ TEST(Util, ToError)
   EXPECT_EQ(error.category_.value_, nullptr);
   EXPECT_EQ(error.message_.size_, 0);
   EXPECT_EQ(error.message_.value_, nullptr);
+}
+
+TEST(Util, ToErrorWarn)
+{
+  Error error;
+  ToError("Test", 2, "Test Warning", MUSICA_SEVERITY_WARN, &error);
+  EXPECT_EQ(error.severity_, MUSICA_SEVERITY_WARN);
+  EXPECT_EQ(error.code_, 2);
+  DeleteError(&error);
+}
+
+TEST(Util, ToErrorCrit)
+{
+  Error error;
+  ToError("Test", 3, "Test Critical", MUSICA_SEVERITY_CRIT, &error);
+  EXPECT_EQ(error.severity_, MUSICA_SEVERITY_CRIT);
+  EXPECT_EQ(error.code_, 3);
+  DeleteError(&error);
 }
 
 TEST(Util, IsSuccess)
@@ -61,7 +81,7 @@ TEST(Util, IsSuccess)
 TEST(Util, IsError)
 {
   Error error;
-  ToError("Test", 1, "Test Error", &error);
+  ToError("Test", 1, "Test Error", MUSICA_SEVERITY_ERR, &error);
   EXPECT_TRUE(IsError(error, "Test", 1));
   DeleteError(&error);
 }

--- a/src/tuvx/grid.cpp
+++ b/src/tuvx/grid.cpp
@@ -43,7 +43,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -99,14 +99,14 @@ namespace musica
     grid_ = InternalCreateGrid(grid_name, strlen(grid_name), units, strlen(units), num_sections, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     updater_ = InternalGetGridUpdater(grid_, &error_code);
     if (error_code != 0)
     {
       InternalDeleteGrid(grid_, &error_code);
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -130,14 +130,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     String name;
     InternalGetGridName(updater_, &name, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     NoError(error);
@@ -153,14 +153,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     String units;
     InternalGetGridUnits(updater_, &units, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     NoError(error);
@@ -176,13 +176,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     std::size_t const n_sections = InternalGetNumberOfSections(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     NoError(error);
@@ -196,13 +196,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalSetEdges(updater_, edges, num_edges, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -215,13 +215,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalGetEdges(updater_, edges, num_edges, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -234,13 +234,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     double *edges_ptr = InternalGetEdgesPointer(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -254,13 +254,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalSetMidpoints(updater_, midpoints, num_midpoints, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -273,13 +273,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalGetMidpoints(updater_, midpoints, num_midpoints, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -292,13 +292,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_GRID_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     double *midpoints_ptr = InternalGetMidpointsPointer(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);

--- a/src/tuvx/grid_map.cpp
+++ b/src/tuvx/grid_map.cpp
@@ -54,7 +54,8 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
+      return;
     }
     NoError(error);
   }
@@ -103,7 +104,8 @@ namespace musica
     grid_map_ = InternalCreateGridMap(&error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
+      return;
     }
     owns_grid_map_ = true;
     NoError(error);
@@ -124,17 +126,17 @@ namespace musica
   {
     if (grid_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (grid->grid_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID, GetErrorMessage(ERROR_UNALLOCATED_GRID), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID, GetErrorMessage(ERROR_UNALLOCATED_GRID), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (grid->updater_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_UPDATER, GetErrorMessage(ERROR_UNALLOCATED_GRID_UPDATER), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_UPDATER, GetErrorMessage(ERROR_UNALLOCATED_GRID_UPDATER), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -145,25 +147,25 @@ namespace musica
       InternalAddGrid(grid_map_, grid->grid_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       InternalDeleteGridUpdater(grid->updater_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       grid->updater_ = InternalGetGridUpdaterFromMap(grid_map_, grid->grid_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       InternalDeleteGrid(grid->grid_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteGridUpdater(grid->updater_, &error_code);
         grid->updater_ = nullptr;
         return;
@@ -172,12 +174,12 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -187,7 +189,7 @@ namespace musica
   {
     if (grid_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
 
@@ -199,20 +201,20 @@ namespace musica
       void *grid_ptr = InternalGetGrid(grid_map_, grid_name, strlen(grid_name), grid_units, strlen(grid_units), &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return nullptr;
       }
       void *updater_ptr = InternalGetGridUpdaterFromMap(grid_map_, grid_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteGrid(grid_ptr, &error_code);
         return nullptr;
       }
       InternalDeleteGrid(grid_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteGridUpdater(updater_ptr, &error_code);
         return nullptr;
       }
@@ -220,12 +222,12 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
     NoError(error);
@@ -236,7 +238,7 @@ namespace musica
   {
     if (grid_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
 
@@ -248,20 +250,20 @@ namespace musica
       void *grid_ptr = InternalGetGridByIndex(grid_map_, index, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return nullptr;
       }
       void *updater_ptr = InternalGetGridUpdaterFromMap(grid_map_, grid_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteGrid(grid_ptr, &error_code);
         return nullptr;
       }
       InternalDeleteGrid(grid_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteGridUpdater(updater_ptr, &error_code);
         return nullptr;
       }
@@ -269,12 +271,12 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
     NoError(error);
@@ -285,7 +287,7 @@ namespace musica
   {
     if (grid_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), MUSICA_SEVERITY_CRIT, error);
       return 0;
     }
 
@@ -297,18 +299,18 @@ namespace musica
       n_grids = InternalGetNumberOfGrids(grid_map_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return 0;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return 0;
     }
     NoError(error);
@@ -319,7 +321,7 @@ namespace musica
   {
     if (grid_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -329,18 +331,18 @@ namespace musica
       InternalRemoveGrid(grid_map_, grid_name, strlen(grid_name), grid_units, strlen(grid_units), &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -350,7 +352,7 @@ namespace musica
   {
     if (grid_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_GRID_MAP, GetErrorMessage(ERROR_UNALLOCATED_GRID_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -360,18 +362,18 @@ namespace musica
       InternalRemoveGridByIndex(grid_map_, index, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_GRID_MAP_ERROR, GetErrorMessage(INTERNAL_GRID_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);

--- a/src/tuvx/profile.cpp
+++ b/src/tuvx/profile.cpp
@@ -44,7 +44,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -64,7 +64,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
   }
@@ -83,7 +83,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
   }
@@ -175,13 +175,13 @@ namespace musica
     profile_ = InternalCreateProfile(profile_name, strlen(profile_name), units, strlen(units), grid->updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     updater_ = InternalGetProfileUpdater(profile_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       int cleanup_error = 0;
       InternalDeleteProfile(profile_, &cleanup_error);
       return;
@@ -210,6 +210,7 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return "";
     }
@@ -217,7 +218,7 @@ namespace musica
     InternalGetProfileName(updater_, &name, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     std::string result(name.value_, name.size_);
@@ -236,6 +237,7 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return "";
     }
@@ -243,7 +245,7 @@ namespace musica
     InternalGetProfileUnits(updater_, &units, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     std::string result(units.value_, units.size_);
@@ -262,13 +264,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalSetEdgeValues(updater_, edge_values, num_values, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -284,13 +287,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalGetEdgeValues(updater_, edge_values, num_values, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -306,13 +310,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return nullptr;
     }
     double *edge_values_ptr = InternalGetEdgeValuesPointer(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -329,13 +334,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalSetMidpointValues(updater_, midpoint_values, num_values, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -351,13 +357,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalGetMidpointValues(updater_, midpoint_values, num_values, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -373,13 +380,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return nullptr;
     }
     double *midpoint_values_ptr = InternalGetMidpointValuesPointer(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -396,13 +404,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalSetLayerDensities(updater_, layer_densities, num_values, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -418,13 +427,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalGetLayerDensities(updater_, layer_densities, num_values, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -440,13 +450,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return nullptr;
     }
     double *layer_densities_ptr = InternalGetLayerDensitiesPointer(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -463,13 +474,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalSetExoLayerDensity(updater_, exo_layer_density, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -485,13 +497,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
     InternalCalculateExoLayerDensity(updater_, scale_height, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -507,13 +520,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return 0.0;
     }
     double const exo_layer_density = InternalGetExoLayerDensity(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0.0;
     }
     NoError(error);
@@ -530,13 +544,14 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return 0;
     }
     std::size_t const num_sections = InternalProfileGetNumberOfSections(updater_, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     NoError(error);

--- a/src/tuvx/profile_map.cpp
+++ b/src/tuvx/profile_map.cpp
@@ -54,7 +54,8 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
+      return;
     }
     NoError(error);
   }
@@ -104,7 +105,7 @@ namespace musica
     profile_map_ = InternalCreateProfileMap(&error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     owns_profile_map_ = true;
@@ -127,12 +128,12 @@ namespace musica
     DeleteError(error);
     if (profile_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (profile->profile_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE, GetErrorMessage(ERROR_UNALLOCATED_PROFILE), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE, GetErrorMessage(ERROR_UNALLOCATED_PROFILE), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (profile->updater_ == nullptr)
@@ -141,6 +142,7 @@ namespace musica
           MUSICA_ERROR_CATEGORY,
           ERROR_UNALLOCATED_PROFILE_UPDATER,
           GetErrorMessage(ERROR_UNALLOCATED_PROFILE_UPDATER),
+          MUSICA_SEVERITY_CRIT,
           error);
       return;
     }
@@ -152,36 +154,36 @@ namespace musica
       InternalAddProfile(profile_map_, profile->profile_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       InternalDeleteProfileUpdater(profile->updater_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       profile->updater_ = InternalGetProfileUpdaterFromMap(profile_map_, profile->profile_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       InternalDeleteProfile(profile->profile_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       }
       profile->profile_ = nullptr;
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -192,7 +194,7 @@ namespace musica
     DeleteError(error);
     if (profile_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
 
@@ -205,20 +207,20 @@ namespace musica
           profile_map_, profile_name, strlen(profile_name), profile_units, strlen(profile_units), &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return nullptr;
       }
       void *updater_ptr = InternalGetProfileUpdaterFromMap(profile_map_, profile_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteProfile(profile_ptr, &error_code);
         return nullptr;
       }
       InternalDeleteProfile(profile_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteProfileUpdater(updater_ptr, &error_code);
         return nullptr;
       }
@@ -226,12 +228,12 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
     NoError(error);
@@ -243,7 +245,7 @@ namespace musica
     DeleteError(error);
     if (profile_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
 
@@ -255,20 +257,20 @@ namespace musica
       void *profile_ptr = InternalGetProfileByIndex(profile_map_, index, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return nullptr;
       }
       void *updater_ptr = InternalGetProfileUpdaterFromMap(profile_map_, profile_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteProfile(profile_ptr, &error_code);
         return nullptr;
       }
       InternalDeleteProfile(profile_ptr, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteProfileUpdater(updater_ptr, &error_code);
         return nullptr;
       }
@@ -276,12 +278,12 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
     NoError(error);
@@ -293,7 +295,7 @@ namespace musica
     DeleteError(error);
     if (profile_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -305,18 +307,18 @@ namespace musica
           profile_map_, profile_name, strlen(profile_name), profile_units, strlen(profile_units), &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -327,7 +329,7 @@ namespace musica
     DeleteError(error);
     if (profile_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -338,18 +340,18 @@ namespace musica
       InternalRemoveProfileByIndex(profile_map_, index, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -360,7 +362,7 @@ namespace musica
     DeleteError(error);
     if (profile_map_ == nullptr)
     {
-      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_PROFILE_MAP, GetErrorMessage(ERROR_UNALLOCATED_PROFILE_MAP), MUSICA_SEVERITY_CRIT, error);
       return 0;
     }
 
@@ -372,18 +374,18 @@ namespace musica
       num_profiles = InternalGetNumberOfProfiles(profile_map_, &error_code);
       if (error_code != 0)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return 0;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_PROFILE_MAP_ERROR, GetErrorMessage(INTERNAL_PROFILE_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return 0;
     }
     NoError(error);

--- a/src/tuvx/radiator.cpp
+++ b/src/tuvx/radiator.cpp
@@ -45,7 +45,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -66,7 +66,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
   }
@@ -179,14 +179,14 @@ namespace musica
         radiator_name, strlen(radiator_name), height_grid->updater_, wavelength_grid->updater_, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     updater_ = InternalGetRadiatorUpdater(radiator_, &error_code);
     if (error_code != ERROR_NONE)
     {
       InternalDeleteRadiator(radiator_, &error_code);
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -210,14 +210,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     String name;
     InternalGetRadiatorName(updater_, &name, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return "";
     }
     std::string result(name.value_, name.size_);
@@ -236,13 +236,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalSetOpticalDepths(updater_, optical_depths, num_vertical_layers, num_wavelength_bins, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -258,13 +258,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalGetOpticalDepths(updater_, optical_depths, num_vertical_layers, num_wavelength_bins, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -277,13 +277,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     double *optical_depths_ptr = InternalGetOpticalDepthsPointer(updater_, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -300,14 +300,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalSetSingleScatteringAlbedos(
         updater_, single_scattering_albedos, num_vertical_layers, num_wavelength_bins, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -323,14 +323,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalGetSingleScatteringAlbedos(
         updater_, single_scattering_albedos, num_vertical_layers, num_wavelength_bins, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -343,13 +343,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     double *single_scattering_albedos_ptr = InternalGetSingleScatteringAlbedosPointer(updater_, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -367,14 +367,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalSetAsymmetryFactors(
         updater_, asymmetry_factors, num_vertical_layers, num_wavelength_bins, num_streams, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -391,14 +391,14 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     InternalGetAsymmetryFactors(
         updater_, asymmetry_factors, num_vertical_layers, num_wavelength_bins, num_streams, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -411,13 +411,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     double *asymmetry_factors_ptr = InternalGetAsymmetryFactorsPointer(updater_, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     NoError(error);
@@ -431,13 +431,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     std::size_t num_height_sections = InternalGetRadiatorNumberOfHeightSections(updater_, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     NoError(error);
@@ -451,13 +451,13 @@ namespace musica
     if (updater_ == nullptr)
     {
       error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     std::size_t num_wavelength_sections = InternalGetRadiatorNumberOfWavelengthSections(updater_, &error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     NoError(error);

--- a/src/tuvx/radiator_map.cpp
+++ b/src/tuvx/radiator_map.cpp
@@ -53,7 +53,7 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     NoError(error);
@@ -103,7 +103,8 @@ namespace musica
     radiator_map_ = InternalCreateRadiatorMap(&error_code);
     if (error_code != ERROR_NONE)
     {
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
+      return;
     }
     owns_radiator_map_ = true;
     NoError(error);
@@ -125,20 +126,17 @@ namespace musica
     int error_code = ERROR_NONE;
     if (radiator_map_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_MAP;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_MAP, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (radiator->radiator_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (radiator->updater_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_UPDATER;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_UPDATER, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_UPDATER), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -147,37 +145,38 @@ namespace musica
       InternalAddRadiator(radiator_map_, radiator->radiator_, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       InternalDeleteRadiatorUpdater(radiator->updater_, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       radiator->updater_ = InternalGetRadiatorUpdaterFromMap(radiator_map_, radiator->radiator_, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       InternalDeleteRadiator(radiator->radiator_, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
       radiator->radiator_ = nullptr;
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
+      return;
     }
     catch (...)
     {
-      error_code = INTERNAL_RADIATOR_MAP_ERROR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_RADIATOR_MAP_ERROR, GetErrorMessage(INTERNAL_RADIATOR_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
+      return;
     }
     NoError(error);
   }
@@ -188,8 +187,7 @@ namespace musica
     DeleteError(error);
     if (radiator_map_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_MAP;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_MAP, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_MAP), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
 
@@ -200,20 +198,20 @@ namespace musica
       void *radiator_ptr = InternalGetRadiator(radiator_map_, radiator_name, strlen(radiator_name), &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return nullptr;
       }
       void *updater_ptr = InternalGetRadiatorUpdaterFromMap(radiator_map_, radiator_ptr, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteRadiator(radiator_ptr, &error_code);
         return nullptr;
       }
       InternalDeleteRadiator(radiator_ptr, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteRadiatorUpdater(updater_ptr, &error_code);
         return nullptr;
       }
@@ -221,12 +219,13 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
+      return nullptr;
     }
     catch (...)
     {
-      error_code = INTERNAL_RADIATOR_MAP_ERROR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_RADIATOR_MAP_ERROR, GetErrorMessage(INTERNAL_RADIATOR_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
+      return nullptr;
     }
     NoError(error);
     return radiator;
@@ -238,8 +237,7 @@ namespace musica
     DeleteError(error);
     if (radiator_map_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_MAP;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_MAP, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_MAP), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
 
@@ -250,20 +248,20 @@ namespace musica
       void *radiator_ptr = InternalGetRadiatorByIndex(radiator_map_, index, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return nullptr;
       }
       void *updater_ptr = InternalGetRadiatorUpdaterFromMap(radiator_map_, radiator_ptr, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteRadiator(radiator_ptr, &error_code);
         return nullptr;
       }
       InternalDeleteRadiator(radiator_ptr, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         InternalDeleteRadiatorUpdater(updater_ptr, &error_code);
         return nullptr;
       }
@@ -271,13 +269,12 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return nullptr;
     }
     catch (...)
     {
-      error_code = INTERNAL_RADIATOR_MAP_ERROR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_RADIATOR_MAP_ERROR, GetErrorMessage(INTERNAL_RADIATOR_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return nullptr;
     }
     NoError(error);
@@ -290,8 +287,7 @@ namespace musica
     int error_code = ERROR_NONE;
     if (radiator_map_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_MAP;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_MAP, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -300,19 +296,18 @@ namespace musica
       InternalRemoveRadiator(radiator_map_, radiator_name, strlen(radiator_name), &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      error_code = INTERNAL_RADIATOR_MAP_ERROR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_RADIATOR_MAP_ERROR, GetErrorMessage(INTERNAL_RADIATOR_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -324,8 +319,7 @@ namespace musica
     DeleteError(error);
     if (radiator_map_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_MAP;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_MAP, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_MAP), MUSICA_SEVERITY_CRIT, error);
       return;
     }
 
@@ -334,19 +328,18 @@ namespace musica
       InternalRemoveRadiatorByIndex(radiator_map_, index, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      error_code = INTERNAL_RADIATOR_MAP_ERROR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_RADIATOR_MAP_ERROR, GetErrorMessage(INTERNAL_RADIATOR_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return;
     }
     NoError(error);
@@ -358,8 +351,7 @@ namespace musica
     int error_code = ERROR_NONE;
     if (radiator_map_ == nullptr)
     {
-      error_code = ERROR_UNALLOCATED_RADIATOR_MAP;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, ERROR_UNALLOCATED_RADIATOR_MAP, GetErrorMessage(ERROR_UNALLOCATED_RADIATOR_MAP), MUSICA_SEVERITY_CRIT, error);
       return 0;
     }
 
@@ -370,19 +362,18 @@ namespace musica
       num_radiators = InternalGetNumberOfRadiators(radiator_map_, &error_code);
       if (error_code != ERROR_NONE)
       {
-        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+        ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERR, error);
         return 0;
       }
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return 0;
     }
     catch (...)
     {
-      error_code = INTERNAL_RADIATOR_MAP_ERROR;
-      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), error);
+      ToError(MUSICA_ERROR_CATEGORY, INTERNAL_RADIATOR_MAP_ERROR, GetErrorMessage(INTERNAL_RADIATOR_MAP_ERROR), MUSICA_SEVERITY_CRIT, error);
       return 0;
     }
     NoError(error);

--- a/src/tuvx/tuvx.cpp
+++ b/src/tuvx/tuvx.cpp
@@ -36,7 +36,7 @@ namespace musica
       // check that the file exists
       if (!std::filesystem::exists(config_path))
       {
-        ToError(MUSICA_ERROR_CATEGORY, 1, "Config file does not exist", error);
+        ToError(MUSICA_ERROR_CATEGORY, 1, "Config file does not exist", MUSICA_SEVERITY_ERR, error);
         return;
       }
 
@@ -51,7 +51,7 @@ namespace musica
           &parsing_status);
       if (parsing_status == 1)
       {
-        ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create tuvx instance", error);
+        ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create tuvx instance", MUSICA_SEVERITY_CRIT, error);
       }
       else
       {
@@ -60,11 +60,11 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create tuvx instance", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create tuvx instance", MUSICA_SEVERITY_CRIT, error);
     }
   }
 
@@ -94,7 +94,7 @@ namespace musica
           &error_code);
       if (error_code != 0 || tuvx_ == nullptr)
       {
-        ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create TUV-x instance from config string", error);
+        ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create TUV-x instance from config string", MUSICA_SEVERITY_CRIT, error);
       }
       else
       {
@@ -103,11 +103,11 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create TUV-x instance from config string", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to create TUV-x instance from config string", MUSICA_SEVERITY_CRIT, error);
     }
   }
 
@@ -118,7 +118,7 @@ namespace musica
     GridMap *grid_map = new GridMap(InternalGetGridMap(tuvx_, &error_code));
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get grid map", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get grid map", MUSICA_SEVERITY_CRIT, error);
     }
     else
     {
@@ -133,7 +133,7 @@ namespace musica
     ProfileMap *profile_map = new ProfileMap(InternalGetProfileMap(tuvx_, &error_code));
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get profile map", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get profile map", MUSICA_SEVERITY_CRIT, error);
     }
     else
     {
@@ -148,7 +148,7 @@ namespace musica
     RadiatorMap *radiator_map = new RadiatorMap(InternalGetRadiatorMap(tuvx_, &error_code));
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get radiator map", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get radiator map", MUSICA_SEVERITY_CRIT, error);
     }
     else
     {
@@ -163,7 +163,7 @@ namespace musica
     InternalGetPhotolysisRateConstantsOrdering(tuvx_, mappings, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get photolysis rate constants ordering", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get photolysis rate constants ordering", MUSICA_SEVERITY_ERR, error);
     }
     else
     {
@@ -177,7 +177,7 @@ namespace musica
     InternalGetHeatingRatesOrdering(tuvx_, mappings, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get heating rates ordering", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get heating rates ordering", MUSICA_SEVERITY_ERR, error);
     }
     else
     {
@@ -191,7 +191,7 @@ namespace musica
     InternalGetDoseRatesOrdering(tuvx_, mappings, &error_code);
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get dose rates ordering", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get dose rates ordering", MUSICA_SEVERITY_ERR, error);
     }
     else
     {
@@ -228,17 +228,17 @@ namespace musica
     }
     catch (const std::system_error &e)
     {
-      ToError(e, error);
+      ToError(e, MUSICA_SEVERITY_ERR, error);
       return;
     }
     catch (...)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to run TUV-x", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to run TUV-x", MUSICA_SEVERITY_CRIT, error);
       return;
     }
     if (error_code != 0)
     {
-      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to run TUV-x", error);
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to run TUV-x", MUSICA_SEVERITY_CRIT, error);
       return;
     }
   }

--- a/src/tuvx/tuvx_c_interface.cpp
+++ b/src/tuvx/tuvx_c_interface.cpp
@@ -32,7 +32,8 @@ namespace musica
       }
       catch (const std::system_error &e)
       {
-        ToError(e, error);
+        ToError(e, MUSICA_SEVERITY_ERR, error);
+        return;
       }
       NoError(error);
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,25 +29,45 @@ namespace musica
 
   void NoError(Error* error)
   {
-    ToError("", 0, "Success", error);
+    DeleteError(error);
+    error->severity_ = MUSICA_SEVERITY_OK;
+    error->code_ = 0;
+    CreateString("", &error->category_);
+    CreateString("Success", &error->message_);
   }
 
-  void ToError(const char* category, int code, Error* error)
+  void ToError(const char* category, int code, int severity, Error* error)
   {
-    ToError(category, code, "", error);
+    ToError(category, code, "", severity, error);
   }
 
-  void ToError(const char* category, int code, const char* message, Error* error)
+  void ToError(const char* category, int code, const char* message, int severity, Error* error)
   {
+    DeleteError(error);
+    error->severity_ = severity;
     error->code_ = code;
     CreateString(category, &error->category_);
     CreateString(message, &error->message_);
   }
 
-  void ToError(const std::system_error& e, Error* error)
+  void ToError(const std::system_error& e, int severity, Error* error)
   {
-    ToError(e.code().category().name(), e.code().value(), e.what(), error);
+    ToError(e.code().category().name(), e.code().value(), e.what(), severity, error);
   }
+
+#ifdef MUSICA_USE_MICM
+  void ToError(const micm::MicmException& e, Error* error)
+  {
+    int severity;
+    switch (e.severity_)
+    {
+      case micm::MicmSeverity::Warning:  severity = MUSICA_SEVERITY_WARN; break;
+      case micm::MicmSeverity::Critical: severity = MUSICA_SEVERITY_CRIT; break;
+      default:                           severity = MUSICA_SEVERITY_ERR;  break;
+    }
+    ToError(e.category_, e.code_, e.what(), severity, error);
+  }
+#endif
 
   bool IsSuccess(const Error& error)
   {
@@ -92,7 +112,7 @@ namespace musica
     catch (const std::exception& e)
     {
       configuration->data_ = nullptr;
-      ToError(MUSICA_ERROR_CATEGORY, MUSICA_PARSE_PARSING_FAILED, e.what(), error);
+      ToError(MUSICA_ERROR_CATEGORY, MUSICA_PARSE_PARSING_FAILED, e.what(), MUSICA_SEVERITY_ERR, error);
     }
   }
 
@@ -107,7 +127,7 @@ namespace musica
     catch (const std::exception& e)
     {
       configuration->data_ = nullptr;
-      ToError(MUSICA_ERROR_CATEGORY, MUSICA_PARSE_PARSING_FAILED, e.what(), error);
+      ToError(MUSICA_ERROR_CATEGORY, MUSICA_PARSE_PARSING_FAILED, e.what(), MUSICA_SEVERITY_ERR, error);
     }
   }
 
@@ -147,7 +167,7 @@ namespace musica
       }
     }
     std::string const msg = "Mapping element '" + std::string(name) + "' not found";
-    ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_MAPPING_NOT_FOUND, msg.c_str(), error);
+    ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_MAPPING_NOT_FOUND, msg.c_str(), MUSICA_SEVERITY_ERR, error);
     return 0;
   }
 
@@ -182,7 +202,7 @@ namespace musica
     index_mapping->size_ = 0;
     if (map_options == IndexMappingOptions::UndefinedMapping)
     {
-      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_MAPPING_OPTIONS_UNDEFINED, "Mapping options are undefined", error);
+      ToError(MUSICA_ERROR_CATEGORY, MUSICA_ERROR_CODE_MAPPING_OPTIONS_UNDEFINED, "Mapping options are undefined", MUSICA_SEVERITY_ERR, error);
       return;
     }
     for (std::size_t i = 0; i < size; i++)


### PR DESCRIPTION
Partially closes #795, will do the subissues as separate PRs to update fortran, python interfaces. At this point, we don't seem to have much error handling in the javascript and julia interfaces (yet) so nothing to do there. This will allow us to better comply with MPAS log population

Adds MUSICA_SEVERITY_OK/WARN/ERR/CRIT severity levels to the Error struct and all ToError() overloads. Updates MICM dependency to 032b30e to use MicmException, with a shared ToError(MicmException) overload that maps MicmSeverity to musica severity levels.