### PR TITLE
installing with rpath

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -73,7 +73,7 @@ endif()
 
 if (MUSICA_ENABLE_MICM AND MUSICA_BUILD_C_CXX_INTERFACE AND NOT MUSICA_USE_PREBUILT)
   set_git_default(MICM_GIT_REPOSITORY https://github.com/NCAR/micm.git)
-  set_git_default(MICM_GIT_TAG 67f43700102d1e38640b8346dad359e372602dd5)
+  set_git_default(MICM_GIT_TAG f4a9e6843018aa2aafa8af4bc818a03552814897)
 
   FetchContent_Declare(micm
       GIT_REPOSITORY ${MICM_GIT_REPOSITORY}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 FROM fedora:latest
 
-ARG MUSICA_GIT_TAG=main
 ARG BUILD_TYPE=Debug
 
 RUN dnf -y update \
@@ -28,9 +27,8 @@ RUN cd musica \
              -B build \
              -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
              -D MUSICA_BUILD_FORTRAN_INTERFACE=ON \
-             -D MUSICA_GIT_TAG=${MUSICA_GIT_TAG} \
     && cd build \
-    && make install -j 8
+    && make install -j 1
     
 # Try building a simple application
 RUN cd musica/build \

--- a/fortran/micm/micm.F90
+++ b/fortran/micm/micm.F90
@@ -24,6 +24,7 @@ module musica_micm
     integer(c_int64_t) :: rejected_ = 0_c_int64_t
     integer(c_int64_t) :: decompositions_ = 0_c_int64_t
     integer(c_int64_t) :: solves_ = 0_c_int64_t
+    integer(c_int64_t) :: constraint_init_iterations_ = 0_c_int64_t
     real(c_double)     :: final_time_ = 0._c_double
   end type solver_stats_t_c
 
@@ -239,6 +240,7 @@ module musica_micm
     integer(int64) :: rejected_
     integer(int64) :: decompositions_
     integer(int64) :: solves_
+    integer(int64) :: constraint_init_iterations_
     real           :: final_time_
   contains
     procedure :: function_calls => solver_stats_t_function_calls
@@ -248,6 +250,7 @@ module musica_micm
     procedure :: rejected => solver_stats_t_rejected
     procedure :: decompositions => solver_stats_t_decompositions
     procedure :: solves => solver_stats_t_solves
+    procedure :: constraint_init_iterations => solver_stats_t_constraint_init_iterations
     procedure :: final_time => solver_stats_t_final_time
   end type solver_stats_t
 
@@ -365,6 +368,7 @@ contains
     new_solver_stats%rejected_ = c_solver_stats%rejected_
     new_solver_stats%decompositions_ = c_solver_stats%decompositions_
     new_solver_stats%solves_ = c_solver_stats%solves_
+    new_solver_stats%constraint_init_iterations_ = c_solver_stats%constraint_init_iterations_
     new_solver_stats%final_time_ = real( c_solver_stats%final_time_ )
   end function solver_stats_t_constructor
 
@@ -430,6 +434,15 @@ contains
 
     solves = this%solves_
   end function solver_stats_t_solves
+
+  !> Get the number of constraint initialization iterations
+  function solver_stats_t_constraint_init_iterations( this ) result( constraint_init_iterations )
+    use iso_fortran_env, only: int64
+    class(solver_stats_t), intent(in) :: this
+    integer(int64)                    :: constraint_init_iterations
+
+    constraint_init_iterations = this%constraint_init_iterations_
+  end function solver_stats_t_constraint_init_iterations
 
   !> Get the final time the solver iterated to
   function solver_stats_t_final_time( this ) result( final_time )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,7 @@ set_target_properties(musica PROPERTIES
 if(APPLE)
   set_target_properties(musica PROPERTIES
     INSTALL_RPATH "@loader_path"
+    BUILD_WITH_INSTALL_RPATH TRUE
   )
 elseif(UNIX)
   set_target_properties(musica PROPERTIES

--- a/src/micm/v0_parse.cpp
+++ b/src/micm/v0_parse.cpp
@@ -105,7 +105,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::ArrheniusRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -132,7 +132,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(alkoxy_products)
-                                        .SetRateConstant(micm::BranchedRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
 
@@ -141,7 +141,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(nitrate_products)
-                                        .SetRateConstant(micm::BranchedRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -162,7 +162,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::UserDefinedRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -204,7 +204,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::SurfaceRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -231,7 +231,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TroeRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -258,7 +258,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TernaryChemicalActivationRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -280,7 +280,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TunnelingRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }

--- a/src/micm/v1_parse.cpp
+++ b/src/micm/v1_parse.cpp
@@ -135,7 +135,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::ArrheniusRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -163,7 +163,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(alkoxy_products)
-                                        .SetRateConstant(micm::BranchedRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
 
@@ -172,7 +172,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(nitrate_products)
-                                        .SetRateConstant(micm::BranchedRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -213,7 +213,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::SurfaceRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -240,7 +240,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TroeRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -267,7 +267,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TernaryChemicalActivationRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -289,7 +289,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TunnelingRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -310,11 +310,20 @@ namespace musica
       parameters.C_ = reaction.C;
       parameters.D_ = reaction.D;
       parameters.E_ = reaction.E;
-      parameters.coefficients_ = reaction.taylor_coefficients;
+      if (reaction.taylor_coefficients.size() > micm::TaylorSeriesRateConstantParameters::MAX_COEFFICIENTS)
+      {
+        throw std::system_error(
+            make_error_code(MusicaParseErrc::ParsingFailed),
+            "Number of Taylor series coefficients for reaction '" + reaction.name +
+                "' exceeds the maximum supported (" + std::to_string(micm::TaylorSeriesRateConstantParameters::MAX_COEFFICIENTS) + ").");
+      }
+      std::copy(reaction.taylor_coefficients.begin(),
+                reaction.taylor_coefficients.end(),
+                parameters.coefficients_);
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::TaylorSeriesRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -364,7 +373,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::LambdaRateConstant(params))
+                                        .SetRateConstant(params)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }
@@ -397,7 +406,7 @@ namespace musica
       chemistry.processes.push_back(micm::ChemicalReactionBuilder()
                                         .SetReactants(reactants)
                                         .SetProducts(products)
-                                        .SetRateConstant(micm::UserDefinedRateConstant(parameters))
+                                        .SetRateConstant(parameters)
                                         .SetPhase(chemistry.system.gas_phase_)
                                         .Build());
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -56,14 +56,7 @@ namespace musica
 #ifdef MUSICA_USE_MICM
   void ToError(const micm::MicmException& e, Error* error)
   {
-    int severity;
-    switch (e.severity_)
-    {
-      case micm::MicmSeverity::Warning: severity = MUSICA_SEVERITY_WARNING; break;
-      case micm::MicmSeverity::Critical: severity = MUSICA_SEVERITY_CRITICAL; break;
-      default: severity = MUSICA_SEVERITY_ERROR; break;
-    }
-    ToError(e.category_, e.code_, e.what(), severity, error);
+    ToError(e.category_, e.code_, e.what(), MUSICA_SEVERITY_ERROR, error);
   }
 #endif
 


### PR DESCRIPTION
- add rpath for macOS, apparently necessary to work with uv
- add `constraint_init_iterations_` to fortran now that we are using a more updated micm version
- with the new micm verison, all rate constant classes were removed so we only need to pass paramteres