### PR TITLE
Add config string constructor, species properties to julia interface

### DIFF
--- a/julia/bindings/musica_julia.cpp
+++ b/julia/bindings/musica_julia.cpp
@@ -170,6 +170,24 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
       });
 
   mod.method(
+      "cpp_create_solver_from_string",
+      [](const std::string& config_string, int solver_type)
+      {
+        musica::Error error;
+        musica::MICM* micm =
+            musica::CreateMicmFromConfigString(config_string.c_str(), static_cast<musica::MICMSolver>(solver_type), &error);
+        if (!musica::IsSuccess(error))
+        {
+          std::string msg = "Error creating solver: " + std::string(error.message_.value_);
+          musica::DeleteError(&error);
+          throw std::runtime_error(msg);
+        }
+        if (!micm)
+          throw std::runtime_error("Solver creation returned null pointer");
+        return micm;
+      });
+
+  mod.method(
       "cpp_delete_solver",
       [](musica::MICM* micm)
       {

--- a/julia/bindings/musica_julia.cpp
+++ b/julia/bindings/musica_julia.cpp
@@ -3,14 +3,15 @@
 
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/stl.hpp"
-#include "musica/micm/cuda_availability.hpp"
-#include "musica/micm/micm.hpp"
-#include "musica/micm/micm_c_interface.hpp"
-#include "musica/micm/solver_parameters.hpp"
-#include "musica/micm/state.hpp"
-#include "musica/micm/state_c_interface.hpp"
-#include "musica/version.hpp"
+#include <musica/micm/cuda_availability.hpp>
+#include <musica/micm/micm.hpp>
+#include <musica/micm/micm_c_interface.hpp>
+#include <musica/micm/solver_parameters.hpp>
+#include <musica/micm/state.hpp>
+#include <musica/micm/state_c_interface.hpp>
+#include <musica/version.hpp>
 
+#include <micm/version.hpp>
 #include <micm/solver/solver_result.hpp>
 
 #include <algorithm>
@@ -46,7 +47,8 @@ namespace
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
 {
   // ── Version ──────────────────────────────────────────────────────────
-  mod.method("get_version", []() { return std::string(musica::GetMusicaVersion()); });
+  mod.method("get_musica_version", []() { return std::string(musica::GetMusicaVersion()); });
+  mod.method("get_micm_version", []() { return std::string(micm::GetMicmVersion()); });
 
   // ── MICMSolver enum constants ────────────────────────────────────────
   mod.set_const("SOLVER_ROSENBROCK", static_cast<int>(musica::MICMSolver::Rosenbrock));
@@ -403,6 +405,39 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         for (const auto& [_, idx] : entries)
           indices.push_back(static_cast<int64_t>(idx));
         return indices;
+      });
+
+  // ── Species properties ──────────────────────────────────────────────
+  mod.method(
+      "cpp_get_species_property_double",
+      [](musica::MICM* micm, const std::string& species_name, const std::string& property_name)
+      {
+        check_micm_not_null(micm);
+        return micm->GetSpeciesProperty<double>(species_name, property_name);
+      });
+
+  mod.method(
+      "cpp_get_species_property_int",
+      [](musica::MICM* micm, const std::string& species_name, const std::string& property_name)
+      {
+        check_micm_not_null(micm);
+        return static_cast<int64_t>(micm->GetSpeciesProperty<int>(species_name, property_name));
+      });
+
+  mod.method(
+      "cpp_get_species_property_bool",
+      [](musica::MICM* micm, const std::string& species_name, const std::string& property_name)
+      {
+        check_micm_not_null(micm);
+        return micm->GetSpeciesProperty<bool>(species_name, property_name);
+      });
+
+  mod.method(
+      "cpp_get_species_property_string",
+      [](musica::MICM* micm, const std::string& species_name, const std::string& property_name)
+      {
+        check_micm_not_null(micm);
+        return micm->GetSpeciesProperty<std::string>(species_name, property_name);
       });
 
   // ── Solver parameters ───────────────────────────────────────────────

--- a/julia/src/Musica.jl
+++ b/julia/src/Musica.jl
@@ -32,7 +32,8 @@ include("micm/state.jl")
 include("micm/micm.jl")
 
 # Version
-export get_version
+export get_musica_version
+export get_micm_version
 
 # Constants
 export AVOGADRO, BOLTZMANN, GAS_CONSTANT
@@ -64,6 +65,7 @@ export set_conditions!, get_conditions
 export set_user_defined_rate_parameters!, get_user_defined_rate_parameters
 export get_species_ordering, get_user_defined_rate_parameters_ordering
 export set_solver_parameters!, get_solver_parameters
+export get_species_property
 export solver_type
 
 end # module Musica

--- a/julia/src/micm/micm.jl
+++ b/julia/src/micm/micm.jl
@@ -8,9 +8,13 @@ Wrapper around the C++ MICM chemical kinetics solver.
 
 # Constructor
 
-    MICM(; config_path, solver_type=RosenbrockStandardOrder, solver_parameters=nothing)
+    MICM(; config_path=nothing, config_string=nothing,
+           solver_type=RosenbrockStandardOrder, solver_parameters=nothing)
 
-- `config_path::String`: Path to configuration file or directory
+Provide exactly one of `config_path` or `config_string`.
+
+- `config_path::String`: Path to a configuration file or directory
+- `config_string::String`: A JSON or YAML string holding a valid mechanism configuration
 - `solver_type::SolverType`: Type of solver to use
 - `solver_parameters`: Optional `RosenbrockSolverParameters` or `BackwardEulerSolverParameters`
 """
@@ -20,7 +24,8 @@ mutable struct MICM
     _vector_size::Int
 
     function MICM(;
-        config_path::String,
+        config_path::Union{AbstractString,Nothing} = nothing,
+        config_string::Union{AbstractString,Nothing} = nothing,
         solver_type::SolverType = RosenbrockStandardOrder,
         solver_parameters::Union{
             RosenbrockSolverParameters,
@@ -28,10 +33,18 @@ mutable struct MICM
             Nothing,
         } = nothing,
     )
+        if (config_path === nothing) == (config_string === nothing)
+            error("Provide exactly one of `config_path` or `config_string`")
+        end
+
         vs = Int(cpp_get_vector_size(Int(solver_type)))
         vs > 0 || error("Invalid vector size: $vs")
 
-        ptr = cpp_create_solver(config_path, Int(solver_type))
+        ptr = if config_path !== nothing
+            cpp_create_solver(String(config_path), Int(solver_type))
+        else
+            cpp_create_solver_from_string(String(config_string), Int(solver_type))
+        end
 
         obj = new(ptr, solver_type, vs)
         finalizer(obj) do m

--- a/julia/src/micm/micm.jl
+++ b/julia/src/micm/micm.jl
@@ -72,6 +72,78 @@ function solve!(micm::MICM, state::State, time_step::Real)
 end
 
 """
+    get_species_property(micm::MICM, species_name, property_name, ::Type{T})
+
+Get a property of a chemical species, returned as type `T`.
+
+`T` selects which property kind to read and the return type:
+`Float64`, `Int`, `Bool`, or `String`.
+
+# Examples
+```julia
+mw   = get_species_property(micm, "O3", "molecular weight [kg mol-1]", Float64)
+name = get_species_property(micm, "O3", "__long name", String)
+gas  = get_species_property(micm, "O3", "__is gas", Bool)
+n    = get_species_property(micm, "O3", "__atoms", Int)
+```
+"""
+function get_species_property(
+    micm::MICM,
+    species_name::AbstractString,
+    property_name::AbstractString,
+    ::Type{Float64},
+)
+    return cpp_get_species_property_double(
+        micm._ptr,
+        String(species_name),
+        String(property_name),
+    )
+end
+
+function get_species_property(
+    micm::MICM,
+    species_name::AbstractString,
+    property_name::AbstractString,
+    ::Type{Int},
+)
+    return Int(
+        cpp_get_species_property_int(
+            micm._ptr,
+            String(species_name),
+            String(property_name),
+        ),
+    )
+end
+
+function get_species_property(
+    micm::MICM,
+    species_name::AbstractString,
+    property_name::AbstractString,
+    ::Type{Bool},
+)
+    return cpp_get_species_property_bool(
+        micm._ptr,
+        String(species_name),
+        String(property_name),
+    )
+end
+
+function get_species_property(
+    micm::MICM,
+    species_name::AbstractString,
+    property_name::AbstractString,
+    ::Type{String},
+)
+    return String(
+        cpp_get_species_property_string(
+            micm._ptr,
+            String(species_name),
+            String(property_name),
+        ),
+    )
+end
+
+"""
     set_solver_parameters!(micm::MICM, params::RosenbrockSolverParameters)
     set_solver_parameters!(micm::MICM, params::BackwardEulerSolverParameters)
 

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -330,4 +330,86 @@ using Musica
         @test_throws Exception get_species_property(micm, "bad species", "__atoms", Int)
         @test_throws Exception get_species_property(micm, "O3", "bad property", Float64)
     end
+
+    @testset "MICM from config string" begin
+        # Configure a solver from an in-memory mechanism string (mirrors the
+        # JavaScript MICM.fromConfigString path). A simple A -> B mechanism driven
+        # by a user-defined rate, written as both JSON and YAML.
+        json_mechanism = """
+        {
+            "name": "A to B",
+            "version": "1.0.0",
+            "species": [ { "name": "A" }, { "name": "B" } ],
+            "phases": [
+                { "name": "gas", "species": [ { "name": "A" }, { "name": "B" } ] }
+            ],
+            "reactions": [
+                {
+                    "type": "USER_DEFINED",
+                    "name": "loss",
+                    "gas phase": "gas",
+                    "reactants": [ { "species name": "A", "coefficient": 1.0 } ],
+                    "products": [ { "species name": "B", "coefficient": 1.0 } ]
+                }
+            ]
+        }
+        """
+
+        yaml_mechanism = """
+        name: A to B
+        version: "1.0.0"
+        species:
+          - name: A
+          - name: B
+        phases:
+          - name: gas
+            species:
+              - name: A
+              - name: B
+        reactions:
+          - type: USER_DEFINED
+            name: loss
+            gas phase: gas
+            reactants:
+              - species name: A
+                coefficient: 1.0
+            products:
+              - species name: B
+                coefficient: 1.0
+        """
+
+        for config_string in (json_mechanism, yaml_mechanism)
+            micm = MICM(config_string = config_string)
+            @test solver_type(micm) == RosenbrockStandardOrder
+
+            state = create_state(micm)
+            ordering = get_species_ordering(state)
+            @test haskey(ordering, "A")
+            @test haskey(ordering, "B")
+
+            rate_ordering = get_user_defined_rate_parameters_ordering(state)
+            @test haskey(rate_ordering, "USER.loss")
+
+            set_concentrations!(state, Dict{String,Any}("A" => 1.0, "B" => 0.0))
+            set_conditions!(state, temperatures = 298.0, pressures = 101325.0)
+            set_user_defined_rate_parameters!(state, Dict{String,Any}("USER.loss" => 0.01))
+
+            result = solve!(micm, state, 60.0)
+            @test result.state == Converged
+
+            concs = get_concentrations(state)
+            @test concs["A"][1] < 1.0   # A is consumed
+            @test concs["B"][1] > 0.0   # B is produced
+        end
+
+        # Exactly one of config_path / config_string must be provided.
+        @test_throws ErrorException MICM()
+        @test_throws ErrorException MICM(
+            config_path = config_path,
+            config_string = json_mechanism,
+        )
+
+        # An invalid mechanism string should raise.
+        @test_throws Exception MICM(config_string = "not a valid mechanism")
+    end
 end

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -3,12 +3,17 @@ using Musica
 
 @testset "Musica.jl Tests" begin
     @testset "Version" begin
-        version = Musica.get_version()
-        @test version isa AbstractString
-        @test !isempty(version)
+        musica_version = Musica.get_musica_version()
+        micm_version = Musica.get_micm_version()
+        @test musica_version isa AbstractString
+        @test micm_version isa AbstractString
+        @test !isempty(musica_version)
+        @test !isempty(micm_version)
         # Test version format (semantic versioning: X.Y.Z or X.Y.Z.W)
-        @test occursin(r"^\d+\.\d+\.\d+", version)
-        println("MUSICA version: ", version)
+        @test occursin(r"^\d+\.\d+\.\d+", musica_version)
+        @test occursin(r"^\d+\.\d+\.\d+", micm_version)
+        println("MUSICA version: ", musica_version)
+        println("MICM version: ", micm_version)
     end
 
     @testset "CUDA availability" begin
@@ -308,5 +313,21 @@ using Musica
         retrieved = get_solver_parameters(micm)
         @test retrieved.relative_tolerance ≈ 1e-4
         @test retrieved.max_number_of_steps == 20
+    end
+
+    @testset "Species properties" begin
+        # Mirrors the C++ GetSpeciesProperty test (src/test/unit/micm/micm_c_api.cpp),
+        # using the v1 chapman example mechanism. O3 defines one property per type.
+        v1_config_path = joinpath(@__DIR__, "..", "..", "configs", "v1", "chapman", "config.json")
+        micm = MICM(config_path = v1_config_path)
+
+        @test get_species_property(micm, "O3", "__long name", String) == "ozone"
+        @test get_species_property(micm, "O3", "molecular weight [kg mol-1]", Float64) ≈ 0.048
+        @test get_species_property(micm, "O3", "__atoms", Int) == 3
+        @test get_species_property(micm, "O3", "__do advect", Bool) == true
+
+        # Unknown species and unknown property should raise.
+        @test_throws Exception get_species_property(micm, "bad species", "__atoms", Int)
+        @test_throws Exception get_species_property(micm, "O3", "bad property", Float64)
     end
 end


### PR DESCRIPTION
Closes #902 

- allows species properties to be returned, which will be needed when converting from mixing ratio to molar concentration
- allows a mechanism to be built from a string config
- also allows getting both the micm and musica versions, changes the name of `get_version` to `get_musica_version`
- adds tests for all of these