### PR TITLE
Add Julia in-code mechanism configuration interface

### DIFF
--- a/docs/source/api/julia.rst
+++ b/docs/source/api/julia.rst
@@ -425,6 +425,90 @@ State Functions
 
    Return the mapping of user-defined rate parameter names to their 0-based indices.
 
+Mechanism Configuration
+-----------------------
+
+The ``Musica.MechanismConfiguration`` submodule builds version 1 mechanism
+configurations in code and serializes them to a string for ``MICM(config_string = ...)``.
+See the :ref:`user guide <julia-user-guide>` for a full example.
+
+Data Types
+^^^^^^^^^^
+
+.. type:: Species
+
+   A chemical species.
+
+   .. code-block:: julia
+
+      Species(; name, molecular_weight=nothing, constant_concentration=nothing,
+                constant_mixing_ratio=nothing, is_third_body=nothing,
+                other_properties=Dict())
+
+   Optional fields left as ``nothing`` are omitted from the output. Keys in
+   ``other_properties`` are serialized with a ``__`` prefix.
+
+.. type:: PhaseSpecies
+
+   A species reference within a phase, optionally carrying a diffusion coefficient.
+
+   .. code-block:: julia
+
+      PhaseSpecies(; name, diffusion_coefficient=nothing, other_properties=Dict())
+
+.. type:: Phase
+
+   A phase grouping species. Members may be a ``Species``, a ``PhaseSpecies``, or a
+   bare species-name ``String``.
+
+   .. code-block:: julia
+
+      Phase(; name, species, other_properties=Dict())
+
+.. type:: ReactionComponent
+
+   A reactant or product entry.
+
+   .. code-block:: julia
+
+      ReactionComponent(; species_name, coefficient=1.0, other_properties=Dict())
+
+Reaction Types
+^^^^^^^^^^^^^^
+
+Each reaction type is constructed with keyword arguments and supports ``name``,
+``gas_phase``, and ``other_properties``:
+``Arrhenius``, ``Branched``, ``Emission``, ``FirstOrderLoss``, ``Photolysis``,
+``Surface``, ``TaylorSeries``, ``Troe``, ``TernaryChemicalActivation``,
+``Tunneling``, and ``UserDefined``.
+
+Mechanism and Serialization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. type:: Mechanism
+
+   A complete mechanism configuration.
+
+   .. code-block:: julia
+
+      Mechanism(; name, version="1.0.0", species, phases, reactions)
+
+.. function:: to_json_string(m::Mechanism) -> String
+
+   Serialize the mechanism to a JSON string.
+
+.. function:: to_yaml_string(m::Mechanism) -> String
+
+   Serialize the mechanism to a YAML string.
+
+.. function:: to_string(m::Mechanism; format=:json) -> String
+
+   Serialize the mechanism to a string. ``format`` may be ``:json`` or ``:yaml``.
+
+.. function:: to_dict(m::Mechanism) -> Dict{String,Any}
+
+   Build the nested dictionary representation in the version 1 schema.
+
 Multi-Grid-Cell Example
 -----------------------
 

--- a/docs/source/user_guide/julia/index.rst
+++ b/docs/source/user_guide/julia/index.rst
@@ -19,6 +19,83 @@ directory. Use the bundled ``configs/v0/analytical`` example or provide your own
 
    solver = MICM("configs/v0/analytical", SolverType.rosenbrock_standard_order)
 
+Building a Mechanism in Code
+----------------------------
+
+Instead of loading a configuration file, you can assemble a version 1 mechanism
+configuration directly in Julia using the ``Musica.MechanismConfiguration``
+submodule, then serialize it to a JSON or YAML string and hand it to ``MICM``. This
+mirrors the Python and JavaScript interfaces.
+
+.. code-block:: julia
+
+   using Musica
+   using Musica.MechanismConfiguration
+
+   # Species (molecular weight in kg mol-1). Arbitrary extra properties may be
+   # supplied via `other_properties`; they are serialized with a `__` prefix.
+   A  = Species(name = "A",  molecular_weight = 0.029,
+                other_properties = Dict("long name" => "atom_A"))
+   B  = Species(name = "B",  molecular_weight = 0.029)
+   AB = Species(name = "AB", molecular_weight = 0.058)
+
+   # A phase groups species. Members may be a `Species`, a `PhaseSpecies`
+   # (carrying a diffusion coefficient), or a bare species-name string.
+   gas = Phase(name = "gas", species = [A, B, AB])
+
+   # Reactions reference species by name through `ReactionComponent`s.
+   forward = UserDefined(
+       name = "AB_loss",
+       gas_phase = "gas",
+       scaling_factor = 2.0e-3,
+       reactants = [ReactionComponent(species_name = "AB")],
+       products  = [ReactionComponent(species_name = "A"),
+                    ReactionComponent(species_name = "B")],
+   )
+   photo = Photolysis(
+       name = "jAB",
+       gas_phase = "gas",
+       reactants = [ReactionComponent(species_name = "AB")],
+       products  = [ReactionComponent(species_name = "A"),
+                    ReactionComponent(species_name = "B")],
+   )
+
+   mech = Mechanism(
+       name = "ABBA", version = "1.0.0",
+       species = [A, B, AB], phases = [gas], reactions = [forward, photo],
+   )
+
+   # Serialize to a string (JSON or YAML) ...
+   json_string = to_json_string(mech)
+   yaml_string = to_yaml_string(mech)
+   # ... or `to_string(mech; format = :json)` / `:yaml`.
+
+   # ... and build a solver directly from it.
+   micm  = MICM(config_string = json_string)
+   state = create_state(micm)
+
+The available reaction types are ``Arrhenius``, ``Branched``, ``Emission``,
+``FirstOrderLoss``, ``Photolysis``, ``Surface``, ``TaylorSeries``, ``Troe``,
+``TernaryChemicalActivation``, ``Tunneling``, and ``UserDefined``.
+
+Species properties stored in the mechanism can be read back from the solver. For
+example, to convert a mass mixing ratio (kg kg⁻¹) to a molar concentration
+(mol m⁻³) using a species' molecular weight and an ideal-gas air density:
+
+.. code-block:: julia
+
+   temperature = 298.0      # K
+   pressure    = 101325.0   # Pa
+   M_air       = 0.0289647  # kg mol-1 (dry air)
+
+   # Air density from the ideal gas law: molar [mol m-3] -> mass [kg m-3]
+   molar_density    = pressure / (GAS_CONSTANT * temperature)  # mol m-3
+   air_mass_density = molar_density * M_air                    # kg m-3
+
+   mw_AB             = get_species_property(micm, "AB", "molecular weight [kg mol-1]", Float64)
+   mass_mixing_ratio = 0.6  # kg AB per kg air
+   conc_AB           = mass_mixing_ratio * air_mass_density / mw_AB  # mol m-3
+
 Creating a Solver
 -----------------
 

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -5,10 +5,14 @@ version = "0.15.0"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Musica_jll = "f5e5459d-1a87-5129-97d9-bab22ca84fbb"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 CxxWrap = "0.17"
+JSON = "0.21, 1"
+YAML = "0.4"
 julia = "1.10 - 1.12"
 Musica_jll = ">= 0.14"
 

--- a/julia/src/Musica.jl
+++ b/julia/src/Musica.jl
@@ -31,6 +31,10 @@ include("micm/utils.jl")
 include("micm/state.jl")
 include("micm/micm.jl")
 
+# Mechanism configuration (pure-Julia; builds config strings for MICM)
+include("mechanism_configuration/mechanism_configuration.jl")
+export MechanismConfiguration
+
 # Version
 export get_musica_version
 export get_micm_version

--- a/julia/src/mechanism_configuration/mechanism.jl
+++ b/julia/src/mechanism_configuration/mechanism.jl
@@ -1,0 +1,86 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+    Mechanism(; name, version="1.0.0", species, phases, reactions)
+
+A complete version 1 mechanism configuration assembled in code.
+
+# Fields
+- `name::String`: Mechanism name.
+- `version::String`: Configuration schema version (default `"1.0.0"`).
+- `species::Vector`: A vector of [`Species`](@ref).
+- `phases::Vector`: A vector of [`Phase`](@ref).
+- `reactions::Vector`: A vector of reaction objects (e.g. [`Arrhenius`](@ref),
+  [`UserDefined`](@ref), [`Photolysis`](@ref), …).
+
+Serialize with [`to_json_string`](@ref) or [`to_yaml_string`](@ref) and pass the
+result to `MICM(config_string = ...)`.
+"""
+struct Mechanism
+    name::String
+    version::String
+    species::Vector{Any}
+    phases::Vector{Any}
+    reactions::Vector{Any}
+end
+
+function Mechanism(;
+    name::AbstractString,
+    version::AbstractString = "1.0.0",
+    species::AbstractVector = [],
+    phases::AbstractVector = [],
+    reactions::AbstractVector = [],
+)
+    return Mechanism(
+        String(name),
+        String(version),
+        collect(Any, species),
+        collect(Any, phases),
+        collect(Any, reactions),
+    )
+end
+
+"""
+    to_dict(m::Mechanism) -> Dict{String,Any}
+
+Build the nested dictionary representation of the mechanism in the version 1 schema.
+"""
+function to_dict(m::Mechanism)
+    return Dict{String,Any}(
+        "name" => m.name,
+        "version" => m.version,
+        "species" => [to_dict(s) for s in m.species],
+        "phases" => [to_dict(p) for p in m.phases],
+        "reactions" => [to_dict(r) for r in m.reactions],
+    )
+end
+
+"""
+    to_json_string(m::Mechanism) -> String
+
+Serialize the mechanism to a JSON string suitable for `MICM(config_string = ...)`.
+"""
+to_json_string(m::Mechanism) = JSON.json(to_dict(m))
+
+"""
+    to_yaml_string(m::Mechanism) -> String
+
+Serialize the mechanism to a YAML string suitable for `MICM(config_string = ...)`.
+"""
+to_yaml_string(m::Mechanism) = sprint(YAML.write, to_dict(m))
+
+"""
+    to_string(m::Mechanism; format=:json) -> String
+
+Serialize the mechanism to a string. `format` may be `:json` (default) or `:yaml`.
+"""
+function to_string(m::Mechanism; format::Symbol = :json)
+    if format === :json
+        return to_json_string(m)
+    elseif format === :yaml
+        return to_yaml_string(m)
+    else
+        error("Unknown format: $format (expected :json or :yaml)")
+    end
+end

--- a/julia/src/mechanism_configuration/mechanism_configuration.jl
+++ b/julia/src/mechanism_configuration/mechanism_configuration.jl
@@ -1,0 +1,66 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+    Musica.MechanismConfiguration
+
+Build version 1 mechanism configurations in code and serialize them to JSON or YAML
+strings that can be passed to `MICM(config_string = ...)`.
+
+This mirrors the Python (`musica.mechanism_configuration`) and JavaScript
+(`musica.mechanismConfiguration`) interfaces.
+
+# Example
+```julia
+using Musica
+using Musica.MechanismConfiguration
+
+A  = Species(name = "A", molecular_weight = 0.029)
+B  = Species(name = "B", molecular_weight = 0.029)
+AB = Species(name = "AB", molecular_weight = 0.058)
+
+gas = Phase(name = "gas", species = [A, B, AB])
+
+loss = UserDefined(
+    name = "AB loss",
+    gas_phase = "gas",
+    reactants = [ReactionComponent(species_name = "AB")],
+    products = [ReactionComponent(species_name = "A"), ReactionComponent(species_name = "B")],
+)
+
+mech = Mechanism(name = "ABBA", version = "1.0.0",
+                 species = [A, B, AB], phases = [gas], reactions = [loss])
+
+micm = MICM(config_string = to_json_string(mech))
+```
+"""
+module MechanismConfiguration
+
+using JSON
+using YAML
+
+include("types.jl")
+include("reaction_types.jl")
+include("mechanism.jl")
+
+# Core data types
+export Species, PhaseSpecies, Phase, ReactionComponent
+
+# Reaction types
+export Arrhenius,
+    Branched,
+    Emission,
+    FirstOrderLoss,
+    Photolysis,
+    Surface,
+    TaylorSeries,
+    Troe,
+    TernaryChemicalActivation,
+    Tunneling,
+    UserDefined
+
+# Mechanism and serialization
+export Mechanism
+export to_dict, to_json_string, to_yaml_string, to_string
+
+end # module MechanismConfiguration

--- a/julia/src/mechanism_configuration/reaction_types.jl
+++ b/julia/src/mechanism_configuration/reaction_types.jl
@@ -1,0 +1,619 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+# Reaction types for building a version 1 mechanism configuration in code.
+#
+# These mirror the JavaScript and Python interfaces. Each reaction is a plain data
+# object with a `to_dict` method that produces the spaced-key schema expected by the
+# MICM parser. The `LambdaRateConstant` reaction is intentionally not provided: it
+# relies on a C++ lambda string / host-language callback that has no Julia analog.
+
+# Convert a vector of `ReactionComponent`s to a vector of dictionaries.
+_components(v) = [to_dict(c) for c in v]
+
+# Add the optional `name` and `gas phase` keys, omitting them when `nothing`.
+function _add_common!(d::Dict{String,Any}, name, gas_phase)
+    name === nothing || (d["name"] = name)
+    gas_phase === nothing || (d["gas phase"] = gas_phase)
+    return d
+end
+
+"""
+    Arrhenius(; A=1.0, B=0.0, C=0.0, D=300.0, E=0.0, Ea=nothing,
+                reactants, products, name=nothing, gas_phase=nothing,
+                other_properties=Dict())
+
+Arrhenius-type rate constant: `k = A * exp(C/T) * (T/D)^B * (1 + E*P)`.
+`C` and `Ea` are mutually exclusive; if `Ea` is given it is emitted in place of `C`.
+"""
+struct Arrhenius
+    A::Float64
+    B::Float64
+    C::Float64
+    D::Float64
+    E::Float64
+    Ea::Union{Float64,Nothing}
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Arrhenius(;
+    A::Real = 1.0,
+    B::Real = 0.0,
+    C::Real = 0.0,
+    D::Real = 300.0,
+    E::Real = 0.0,
+    Ea::Union{Real,Nothing} = nothing,
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Arrhenius(
+        A,
+        B,
+        C,
+        D,
+        E,
+        Ea === nothing ? nothing : Float64(Ea),
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Arrhenius)
+    d = Dict{String,Any}(
+        "type" => "ARRHENIUS",
+        "A" => r.A,
+        "B" => r.B,
+        "D" => r.D,
+        "E" => r.E,
+    )
+    r.Ea === nothing ? (d["C"] = r.C) : (d["Ea"] = r.Ea)
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    Branched(; X=nothing, Y=nothing, a0=nothing, n=nothing,
+               reactants, nitrate_products, alkoxy_products,
+               name=nothing, gas_phase=nothing, other_properties=Dict())
+
+Branched (Wennberg NO + RO2) reaction.
+"""
+struct Branched
+    X::Union{Float64,Nothing}
+    Y::Union{Float64,Nothing}
+    a0::Union{Float64,Nothing}
+    n::Union{Float64,Nothing}
+    reactants::Vector{ReactionComponent}
+    nitrate_products::Vector{ReactionComponent}
+    alkoxy_products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Branched(;
+    X::Union{Real,Nothing} = nothing,
+    Y::Union{Real,Nothing} = nothing,
+    a0::Union{Real,Nothing} = nothing,
+    n::Union{Real,Nothing} = nothing,
+    reactants::AbstractVector = ReactionComponent[],
+    nitrate_products::AbstractVector = ReactionComponent[],
+    alkoxy_products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    f(x) = x === nothing ? nothing : Float64(x)
+    return Branched(
+        f(X),
+        f(Y),
+        f(a0),
+        f(n),
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, nitrate_products),
+        collect(ReactionComponent, alkoxy_products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Branched)
+    d = Dict{String,Any}("type" => "BRANCHED_NO_RO2")
+    r.X === nothing || (d["X"] = r.X)
+    r.Y === nothing || (d["Y"] = r.Y)
+    r.a0 === nothing || (d["a0"] = r.a0)
+    r.n === nothing || (d["n"] = r.n)
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["nitrate products"] = _components(r.nitrate_products)
+    d["alkoxy products"] = _components(r.alkoxy_products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    Emission(; scaling_factor=1.0, products, name=nothing, gas_phase=nothing,
+               other_properties=Dict())
+
+Emission reaction (zeroth-order production), scaled by a user-defined rate parameter.
+"""
+struct Emission
+    scaling_factor::Float64
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Emission(;
+    scaling_factor::Real = 1.0,
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Emission(
+        Float64(scaling_factor),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Emission)
+    d = Dict{String,Any}("type" => "EMISSION", "scaling factor" => r.scaling_factor)
+    _add_common!(d, r.name, r.gas_phase)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    FirstOrderLoss(; scaling_factor=1.0, reactants, name=nothing, gas_phase=nothing,
+                     other_properties=Dict())
+
+First-order loss reaction, scaled by a user-defined rate parameter.
+"""
+struct FirstOrderLoss
+    scaling_factor::Float64
+    reactants::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function FirstOrderLoss(;
+    scaling_factor::Real = 1.0,
+    reactants::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return FirstOrderLoss(
+        Float64(scaling_factor),
+        collect(ReactionComponent, reactants),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::FirstOrderLoss)
+    d = Dict{String,Any}("type" => "FIRST_ORDER_LOSS", "scaling factor" => r.scaling_factor)
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    Photolysis(; scaling_factor=1.0, reactants, products, name=nothing,
+                 gas_phase=nothing, other_properties=Dict())
+
+Photolysis reaction, scaled by a user-defined photolysis rate parameter.
+"""
+struct Photolysis
+    scaling_factor::Float64
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Photolysis(;
+    scaling_factor::Real = 1.0,
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Photolysis(
+        Float64(scaling_factor),
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Photolysis)
+    d = Dict{String,Any}("type" => "PHOTOLYSIS", "scaling factor" => r.scaling_factor)
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    Surface(; reaction_probability=1.0, gas_phase_species, gas_phase_products,
+              name=nothing, gas_phase=nothing, other_properties=Dict())
+
+Surface (heterogeneous) reaction. `gas_phase_species` is a single `ReactionComponent`;
+only its species name is written to the configuration.
+"""
+struct Surface
+    reaction_probability::Float64
+    gas_phase_species::ReactionComponent
+    gas_phase_products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Surface(;
+    reaction_probability::Real = 1.0,
+    gas_phase_species::ReactionComponent,
+    gas_phase_products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Surface(
+        Float64(reaction_probability),
+        gas_phase_species,
+        collect(ReactionComponent, gas_phase_products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Surface)
+    d = Dict{String,Any}(
+        "type" => "SURFACE",
+        "reaction probability" => r.reaction_probability,
+    )
+    _add_common!(d, r.name, r.gas_phase)
+    d["gas-phase species"] = r.gas_phase_species.species_name
+    d["gas-phase products"] = _components(r.gas_phase_products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    TaylorSeries(; A=1.0, B=0.0, C=0.0, D=300.0, E=0.0, Ea=nothing,
+                   taylor_coefficients=[1.0], reactants, products,
+                   name=nothing, gas_phase=nothing, other_properties=Dict())
+
+Taylor-series rate constant. `C` and `Ea` are mutually exclusive.
+"""
+struct TaylorSeries
+    A::Float64
+    B::Float64
+    C::Float64
+    D::Float64
+    E::Float64
+    Ea::Union{Float64,Nothing}
+    taylor_coefficients::Vector{Float64}
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function TaylorSeries(;
+    A::Real = 1.0,
+    B::Real = 0.0,
+    C::Real = 0.0,
+    D::Real = 300.0,
+    E::Real = 0.0,
+    Ea::Union{Real,Nothing} = nothing,
+    taylor_coefficients::AbstractVector = [1.0],
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return TaylorSeries(
+        A,
+        B,
+        C,
+        D,
+        E,
+        Ea === nothing ? nothing : Float64(Ea),
+        collect(Float64, taylor_coefficients),
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::TaylorSeries)
+    d = Dict{String,Any}(
+        "type" => "TAYLOR_SERIES",
+        "A" => r.A,
+        "B" => r.B,
+        "D" => r.D,
+        "E" => r.E,
+    )
+    r.Ea === nothing ? (d["C"] = r.C) : (d["Ea"] = r.Ea)
+    d["taylor coefficients"] = r.taylor_coefficients
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    Troe(; k0_A=1.0, k0_B=0.0, k0_C=0.0, kinf_A=1.0, kinf_B=0.0, kinf_C=0.0,
+           Fc=0.6, N=1.0, reactants, products, name=nothing, gas_phase=nothing,
+           other_properties=Dict())
+
+Troe (falloff) reaction.
+"""
+struct Troe
+    k0_A::Float64
+    k0_B::Float64
+    k0_C::Float64
+    kinf_A::Float64
+    kinf_B::Float64
+    kinf_C::Float64
+    Fc::Float64
+    N::Float64
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Troe(;
+    k0_A::Real = 1.0,
+    k0_B::Real = 0.0,
+    k0_C::Real = 0.0,
+    kinf_A::Real = 1.0,
+    kinf_B::Real = 0.0,
+    kinf_C::Real = 0.0,
+    Fc::Real = 0.6,
+    N::Real = 1.0,
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Troe(
+        k0_A,
+        k0_B,
+        k0_C,
+        kinf_A,
+        kinf_B,
+        kinf_C,
+        Fc,
+        N,
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Troe)
+    d = Dict{String,Any}(
+        "type" => "TROE",
+        "k0_A" => r.k0_A,
+        "k0_B" => r.k0_B,
+        "k0_C" => r.k0_C,
+        "kinf_A" => r.kinf_A,
+        "kinf_B" => r.kinf_B,
+        "kinf_C" => r.kinf_C,
+        "Fc" => r.Fc,
+        "N" => r.N,
+    )
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    TernaryChemicalActivation(; k0_A=1.0, k0_B=0.0, k0_C=0.0, kinf_A=1.0,
+                                kinf_B=0.0, kinf_C=0.0, Fc=0.6, N=1.0,
+                                reactants, products, name=nothing,
+                                gas_phase=nothing, other_properties=Dict())
+
+Ternary chemical activation reaction.
+"""
+struct TernaryChemicalActivation
+    k0_A::Float64
+    k0_B::Float64
+    k0_C::Float64
+    kinf_A::Float64
+    kinf_B::Float64
+    kinf_C::Float64
+    Fc::Float64
+    N::Float64
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function TernaryChemicalActivation(;
+    k0_A::Real = 1.0,
+    k0_B::Real = 0.0,
+    k0_C::Real = 0.0,
+    kinf_A::Real = 1.0,
+    kinf_B::Real = 0.0,
+    kinf_C::Real = 0.0,
+    Fc::Real = 0.6,
+    N::Real = 1.0,
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return TernaryChemicalActivation(
+        k0_A,
+        k0_B,
+        k0_C,
+        kinf_A,
+        kinf_B,
+        kinf_C,
+        Fc,
+        N,
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::TernaryChemicalActivation)
+    d = Dict{String,Any}(
+        "type" => "TERNARY_CHEMICAL_ACTIVATION",
+        "k0_A" => r.k0_A,
+        "k0_B" => r.k0_B,
+        "k0_C" => r.k0_C,
+        "kinf_A" => r.kinf_A,
+        "kinf_B" => r.kinf_B,
+        "kinf_C" => r.kinf_C,
+        "Fc" => r.Fc,
+        "N" => r.N,
+    )
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    Tunneling(; A=1.0, B=0.0, C=0.0, reactants, products, name=nothing,
+                gas_phase=nothing, other_properties=Dict())
+
+Wennberg tunneling reaction.
+"""
+struct Tunneling
+    A::Float64
+    B::Float64
+    C::Float64
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Tunneling(;
+    A::Real = 1.0,
+    B::Real = 0.0,
+    C::Real = 0.0,
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Tunneling(
+        A,
+        B,
+        C,
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::Tunneling)
+    d = Dict{String,Any}("type" => "TUNNELING", "A" => r.A, "B" => r.B, "C" => r.C)
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end
+
+"""
+    UserDefined(; scaling_factor=1.0, reactants, products, name=nothing,
+                  gas_phase=nothing, other_properties=Dict())
+
+User-defined reaction whose rate is supplied at runtime via a user-defined rate
+parameter.
+"""
+struct UserDefined
+    scaling_factor::Float64
+    reactants::Vector{ReactionComponent}
+    products::Vector{ReactionComponent}
+    name::Union{String,Nothing}
+    gas_phase::Union{String,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function UserDefined(;
+    scaling_factor::Real = 1.0,
+    reactants::AbstractVector = ReactionComponent[],
+    products::AbstractVector = ReactionComponent[],
+    name::Union{AbstractString,Nothing} = nothing,
+    gas_phase::Union{AbstractString,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return UserDefined(
+        Float64(scaling_factor),
+        collect(ReactionComponent, reactants),
+        collect(ReactionComponent, products),
+        name === nothing ? nothing : String(name),
+        gas_phase === nothing ? nothing : String(gas_phase),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(r::UserDefined)
+    d = Dict{String,Any}("type" => "USER_DEFINED", "scaling factor" => r.scaling_factor)
+    _add_common!(d, r.name, r.gas_phase)
+    d["reactants"] = _components(r.reactants)
+    d["products"] = _components(r.products)
+    _merge_other_properties!(d, r.other_properties)
+    return d
+end

--- a/julia/src/mechanism_configuration/types.jl
+++ b/julia/src/mechanism_configuration/types.jl
@@ -1,0 +1,189 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+# Core data types for building a version 1 mechanism configuration in code.
+#
+# These mirror the JavaScript (`javascript/mechanism_configuration`) and Python
+# (`python/musica/mechanism_configuration`) interfaces: plain data objects with a
+# `to_dict` method that produces the spaced-key schema the MICM parser expects.
+#
+# Arbitrary user properties are passed via `other_properties` (a `Dict{String,Any}`
+# keyed by the human-readable name *without* the `__` prefix). On serialization each
+# such key is emitted with a leading `__`, matching the convention used by the C++
+# parser and the other language bindings.
+
+"""
+    _merge_other_properties!(d::Dict, other_properties::Dict)
+
+Copy `other_properties` into `d`, prefixing each key with `__`.
+"""
+function _merge_other_properties!(d::Dict{String,Any}, other_properties::AbstractDict)
+    for (key, value) in other_properties
+        d["__"*String(key)] = value
+    end
+    return d
+end
+
+"""
+    ReactionComponent(; species_name, coefficient=1.0, other_properties=Dict())
+
+A single reactant or product entry in a reaction.
+
+# Fields
+- `species_name::String`: Name of the species.
+- `coefficient::Float64`: Stoichiometric coefficient (default `1.0`).
+- `other_properties::Dict{String,Any}`: Arbitrary extra properties.
+"""
+struct ReactionComponent
+    species_name::String
+    coefficient::Float64
+    other_properties::Dict{String,Any}
+end
+
+function ReactionComponent(;
+    species_name::AbstractString,
+    coefficient::Real = 1.0,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return ReactionComponent(
+        String(species_name),
+        Float64(coefficient),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(c::ReactionComponent)
+    d = Dict{String,Any}("species name" => c.species_name, "coefficient" => c.coefficient)
+    _merge_other_properties!(d, c.other_properties)
+    return d
+end
+
+"""
+    Species(; name, molecular_weight=nothing, constant_concentration=nothing,
+              constant_mixing_ratio=nothing, is_third_body=nothing,
+              other_properties=Dict())
+
+A chemical species. Optional fields that are left as `nothing` are omitted from the
+serialized configuration.
+
+# Fields
+- `name::String`: Species name.
+- `molecular_weight`: Molecular weight in kg mol⁻¹.
+- `constant_concentration`: Fixed concentration in mol m⁻³.
+- `constant_mixing_ratio`: Fixed mixing ratio in mol mol⁻¹.
+- `is_third_body`: Whether the species acts as a third body (e.g. `M`).
+- `other_properties::Dict{String,Any}`: Arbitrary extra properties.
+"""
+struct Species
+    name::String
+    molecular_weight::Union{Float64,Nothing}
+    constant_concentration::Union{Float64,Nothing}
+    constant_mixing_ratio::Union{Float64,Nothing}
+    is_third_body::Union{Bool,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function Species(;
+    name::AbstractString,
+    molecular_weight::Union{Real,Nothing} = nothing,
+    constant_concentration::Union{Real,Nothing} = nothing,
+    constant_mixing_ratio::Union{Real,Nothing} = nothing,
+    is_third_body::Union{Bool,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Species(
+        String(name),
+        molecular_weight === nothing ? nothing : Float64(molecular_weight),
+        constant_concentration === nothing ? nothing : Float64(constant_concentration),
+        constant_mixing_ratio === nothing ? nothing : Float64(constant_mixing_ratio),
+        is_third_body,
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(s::Species)
+    d = Dict{String,Any}("name" => s.name)
+    s.molecular_weight === nothing ||
+        (d["molecular weight [kg mol-1]"] = s.molecular_weight)
+    s.constant_concentration === nothing ||
+        (d["constant concentration [mol m-3]"] = s.constant_concentration)
+    s.constant_mixing_ratio === nothing ||
+        (d["constant mixing ratio [mol mol-1]"] = s.constant_mixing_ratio)
+    s.is_third_body === nothing || (d["is third body"] = s.is_third_body)
+    _merge_other_properties!(d, s.other_properties)
+    return d
+end
+
+"""
+    PhaseSpecies(; name, diffusion_coefficient=nothing, other_properties=Dict())
+
+A reference to a species within a phase, optionally carrying a diffusion coefficient.
+
+# Fields
+- `name::String`: Species name.
+- `diffusion_coefficient`: Diffusion coefficient in m² s⁻¹.
+- `other_properties::Dict{String,Any}`: Arbitrary extra properties.
+"""
+struct PhaseSpecies
+    name::String
+    diffusion_coefficient::Union{Float64,Nothing}
+    other_properties::Dict{String,Any}
+end
+
+function PhaseSpecies(;
+    name::AbstractString,
+    diffusion_coefficient::Union{Real,Nothing} = nothing,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return PhaseSpecies(
+        String(name),
+        diffusion_coefficient === nothing ? nothing : Float64(diffusion_coefficient),
+        Dict{String,Any}(other_properties),
+    )
+end
+
+function to_dict(s::PhaseSpecies)
+    d = Dict{String,Any}("name" => s.name)
+    s.diffusion_coefficient === nothing ||
+        (d["diffusion coefficient [m2 s-1]"] = s.diffusion_coefficient)
+    _merge_other_properties!(d, s.other_properties)
+    return d
+end
+
+"""
+    Phase(; name, species, other_properties=Dict())
+
+A phase grouping a set of species.
+
+# Fields
+- `name::String`: Phase name.
+- `species::Vector`: Members of the phase. Each entry may be a `PhaseSpecies`, a
+  `Species` (only its name is used), or a plain species-name `String`.
+- `other_properties::Dict{String,Any}`: Arbitrary extra properties.
+"""
+struct Phase
+    name::String
+    species::Vector{Any}
+    other_properties::Dict{String,Any}
+end
+
+function Phase(;
+    name::AbstractString,
+    species::AbstractVector,
+    other_properties::AbstractDict = Dict{String,Any}(),
+)
+    return Phase(String(name), collect(Any, species), Dict{String,Any}(other_properties))
+end
+
+_phase_species_dict(s::PhaseSpecies) = to_dict(s)
+_phase_species_dict(s::Species) = Dict{String,Any}("name" => s.name)
+_phase_species_dict(s::AbstractString) = Dict{String,Any}("name" => String(s))
+
+function to_dict(p::Phase)
+    d = Dict{String,Any}(
+        "name" => p.name,
+        "species" => [_phase_species_dict(s) for s in p.species],
+    )
+    _merge_other_properties!(d, p.other_properties)
+    return d
+end

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -415,3 +415,5 @@ using Musica
         @test_throws Exception MICM(config_string = "not a valid mechanism")
     end
 end
+
+include("test_mechanism_configuration.jl")

--- a/julia/test/test_mechanism_configuration.jl
+++ b/julia/test/test_mechanism_configuration.jl
@@ -1,0 +1,220 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the in-code mechanism configuration interface
+# (`Musica.MechanismConfiguration`).
+#
+# Builds the "ABBA" mechanism entirely in code, checks JSON/YAML serialization, then
+# runs a box model from the serialized string and uses a species' molecular weight to
+# convert a mass mixing ratio to a molar concentration.
+
+using Test
+using Musica
+using Musica.MechanismConfiguration
+using JSON
+using YAML
+
+# ── Build the ABBA mechanism in code ────────────────────────────────────────
+# Molecular weights use the standard `molecular weight [kg mol-1]` field.
+A = Species(
+    name = "A",
+    molecular_weight = 0.029,
+    other_properties = Dict(
+        "absolute tolerance" => 1e-4,
+        "long name" => "atom_A",
+        "do advect" => true,
+        "initial concentration" => 0.0,
+    ),
+)
+B = Species(
+    name = "B",
+    molecular_weight = 0.029,
+    other_properties = Dict("absolute tolerance" => 1e-4, "long name" => "atom_B"),
+)
+AB = Species(
+    name = "AB",
+    molecular_weight = 0.058,
+    other_properties = Dict("long name" => "molecule_AB"),
+)
+
+gas = Phase(name = "gas", species = [A, B, AB])
+
+forward = UserDefined(
+    name = "forward_AB_to_A_B",
+    gas_phase = "gas",
+    scaling_factor = 2.0e-3,
+    reactants = [ReactionComponent(species_name = "AB")],
+    products = [
+        ReactionComponent(species_name = "A"),
+        ReactionComponent(species_name = "B"),
+    ],
+)
+reverse_rxn = UserDefined(
+    name = "reverse_A_B_to_AB",
+    gas_phase = "gas",
+    scaling_factor = 1.0e-3,
+    reactants = [
+        ReactionComponent(species_name = "A"),
+        ReactionComponent(species_name = "B"),
+    ],
+    products = [ReactionComponent(species_name = "AB")],
+)
+photo = Photolysis(
+    name = "jNO2",
+    gas_phase = "gas",
+    reactants = [ReactionComponent(species_name = "AB")],
+    products = [
+        ReactionComponent(species_name = "A"),
+        ReactionComponent(species_name = "B"),
+    ],
+)
+
+abba = Mechanism(
+    name = "ABBA",
+    version = "1.0.0",
+    species = [A, B, AB],
+    phases = [gas],
+    reactions = [forward, reverse_rxn, photo],
+)
+
+@testset "MechanismConfiguration" begin
+    @testset "Serialization" begin
+        d = JSON.parse(to_json_string(abba))
+
+        @test d["name"] == "ABBA"
+        @test d["version"] == "1.0.0"
+        @test length(d["species"]) == 3
+        @test length(d["phases"]) == 1
+        @test length(d["reactions"]) == 3
+
+        # Species: standard field + custom properties get the `__` prefix
+        sA = only(filter(s -> s["name"] == "A", d["species"]))
+        @test sA["molecular weight [kg mol-1]"] ≈ 0.029
+        @test sA["__absolute tolerance"] ≈ 1e-4
+        @test sA["__long name"] == "atom_A"
+        @test sA["__do advect"] == true
+
+        # Phase species are emitted as `{name: ...}` objects
+        @test d["phases"][1]["species"] ==
+              [Dict("name" => "A"), Dict("name" => "B"), Dict("name" => "AB")]
+
+        # Reactions: types, spaced keys, default coefficient
+        rf = only(filter(r -> r["name"] == "forward_AB_to_A_B", d["reactions"]))
+        @test rf["type"] == "USER_DEFINED"
+        @test rf["gas phase"] == "gas"
+        @test rf["scaling factor"] ≈ 2.0e-3
+        @test rf["reactants"][1]["species name"] == "AB"
+        @test rf["reactants"][1]["coefficient"] ≈ 1.0
+        @test only(filter(r -> r["name"] == "jNO2", d["reactions"]))["type"] == "PHOTOLYSIS"
+
+        # YAML parses back to the same structure as JSON
+        @test YAML.load(to_yaml_string(abba)) == d
+
+        # to_string dispatches on format
+        @test to_string(abba; format = :json) == to_json_string(abba)
+        @test to_string(abba; format = :yaml) == to_yaml_string(abba)
+        @test_throws ErrorException to_string(abba; format = :toml)
+    end
+
+    # Recreates the single-cell ABBA box model from the CheMPAS-MUSICA dev test
+    # (Fillmore, 2026-01-22): start from a mass mixing ratio, convert to mol m-3 with
+    # the molecular weight and an ideal-gas air density, run A + B <-> AB to
+    # equilibrium, and verify the equilibrium and mass conservation.
+    @testset "ABBA box model reaches equilibrium" begin
+        # Environmental conditions and physical constants.
+        temperature = 298.0      # K
+        pressure = 101325.0      # Pa
+        molar_mass_air = 0.0289647  # kg mol-1 (dry air)
+
+        # Rate constants from the mechanism (= the USER_DEFINED scaling factors):
+        #   formation    A + B -> AB   kf = 1.0e-3
+        #   dissociation AB -> A + B   kr = 2.0e-3
+        kf = 1.0e-3
+        kr = 2.0e-3
+        q_AB0 = 0.6              # initial mass mixing ratio of AB [kg kg-1]
+
+        micm = MICM(config_string = to_json_string(abba))
+        state = create_state(micm)
+
+        ordering = get_species_ordering(state)
+        @test haskey(ordering, "A")
+        @test haskey(ordering, "B")
+        @test haskey(ordering, "AB")
+
+        set_conditions!(state, temperatures = temperature, pressures = pressure)
+
+        # ── Air density from the ideal gas law ──────────────────────────────
+        # molar density [mol m-3] = P / (R T); mass density [kg m-3] = molar * M_air
+        molar_density = pressure / (GAS_CONSTANT * temperature)   # mol m-3
+        air_mass_density = molar_density * molar_mass_air         # kg m-3
+        # Cross-check against the air density MICM computed internally.
+        @test get_conditions(state)["air_density"][1] ≈ molar_density rtol = 1e-6
+
+        # ── Read molecular weights and convert mixing ratio -> mol m-3 ───────
+        M_AB = get_species_property(micm, "AB", "molecular weight [kg mol-1]", Float64)
+        M_A = get_species_property(micm, "A", "molecular weight [kg mol-1]", Float64)
+        M_B = get_species_property(micm, "B", "molecular weight [kg mol-1]", Float64)
+        @test M_AB ≈ 0.058
+        @test M_A ≈ 0.029
+
+        # C [mol m-3] = q [kg kg-1] * air_mass_density [kg m-3] / M [kg mol-1]
+        C_AB0 = q_AB0 * air_mass_density / M_AB
+        @test C_AB0 > 0.0
+
+        # Seed the box model with the converted concentration.
+        set_concentrations!(state, Dict{String,Any}("A" => 0.0, "B" => 0.0, "AB" => C_AB0))
+
+        # Drive the two A + B <-> AB reactions and turn the photolysis pathway off so
+        # the equilibrium is governed purely by kf and kr. Match by reaction name so
+        # the test is independent of the rate-parameter key prefix.
+        rate_ordering = get_user_defined_rate_parameters_ordering(state)
+        @test !isempty(rate_ordering)
+        rates = Dict{String,Any}()
+        for key in keys(rate_ordering)
+            rates[key] =
+                (occursin("forward_AB_to_A_B", key) || occursin("reverse_A_B_to_AB", key)) ?
+                1.0 : 0.0
+        end
+        set_user_defined_rate_parameters!(state, rates)
+
+        # Integrate to equilibrium (dissociation timescale 1/kr = 500 s; 90 min is
+        # many e-folding times).
+        for _ = 1:90
+            result = solve!(micm, state, 60.0)
+            @test result.state == Converged
+        end
+
+        concs = get_concentrations(state)
+        A_eq = concs["A"][1]
+        B_eq = concs["B"][1]
+        AB_eq = concs["AB"][1]
+
+        # AB is dissociated and A/B produced.
+        @test AB_eq < C_AB0
+        @test A_eq > 0.0
+
+        # Stoichiometry: A and B produced one-for-one.
+        @test A_eq ≈ B_eq rtol = 1e-6
+        # Mole conservation: every AB lost yields one A.
+        @test AB_eq + A_eq ≈ C_AB0 rtol = 1e-6
+
+        # Chemical equilibrium: kf[A][B] == kr[AB]  =>  [A][B]/[AB] == kr/kf.
+        @test (A_eq * B_eq) / AB_eq ≈ kr / kf rtol = 1e-2
+
+        # Analytic equilibrium concentration: kf x^2 = kr (C_AB0 - x).
+        x_eq = (-kr + sqrt(kr^2 + 4 * kf * kr * C_AB0)) / (2 * kf)
+        @test A_eq ≈ x_eq rtol = 1e-2
+
+        # Mass mixing ratio is conserved (total stays 0.6).
+        q_total = (M_AB * AB_eq + M_A * A_eq + M_B * B_eq) / air_mass_density
+        @test q_total ≈ q_AB0 rtol = 1e-6
+
+        # Matches the documented surface equilibrium: qAB ~ 0.40, qA ~ 0.10.
+        @test (M_AB * AB_eq) / air_mass_density ≈ 0.40 atol = 0.02
+        @test (M_A * A_eq) / air_mass_density ≈ 0.10 atol = 0.02
+
+        # Confirm we are truly at steady state: another step barely moves AB.
+        solve!(micm, state, 60.0)
+        @test get_concentrations(state)["AB"][1] ≈ AB_eq rtol = 1e-4
+    end
+end


### PR DESCRIPTION
Closes #915 

This PR

- adds a mechanism configuration interface for julia
- can export to both yaml/json
- uses the new interface to recreate the ABBA box model test, because why not?