### PR TITLE
Update the version in preparation of release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.ipynb filter=nbstripout
+*.zpln filter=nbstripout
+*.ipynb diff=ipynb

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -64,4 +64,4 @@ number: 10
 page: "E1743 - E1760"
 doi: "10.1175/BAMS-D-19-0331.1"
 url: "https://journals.ametsoc.org/view/journals/bams/101/10/bamsD190331.xml"
-version: 0.15.0
+version: 0.16.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 # pyproject.toml extracts the version from this line via regex — keep version on this line
-project(musica VERSION 0.15.0)
+project(musica VERSION 0.16.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -115,7 +115,7 @@ endif()
 
 if (MUSICA_ENABLE_MICM AND MUSICA_BUILD_C_CXX_INTERFACE AND NOT MUSICA_USE_PREBUILT)
   set_git_default(MICM_GIT_REPOSITORY https://github.com/NCAR/micm.git)
-  set_git_default(MICM_GIT_TAG 41ae650b3c5170522383edb0d48676e3406f5245)
+  set_git_default(MICM_GIT_TAG v3.13.0)
 
   FetchContent_Declare(micm
       GIT_REPOSITORY ${MICM_GIT_REPOSITORY}
@@ -168,7 +168,7 @@ if (MUSICA_ENABLE_TUVX AND MUSICA_BUILD_C_CXX_INTERFACE AND NOT MUSICA_USE_PREBU
   # NOTE: `docker/Dockerfile.tuvx` extracts TUVX_GIT_REPOSITORY and TUVX_GIT_TAG
   #       from this script to set up tests against stand-alone TUV-x
   set_git_default(TUVX_GIT_REPOSITORY https://github.com/NCAR/tuv-x.git)
-  set_git_default(TUVX_GIT_TAG 746f9ae6a1234362935c59987ae005cb799eb29b)
+  set_git_default(TUVX_GIT_TAG v0.16.0)
 
   FetchContent_Declare(tuvx
     GIT_REPOSITORY ${TUVX_GIT_REPOSITORY}

--- a/docker/Dockerfile.wheel
+++ b/docker/Dockerfile.wheel
@@ -25,7 +25,7 @@ RUN for whl in /wheelhouse/*.whl; do \
     done
 
 # Pass the wheel filename at build time, e.g.:
-#   docker build --build-arg WHEEL_FILE=musica-0.15.0-cp310-cp310-manylinux_2_28_x86_64.whl -f docker/Dockerfile.wheel .
+#   docker build --build-arg WHEEL_FILE=musica-0.16.0-cp310-cp310-manylinux_2_28_x86_64.whl -f docker/Dockerfile.wheel .
 # The filename follows the pattern: musica-<version>-<python>-<python>-<platform>.whl
 ARG WHEEL_FILE
 RUN pip install --no-cache-dir "musica[cli,gpu] @ file:/wheelhouse/${WHEEL_FILE}"

--- a/docs/source/api/julia.rst
+++ b/docs/source/api/julia.rst
@@ -70,7 +70,7 @@ Core
 
    .. code-block:: julia
 
-      println(Musica.get_version())  # e.g. "0.15.0"
+      println(Musica.get_version())  # e.g. "0.16.0"
 
 Constants
 ^^^^^^^^^

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,7 +1,7 @@
 name = "Musica"
 uuid = "d3d182ee-e566-4962-9279-3a9916be1802"
 authors = ["ACOM MUSICA Developers <musica-support@ucar.edu>"]
-version = "0.15.0"
+version = "0.16.0"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"

--- a/julia/bindings/musica_julia.cpp
+++ b/julia/bindings/musica_julia.cpp
@@ -4,6 +4,10 @@
 // jlcxx/stl.hpp uses std::ranges algorithms (fill, binary_search, lower_bound)
 // but does not include <algorithm>/<ranges> itself; under C++23 libc++ no longer
 // pulls them in transitively, so include them before the jlcxx headers.
+//
+// clang-format off: IncludeBlocks: Regroup is disabled because it would move
+// "jlcxx/..." headers ahead of standard library headers, breaking the intended
+// include order above.
 #include <algorithm>
 #include <ranges>
 
@@ -26,6 +30,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+// clang-format on
 
 namespace
 {

--- a/julia/bindings/musica_julia.cpp
+++ b/julia/bindings/musica_julia.cpp
@@ -4,6 +4,9 @@
 // jlcxx/stl.hpp uses std::ranges algorithms (fill, binary_search, lower_bound)
 // but does not include <algorithm>/<ranges> itself; under C++23 libc++ no longer
 // pulls them in transitively, so include them before the jlcxx headers.
+#include <algorithm>
+#include <ranges>
+
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/stl.hpp"
 
@@ -18,9 +21,7 @@
 #include <micm/solver/solver_result.hpp>
 #include <micm/version.hpp>
 
-#include <algorithm>
 #include <iostream>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ncar/musica",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "The Multiscale Interface for Chemistry and Aerosols (MUSICA) javascript library",
   "type": "module",
   "main": "./javascript/index.js",

--- a/src/packaging/CMakeLists.txt
+++ b/src/packaging/CMakeLists.txt
@@ -12,7 +12,7 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-if (MUSICA_USE_FMT)
+if (MUSICA_USE_FMT AND TARGET fmt)
   install(
     TARGETS
       fmt

--- a/src/test/unit/miam/miam_builder.cpp
+++ b/src/test/unit/miam/miam_builder.cpp
@@ -42,9 +42,9 @@ namespace
   {
     // Minimal mechanism: gas phase with the 3 gas species, no gas reactions
     // (all reactions happen in the MIAM external model).
-    namespace v1 = mechanism_configuration::v1::types;
+    namespace v1 = mechanism_configuration::types;
 
-    v1::Mechanism mech;
+    mechanism_configuration::Mechanism mech;
 
     // Gas-phase species
     v1::Species so2_g, h2o2_g, o3_g;
@@ -63,7 +63,7 @@ namespace
     };
     mech.phases.push_back(gas_phase);
 
-    return musica::ConvertV1Mechanism(mech);
+    return musica::ConvertMechanism(mech);
   }
 
   // Build MIAM model config for simplified cloud chemistry

--- a/tutorials/0. Welcome to MUSICA.ipynb
+++ b/tutorials/0. Welcome to MUSICA.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "beb6d5ad-50f3-4a00-8ebc-4ecc643b725f",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Welcome to `musica`!\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "97112653-19a6-4bf3-8031-0d9977d61992",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Installation (optional)"
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a597c729-a7e5-4ebc-81ae-d2e2317dc276",
+   "id": "2",
    "metadata": {},
    "source": [
     "You probably arrived at this tutorial through [binder](https://mybinder.org/). If so, __please skip this section__ as we've taken care of installing everything for you.\n",
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50b3d12f-85ae-4981-92bd-dc0697c796ce",
+   "id": "3",
    "metadata": {},
    "source": [
     "### CLI\n",
@@ -72,13 +72,13 @@
     "```\n",
     "You should see something like\n",
     "```text\n",
-    "musica 0.15.0 (MICM 3.12.0, TUV-x 0.15.0, CARMA 4.0.0)\n",
+    "musica 0.16.0 (MICM 3.13.0, TUV-x 0.16.0, CARMA 4.0.0)\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f971c0e1-c7bc-4e8a-a46f-d3d06f23c3b5",
+   "id": "4",
    "metadata": {},
    "source": [
     "## Using `musica`\n",
@@ -91,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "f237ec7f-624c-4106-bf19-3cacc58d3af9",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "a56c1271-1c5d-497e-a323-6ba0e4d6e95a",
+   "id": "6",
    "metadata": {},
    "outputs": [
     {
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff9b4671-aece-4fca-b2b3-bd410ce4ae8f",
+   "id": "7",
    "metadata": {},
    "source": [
     "Each of `musica`'s componenents can be imported as a separate package. There are currently three:\n",
@@ -132,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "712294e2-7822-4cf0-892e-712a6c21bdde",
+   "id": "8",
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "20818f97-8f2d-483d-a91e-c993dfd424d2",
+   "id": "9",
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "c104c9ea-778e-442e-a58b-a5e262a89d2c",
+   "id": "10",
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "781a749b-dcc6-43c4-8dd9-b561efb4e25c",
+   "id": "11",
    "metadata": {},
    "source": [
     "To run chemistry you only need `micm`, which is our ODE solver. There are separate tutorials for `tuv-x` and `carma` so we will forget about them for now.\n",
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "887a203e-dd11-4492-bcac-c265e701921a",
+   "id": "12",
    "metadata": {},
    "source": [
     "There are two ways to configure `musica`:\n",
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "84ca8ccd-e60a-4fd4-9422-1c98fd8b06a5",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02c37997",
+   "id": "14",
    "metadata": {},
    "source": [
     "Before we build our model, let's take a look at the configuration file to see how it's organized"
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "0aeefee9",
+   "id": "15",
    "metadata": {},
    "outputs": [
     {
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2ffd3143",
+   "id": "16",
    "metadata": {},
    "source": [
     "This simple mechanism comprises:\n",
@@ -339,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "029d6499-0a66-451e-ad77-a1a87eb59642",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "39195e8f-33bc-46eb-aaf3-7d36f96d8d42",
+   "id": "18",
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cb43af3d-02bc-416f-8d14-65fb62b014d8",
+   "id": "19",
    "metadata": {},
    "source": [
     "Above, we had our parser read the mechanism file and return a valid mechanism. We can see the same reactions from the configuration file, now part of a `mechanism` instance.\n",
@@ -379,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "26b69c99-d52f-4193-ad81-a295e15a2c2a",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5c0fb2e-298b-4bdb-9641-4c40b277ed88",
+   "id": "21",
    "metadata": {},
    "source": [
     "_Why do we need a solver and a state?_\n",
@@ -406,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "341bf8d8-1f75-4b4e-bb4a-bc2990ba4cd3",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0010d2c2-8d75-4be5-b844-f7b14982c37b",
+   "id": "23",
    "metadata": {},
    "source": [
     "Now all that's left is to solve and collect the concentrations as they change over time. For now, we'll print them out. Later tutorials have more code to make some pretty graphs.\n",
@@ -432,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "643cafc9-2576-4bdc-823f-565970b26eb3",
+   "id": "24",
    "metadata": {},
    "outputs": [
     {
@@ -466,7 +466,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f6d0ceef-7ac0-48a2-9b68-150178eba502",
+   "id": "25",
    "metadata": {},
    "source": [
     "And that's your first MUSICA box model! Read on to learn how to define mechanisms in-code for solving and to do more some more complex tasks."
@@ -474,11 +474,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": ".venv (3.12.3)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -488,8 +483,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Updates the MICM,  TUV-x tags
- Fixes a CMake installation error due to the fmt library. 
  - The `install(TARGETS fmt ...)` block assumes an `fmt` target exists whenever `MUSICA_USE_FMT` is `ON` but `fmt` is only created when `mechanism_configuration` is built from source, not when it's found via `find_package`. The fix applies a guard to the `fmt` block.
-  Sets up `.gitattributes` filter to automatically strip `kernelspec/language_info` on commit to strip metadata change.
- Disables `clang-format off: IncludeBlocks: Regroup` in julia/bindings/musica.julia.cpp` because it would move
`"jlcxx/..."` headers ahead of standard library headers, breaking the intended include order.