### PR TITLE
version 0.16.1

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -42,7 +42,4 @@ jobs:
           pytest --nbmake --nbmake-timeout=900 --nbmake-kernel=python3 -v tutorials/ \
             --ignore-glob='*.ipynb_checkpoints*' \
             --ignore-glob='*hpc_parallelization*' \
-            --ignore-glob='*gpu_solver*' \
-            --ignore-glob='*dae_solving_intro*' \
-            --ignore-glob='*miam_processes_and_constraints*' \
-            --ignore-glob='*cam_cloud_chemistry*'
+            --ignore-glob='*gpu_solver*'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -64,4 +64,4 @@ number: 10
 page: "E1743 - E1760"
 doi: "10.1175/BAMS-D-19-0331.1"
 url: "https://journals.ametsoc.org/view/journals/bams/101/10/bamsD190331.xml"
-version: 0.16.0
+version: 0.16.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 # pyproject.toml extracts the version from this line via regex — keep version on this line
-project(musica VERSION 0.16.0)
+project(musica VERSION 0.16.1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Update the version and enable testing of miam notebooks so we can release miam in python to get the binder link working.

We are only releasing the python library, so we won't do any of the other releases. This is one downside of a mono repository where we try to version all packages the same

notebook tests were added in #919, but that same PR disabled miam
miam was re-enabled in #930