### PR TITLE
Add musica::EmissionsModel wrapper around miem

### DIFF
--- a/include/musica/miem/emissions.hpp
+++ b/include/musica/miem/emissions.hpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file contains the definition of the EmissionsModel class, a musica-level
+// convenience wrapper around miem::EmissionsBuilder and miem::Emissions, so that
+// C/Python/Fortran bindings can target one stable interface instead of miem directly.
+#pragma once
+
+#include <musica/configuration/emissions.hpp>
+
+#include <mechanism_configuration/mechanism.hpp>
+
+#include <miem/emissions.hpp>
+#include <miem/emissions_state.hpp>
+
+#include <string>
+#include <vector>
+
+namespace musica
+{
+  class EmissionsModel
+  {
+   public:
+    /// @brief Build an emissions module from an already-translated musica::Emissions
+    /// @param emissions Sources and regridding spec, e.g. produced by ConvertEmissions
+    /// @param n_cells Number of horizontal grid cells
+    /// @param n_vert_levels Number of vertical levels
+    EmissionsModel(const Emissions& emissions, int n_cells, int n_vert_levels);
+
+    /// @brief Convenience: parse a Mechanism's emissions config via ConvertEmissions and build
+    /// @param mechanism Parsed mechanism configuration containing an emissions section
+    /// @param n_cells Number of horizontal grid cells
+    /// @param n_vert_levels Number of vertical levels
+    static EmissionsModel FromMechanism(
+        const mechanism_configuration::Mechanism& mechanism,
+        int n_cells,
+        int n_vert_levels);
+
+    /// @brief Advance one time step and return the resulting state
+    /// @param epoch_seconds Simulation time as seconds since epoch
+    /// @param dt_seconds Time step [s]
+    /// @return The emissions state computed for this time step
+    const miem::EmissionsState& Run(double epoch_seconds, double dt_seconds);
+
+    /// @brief Get the number of aggregated mechanism species across all sources
+    int NumSpecies() const;
+
+    /// @brief Get the aggregated mechanism species names across all sources
+    const std::vector<std::string>& SpeciesNames() const;
+
+    /// @brief Get the surface flux for a given cell and species from the most recent Run()
+    /// @param cell Grid cell index
+    /// @param species Mechanism species name
+    double SurfaceFlux(int cell, const std::string& species) const;
+
+   private:
+    miem::Emissions emissions_;
+    miem::EmissionsState state_;
+  };
+
+}  // namespace musica

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 # MIEM sources
 if(MUSICA_ENABLE_MIEM)
   list(APPEND musica_compile_definitions MUSICA_USE_MIEM)
+  add_subdirectory(miem)
 endif()
 
 # TUV-x sources

--- a/src/miem/CMakeLists.txt
+++ b/src/miem/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(musica PRIVATE
+  emissions.cpp
+)

--- a/src/miem/emissions.cpp
+++ b/src/miem/emissions.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file contains the implementation of the EmissionsModel class.
+#include <musica/miem/emissions.hpp>
+
+#include <miem/emissions_builder.hpp>
+
+namespace musica
+{
+  namespace
+  {
+    miem::Emissions BuildEmissions(const Emissions& emissions, int n_cells, int n_vert_levels)
+    {
+      miem::EmissionsBuilder builder;
+      builder.SetGridDimensions(n_cells, n_vert_levels);
+      builder.SetRegridding(emissions.regridding);
+      for (const auto& source : emissions.sources)
+      {
+        builder.AddSource(source);
+      }
+      return builder.Build();
+    }
+  }  // namespace
+
+  EmissionsModel::EmissionsModel(const Emissions& emissions, int n_cells, int n_vert_levels)
+      : emissions_(BuildEmissions(emissions, n_cells, n_vert_levels))
+  {
+  }
+
+  EmissionsModel EmissionsModel::FromMechanism(
+      const mechanism_configuration::Mechanism& mechanism,
+      int n_cells,
+      int n_vert_levels)
+  {
+    return EmissionsModel(ConvertEmissions(mechanism), n_cells, n_vert_levels);
+  }
+
+  const miem::EmissionsState& EmissionsModel::Run(double epoch_seconds, double dt_seconds)
+  {
+    state_ = emissions_.Run(epoch_seconds, dt_seconds);
+    return state_;
+  }
+
+  int EmissionsModel::NumSpecies() const
+  {
+    return emissions_.NumSpecies();
+  }
+
+  const std::vector<std::string>& EmissionsModel::SpeciesNames() const
+  {
+    return emissions_.SpeciesNames();
+  }
+
+  double EmissionsModel::SurfaceFlux(int cell, const std::string& species) const
+  {
+    return static_cast<double>(state_.surface_flux_(cell, species));
+  }
+
+}  // namespace musica

--- a/src/test/unit/miem/CMakeLists.txt
+++ b/src/test/unit/miem/CMakeLists.txt
@@ -2,10 +2,10 @@ include(test_util)
 
 create_standard_test_cxx(NAME miem_parser SOURCES parser.cpp)
 
-create_standard_test_cxx(NAME miem_end_to_end SOURCES end_to_end.cpp)
-target_compile_definitions(test_miem_end_to_end PRIVATE
+create_standard_test_cxx(NAME miem_emissions_model_end_to_end SOURCES emissions_model_end_to_end.cpp)
+target_compile_definitions(test_miem_emissions_model_end_to_end PRIVATE
   MIEM_REAL_FIXTURE_PATH="${miem_SOURCE_DIR}/test/data/CAMS-GLOB-ANT_2012_MPAS_bc_subset.nc")
 
-create_standard_test_cxx(NAME miem_end_to_end_nox SOURCES end_to_end_nox.cpp)
-target_compile_definitions(test_miem_end_to_end_nox PRIVATE
+create_standard_test_cxx(NAME miem_emissions_model_end_to_end_nox SOURCES emissions_model_end_to_end_nox.cpp)
+target_compile_definitions(test_miem_emissions_model_end_to_end_nox PRIVATE
   MIEM_REAL_NOX_FIXTURE_PATH="${miem_SOURCE_DIR}/test/data/x1.163842_2024_nox_subset.nc")

--- a/src/test/unit/miem/emissions_model_end_to_end.cpp
+++ b/src/test/unit/miem/emissions_model_end_to_end.cpp
@@ -1,21 +1,20 @@
 // Copyright (C) 2023-2026 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
-// End-to-end: an emissions config is parsed by MechanismConfiguration,
-// translated by musica::ConvertEmissions into a miem::Source, and that
-// Source is handed to MIEM's own EmissionsBuilder, which opens the real
-// committed fixture (test/data/CAMS-GLOB-ANT_2012_MPAS_bc_subset.nc) and
-// produces real surface flux. Mirrors the assertions in miem's own
+// End-to-end: an emissions config is parsed by MechanismConfiguration and
+// built into a musica::EmissionsModel via FromMechanism, which internally
+// translates it (ConvertEmissions) and hands it to MIEM's EmissionsBuilder.
+// The model opens the real committed fixture
+// (test/data/CAMS-GLOB-ANT_2012_MPAS_bc_subset.nc) and produces real
+// surface flux. Mirrors the assertions in miem's own
 // test/integration/test_bc_pipeline.cpp, but drives the pipeline through
-// MUSICA's parse/translate layer instead of hand-building the miem::Source.
+// MUSICA's musica::EmissionsModel interface instead of hand-building the
+// miem::Source and miem::EmissionsBuilder.
 
-#include <musica/configuration/emissions.hpp>
 #include <musica/configuration/read_mechanism.hpp>
+#include <musica/miem/emissions.hpp>
 
 #include <gtest/gtest.h>
-#include <miem/emissions.hpp>
-#include <miem/emissions_builder.hpp>
-#include <miem/emissions_state.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -66,24 +65,21 @@ namespace
   }
 }  // namespace
 
-TEST(MiemEndToEnd, MechanismConfigThroughMusicaToRealMiemFlux)
+TEST(EmissionsModelEndToEnd, MechanismConfigThroughMusicaToRealMiemFlux)
 {
-  musica::Emissions parsed = musica::ConvertEmissions(musica::ReadMechanismFromString(EmissionsConfigYaml()));
-  ASSERT_EQ(parsed.sources.size(), 1);
+  musica::EmissionsModel model = musica::EmissionsModel::FromMechanism(
+      musica::ReadMechanismFromString(EmissionsConfigYaml()), kNCells, /*n_vert_levels=*/1);
 
-  miem::Emissions emissions =
-      miem::EmissionsBuilder().SetGridDimensions(kNCells, /*n_vert_levels=*/1).AddSource(parsed.sources[0]).Build();
-
-  ASSERT_EQ(emissions.NumSpecies(), 1);
-  const auto& names = emissions.SpeciesNames();
+  ASSERT_EQ(model.NumSpecies(), 1);
+  const auto& names = model.SpeciesNames();
   ASSERT_NE(std::find(names.begin(), names.end(), "BC"), names.end());
 
-  const miem::EmissionsState state = emissions.Run(kEpoch20120701, /*dt=*/3600.0);
+  model.Run(kEpoch20120701, /*dt=*/3600.0);
 
   bool any_positive = false;
   for (int ic = 0; ic < kNCells; ++ic)
   {
-    const double flux = static_cast<double>(state.surface_flux_(ic, "BC"));
+    const double flux = model.SurfaceFlux(ic, "BC");
     EXPECT_FALSE(std::isnan(flux));
     EXPECT_GE(flux, 0.0);
     any_positive = any_positive || (flux > 0.0);

--- a/src/test/unit/miem/emissions_model_end_to_end_nox.cpp
+++ b/src/test/unit/miem/emissions_model_end_to_end_nox.cpp
@@ -1,11 +1,12 @@
 // Copyright (C) 2023-2026 University Corporation for Atmospheric Research
 // SPDX-License-Identifier: Apache-2.0
 //
-// End-to-end: an emissions config is parsed by MechanismConfiguration,
-// translated by musica::ConvertEmissions into a miem::Source, and that
-// Source is handed to MIEM's own EmissionsBuilder, which opens the real
-// committed fixture (test/data/x1.163842_2024_nox_subset.nc) and produces
-// real surface flux. Same shape as end_to_end.cpp's black-carbon test, but
+// End-to-end: an emissions config is parsed by MechanismConfiguration and
+// built into a musica::EmissionsModel via FromMechanism, which internally
+// translates it (ConvertEmissions) and hands it to MIEM's EmissionsBuilder.
+// The model opens the real committed fixture
+// (test/data/x1.163842_2024_nox_subset.nc) and produces real surface flux.
+// Same shape as emissions_model_end_to_end.cpp's black-carbon test, but
 // against a second real species fixture (fewer sectors, a different year)
 // to check the translation layer isn't accidentally tuned to one file.
 //
@@ -14,13 +15,10 @@
 // inventory species is split across two mechanism species, NO (0.9) and
 // NO2 (0.1), rather than passed through 1:1.
 
-#include <musica/configuration/emissions.hpp>
 #include <musica/configuration/read_mechanism.hpp>
+#include <musica/miem/emissions.hpp>
 
 #include <gtest/gtest.h>
-#include <miem/emissions.hpp>
-#include <miem/emissions_builder.hpp>
-#include <miem/emissions_state.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -74,20 +72,17 @@ namespace
   }
 }  // namespace
 
-TEST(MiemEndToEndNox, MechanismConfigThroughMusicaToRealMiemFlux)
+TEST(EmissionsModelEndToEndNox, MechanismConfigThroughMusicaToRealMiemFlux)
 {
-  musica::Emissions parsed = musica::ConvertEmissions(musica::ReadMechanismFromString(EmissionsConfigYaml()));
-  ASSERT_EQ(parsed.sources.size(), 1);
+  musica::EmissionsModel model = musica::EmissionsModel::FromMechanism(
+      musica::ReadMechanismFromString(EmissionsConfigYaml()), kNCells, /*n_vert_levels=*/1);
 
-  miem::Emissions emissions =
-      miem::EmissionsBuilder().SetGridDimensions(kNCells, /*n_vert_levels=*/1).AddSource(parsed.sources[0]).Build();
-
-  ASSERT_EQ(emissions.NumSpecies(), 2);
-  const auto& names = emissions.SpeciesNames();
+  ASSERT_EQ(model.NumSpecies(), 2);
+  const auto& names = model.SpeciesNames();
   ASSERT_NE(std::find(names.begin(), names.end(), "NO"), names.end());
   ASSERT_NE(std::find(names.begin(), names.end(), "NO2"), names.end());
 
-  const miem::EmissionsState state = emissions.Run(kEpoch20240701, /*dt=*/3600.0);
+  model.Run(kEpoch20240701, /*dt=*/3600.0);
 
   // nox_anth_sum is split 0.9 (NO) / 0.1 (NO2) from the same underlying
   // inventory flux, so NO should be exactly 9x NO2 in every cell.
@@ -96,8 +91,8 @@ TEST(MiemEndToEndNox, MechanismConfigThroughMusicaToRealMiemFlux)
   double sum_no2 = 0.0;
   for (int ic = 0; ic < kNCells; ++ic)
   {
-    const double flux_no = static_cast<double>(state.surface_flux_(ic, "NO"));
-    const double flux_no2 = static_cast<double>(state.surface_flux_(ic, "NO2"));
+    const double flux_no = model.SurfaceFlux(ic, "NO");
+    const double flux_no2 = model.SurfaceFlux(ic, "NO2");
     EXPECT_FALSE(std::isnan(flux_no));
     EXPECT_FALSE(std::isnan(flux_no2));
     EXPECT_GE(flux_no, 0.0);


### PR DESCRIPTION
## Summary
- Adds `musica::EmissionsModel` (`include/musica/miem/emissions.hpp`, `src/miem/emissions.cpp`), a musica-level convenience wrapper around `miem::EmissionsBuilder`/`miem::Emissions`, mirroring how `musica::MICM` wraps micm.
- Methods match the issue's acceptance criteria exactly: `Run(epoch_seconds, dt)` (stores and returns state), `NumSpecies()`, `SpeciesNames()`, `SurfaceFlux(cell, species)`, plus the `FromMechanism(mechanism, n_cells, n_vert_levels)` convenience that internally calls `ConvertEmissions`.
- Migrates and renames `src/test/unit/miem/end_to_end*.cpp` → `emissions_model_end_to_end*.cpp`, rewritten to exercise the new interface instead of hand-building a `miem::EmissionsBuilder`.

Closes #949

## Test plan
- [x] `cmake --build .` — full project builds clean
- [x] `ctest -R miem` — all 3 miem tests pass, including both migrated end-to-end tests
- [x] `ctest` (full suite) — 10/10 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
