### PR TITLE
Add serialize/export to aerosol mechanism configuration objects

### DIFF
--- a/python/musica/mechanism_configuration/aerosol/aerosol.py
+++ b/python/musica/mechanism_configuration/aerosol/aerosol.py
@@ -9,14 +9,14 @@
 # the C++ layer stores. Passing objects (rather than bare strings) lets typos be
 # caught at construction time and keeps the aerosol API consistent with the rest
 # of mechanism_configuration.
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from ... import backend
 from ..._base import CppWrapper, CppField, _unwrap, _unwrap_list, _wrap_list
 from ..species import Phase
 from ..species import Species
 from ..reactions import ReactionComponent
-from ..utils import _convert_components
+from ..utils import _convert_components, _remove_empty_keys
 
 _backend = backend.get_backend()
 _mc = _backend._mechanism_configuration
@@ -68,6 +68,14 @@ class Equilibrium(CppWrapper):
         self.C = C if C is not None else self.C
         self.T0 = T0 if T0 is not None else self.T0
 
+    def serialize(self) -> Dict:
+        return {
+            "type": "EQUILIBRIUM",
+            "A": self.A,
+            "C [K]": self.C,
+            "T0 [K]": self.T0,
+        }
+
 
 class HenryLawConstant(CppWrapper):
     """Henry's law constant: HLC(T) = HLC_ref * exp( C * (1/T - 1/T0) ).
@@ -93,10 +101,38 @@ class HenryLawConstant(CppWrapper):
         self.C = C if C is not None else self.C
         self.T0 = T0 if T0 is not None else self.T0
 
+    def serialize(self) -> Dict:
+        return {
+            "HLC_ref [mol m-3 Pa-1]": self.HLC_ref,
+            "C [K]": self.C,
+            "T0 [K]": self.T0,
+        }
+
 
 def _convert_rate_constant(rc):
     """Unwrap a rate constant (wrapper object) or pass a callable through."""
     return _unwrap(rc)
+
+
+def _serialize_rate_constant(rc) -> Dict:
+    """Serialize an aerosol rate constant to a mechanism configuration dict.
+
+    Aerosol rate constants are either an :class:`Arrhenius` (from the gas-phase
+    reaction types) or an :class:`Equilibrium`. Accessed off the C++ objects the
+    values come back as raw pybind11 objects, so dispatch is by the C++ type.
+    Callable (Python function) rate constants cannot be represented in a
+    configuration file and raise :class:`TypeError`.
+    """
+    cpp = _unwrap(rc)
+    if isinstance(cpp, _mc._Equilibrium):
+        return Equilibrium._from_cpp(cpp).serialize()
+    if isinstance(cpp, _mc._Arrhenius):
+        # The aerosol rate-constant schema allows only A and C for an Arrhenius block.
+        return {"type": "ARRHENIUS", "A": cpp.A, "C": cpp.C}
+    raise TypeError(
+        f"Cannot serialize rate constant of type {type(cpp).__name__}; "
+        "only Arrhenius and Equilibrium rate constants are serializable."
+    )
 
 
 # -- Representations ----------------------------------------------------------
@@ -143,6 +179,17 @@ class UniformSection(CppWrapper):
             {
                 f"{self.name}.MIN_RADIUS": self.min_radius,
                 f"{self.name}.MAX_RADIUS": self.max_radius,
+            }
+        )
+
+    def serialize(self) -> Dict:
+        return _remove_empty_keys(
+            {
+                "type": "UNIFORM_SECTION",
+                "name": self.name,
+                "phases": self.phases,
+                "minimum radius [m]": self.min_radius,
+                "maximum radius [m]": self.max_radius,
             }
         )
 
@@ -197,6 +244,17 @@ class SingleMomentMode(CppWrapper):
             }
         )
 
+    def serialize(self) -> Dict:
+        return _remove_empty_keys(
+            {
+                "type": "SINGLE_MOMENT_MODE",
+                "name": self.name,
+                "phases": self.phases,
+                "geometric mean radius [m]": self.geometric_mean_radius,
+                "geometric standard deviation": self.geometric_standard_deviation,
+            }
+        )
+
 
 class TwoMomentMode(CppWrapper):
     """A two-moment modal aerosol representation.
@@ -238,6 +296,16 @@ class TwoMomentMode(CppWrapper):
         state.set_user_defined_rate_parameters(
             {
                 f"{self.name}.GEOMETRIC_STANDARD_DEVIATION": self.geometric_standard_deviation,
+            }
+        )
+
+    def serialize(self) -> Dict:
+        return _remove_empty_keys(
+            {
+                "type": "TWO_MOMENT_MODE",
+                "name": self.name,
+                "phases": self.phases,
+                "geometric standard deviation": self.geometric_standard_deviation,
             }
         )
 
@@ -311,6 +379,18 @@ class DissolvedReaction(CppWrapper):
     @rate_constants.setter
     def rate_constants(self, value):
         self._cpp.rate_constants = _convert_rate_constant(value)
+
+    def serialize(self) -> Dict:
+        return _remove_empty_keys(
+            {
+                "type": "DISSOLVED_REACTION",
+                "condensed phase": self.phase,
+                "solvent": self.solvent,
+                "reactants": [r.serialize() for r in self.reactants],
+                "products": [p.serialize() for p in self.products],
+                "rate constants": _serialize_rate_constant(self.rate_constants),
+            }
+        )
 
 
 class DissolvedReversibleReaction(CppWrapper):
@@ -397,6 +477,22 @@ class DissolvedReversibleReaction(CppWrapper):
     def equilibrium_constant(self, value):
         self._cpp.equilibrium_constant = _unwrap(value) if value is not None else None
 
+    def serialize(self) -> Dict:
+        serialize_dict = {
+            "type": "DISSOLVED_REVERSIBLE_REACTION",
+            "condensed phase": self.phase,
+            "solvent": self.solvent,
+            "reactants": [r.serialize() for r in self.reactants],
+            "products": [p.serialize() for p in self.products],
+        }
+        if self.forward_rate_constants is not None:
+            serialize_dict["forward rate constants"] = _serialize_rate_constant(self.forward_rate_constants)
+        if self.reverse_rate_constants is not None:
+            serialize_dict["reverse rate constants"] = _serialize_rate_constant(self.reverse_rate_constants)
+        if self.equilibrium_constant is not None:
+            serialize_dict["equilibrium constant"] = self.equilibrium_constant.serialize()
+        return _remove_empty_keys(serialize_dict)
+
 
 class HenryLawPhaseTransfer(CppWrapper):
     """Henry's law gas-to-aqueous phase transfer.
@@ -453,6 +549,22 @@ class HenryLawPhaseTransfer(CppWrapper):
     @henry_law_constant.setter
     def henry_law_constant(self, value):
         self._cpp.henry_law_constant = _unwrap(value)
+
+    def serialize(self) -> Dict:
+        # The diffusion coefficient is sourced from the gas-phase species' definition
+        # (not from this block), so it is not part of the serialized configuration.
+        return _remove_empty_keys(
+            {
+                "type": "HENRY_LAW_PHASE_TRANSFER",
+                "gas phase": self.gas_phase,
+                "gas-phase species": self.gas_species,
+                "condensed phase": self.condensed_phase,
+                "condensed-phase species": self.condensed_species,
+                "solvent": self.solvent,
+                "Henry's law constant": self.henry_law_constant.serialize(),
+                "accommodation coefficient": self.accommodation_coefficient,
+            }
+        )
 
 
 # -- Constraints --------------------------------------------------------------
@@ -511,6 +623,21 @@ class HenryLawEquilibrium(CppWrapper):
     @henry_law_constant.setter
     def henry_law_constant(self, value):
         self._cpp.henry_law_constant = _unwrap(value)
+
+    def serialize(self) -> Dict:
+        # The solvent molecular weight and density are sourced from the solvent
+        # species' definition, so they are not part of the serialized configuration.
+        return _remove_empty_keys(
+            {
+                "type": "HENRY_LAW_EQUILIBRIUM",
+                "gas phase": self.gas_phase,
+                "gas-phase species": self.gas_species,
+                "condensed phase": self.condensed_phase,
+                "condensed-phase species": self.condensed_species,
+                "solvent": self.solvent,
+                "Henry's law constant": self.henry_law_constant.serialize(),
+            }
+        )
 
 
 class DissolvedEquilibrium(CppWrapper):
@@ -576,6 +703,19 @@ class DissolvedEquilibrium(CppWrapper):
     def equilibrium_constant(self, value):
         self._cpp.equilibrium_constant = _unwrap(value)
 
+    def serialize(self) -> Dict:
+        return _remove_empty_keys(
+            {
+                "type": "DISSOLVED_EQUILIBRIUM",
+                "condensed phase": self.phase,
+                "algebraic species": self.algebraic_species,
+                "solvent": self.solvent,
+                "reactants": [r.serialize() for r in self.reactants],
+                "products": [p.serialize() for p in self.products],
+                "equilibrium constant": self.equilibrium_constant.serialize(),
+            }
+        )
+
 
 class LinearConstraintTerm(CppWrapper):
     """A single term of a LinearConstraint: coefficient * [species] in a phase.
@@ -608,6 +748,16 @@ class LinearConstraintTerm(CppWrapper):
     @species.setter
     def species(self, value):
         self._cpp.name = _name(value)
+
+    def serialize(self) -> Dict:
+        return _remove_empty_keys(
+            {
+                "phase": self.phase,
+                # The configuration key for a term's species reference is `name`.
+                "name": self.species,
+                "coefficient": self.coefficient,
+            }
+        )
 
 
 class FixedConstant(CppWrapper):
@@ -673,6 +823,22 @@ class LinearConstraint(CppWrapper):
     @constant.setter
     def constant(self, value):
         self._cpp.constant = _unwrap(value)
+
+    def serialize(self) -> Dict:
+        serialize_dict = {
+            "type": "LINEAR_CONSTRAINT",
+            "algebraic phase": self.algebraic_phase,
+            "algebraic species": self.algebraic_species,
+            "terms": [t.serialize() for t in self.terms],
+        }
+        # The RHS constant is expressed either as a fixed value or as diagnosed
+        # from state (mutually exclusive in the configuration schema).
+        constant = _unwrap(self.constant)
+        if isinstance(constant, _mc._DiagnoseFromState):
+            serialize_dict["diagnose from state"] = True
+        elif isinstance(constant, _mc._FixedConstant):
+            serialize_dict["constant [mol m-3]"] = constant.value
+        return _remove_empty_keys(serialize_dict)
 
 
 # -- Container ----------------------------------------------------------------
@@ -765,3 +931,20 @@ class Aerosol(CppWrapper):
         """
         for representation in self.representations:
             representation.set_default_parameters(state)
+
+    def serialize(self) -> Dict:
+        """Serialize to the two top-level mechanism configuration aerosol sections.
+
+        Returns a dict with ``"aerosol representations"`` and ``"aerosol
+        processes"`` keys. In the configuration format, processes and constraints
+        share the single ``"aerosol processes"`` section, so both are emitted
+        there. The returned keys are merged into the owning Mechanism's
+        top-level configuration.
+        """
+        return {
+            "aerosol representations": [r.serialize() for r in self.representations],
+            "aerosol processes": (
+                [p.serialize() for p in self.processes]
+                + [c.serialize() for c in self.constraints]
+            ),
+        }

--- a/python/musica/mechanism_configuration/mechanism.py
+++ b/python/musica/mechanism_configuration/mechanism.py
@@ -167,6 +167,10 @@ class Mechanism(CppWrapper):
             "phases": [p.serialize() for p in self.phases],
             "version": self.version.to_string(),
         }
+        if self.aerosol is not None:
+            # Aerosol contributes two top-level sections ("aerosol representations"
+            # and "aerosol processes"), so its keys are merged in rather than nested.
+            serialize_dict.update(self.aerosol.serialize())
         if self.emissions is not None:
             serialize_dict["emissions"] = self.emissions.serialize()
         return serialize_dict

--- a/python/test/unit/mechanism_configuration/test_aerosol_types.py
+++ b/python/test/unit/mechanism_configuration/test_aerosol_types.py
@@ -477,3 +477,182 @@ class TestAerosol:
             ],
         )
         assert len(aerosol.constraints) == 3
+
+
+# ═══ Serialization ═══════════════════════════════════════════════════════════
+
+
+class TestRateConstantSerialize:
+    def test_equilibrium(self):
+        assert Equilibrium(A=1725.0, C=0.0, T0=298.15).serialize() == {
+            "type": "EQUILIBRIUM",
+            "A": 1725.0,
+            "C [K]": 0.0,
+            "T0 [K]": 298.15,
+        }
+
+    def test_henry_law_constant(self):
+        assert HenryLawConstant(HLC_ref=1e-2, C=3000.0).serialize() == {
+            "HLC_ref [mol m-3 Pa-1]": 1e-2,
+            "C [K]": 3000.0,
+            "T0 [K]": pytest.approx(298.15),
+        }
+
+
+class TestRepresentationSerialize:
+    def test_uniform_section(self):
+        assert UniformSection(name="CLOUD", phases=["AQ"], min_radius=1e-6, max_radius=1e-5).serialize() == {
+            "type": "UNIFORM_SECTION",
+            "name": "CLOUD",
+            "phases": ["AQ"],
+            "minimum radius [m]": 1e-6,
+            "maximum radius [m]": 1e-5,
+        }
+
+    def test_single_moment_mode(self):
+        assert SingleMomentMode(
+            name="aitken", phases=["AQ"], geometric_mean_radius=1e-6, geometric_standard_deviation=1.5
+        ).serialize() == {
+            "type": "SINGLE_MOMENT_MODE",
+            "name": "aitken",
+            "phases": ["AQ"],
+            "geometric mean radius [m]": 1e-6,
+            "geometric standard deviation": 1.5,
+        }
+
+    def test_two_moment_mode(self):
+        assert TwoMomentMode(name="fine", phases=["AQ"], geometric_standard_deviation=1.6).serialize() == {
+            "type": "TWO_MOMENT_MODE",
+            "name": "fine",
+            "phases": ["AQ"],
+            "geometric standard deviation": 1.6,
+        }
+
+
+class TestProcessSerialize:
+    def test_dissolved_reaction_with_arrhenius(self):
+        d = DissolvedReaction(
+            phase="AQ", solvent="H2O",
+            reactants=[Species(name="A")], products=[Species(name="B")],
+            rate_constants=Arrhenius(A=1e3, C=100.0),
+        ).serialize()
+        assert d["type"] == "DISSOLVED_REACTION"
+        assert d["condensed phase"] == "AQ"
+        assert d["solvent"] == "H2O"
+        assert d["reactants"] == [{"name": "A", "coefficient": 1.0}]
+        assert d["products"] == [{"name": "B", "coefficient": 1.0}]
+        assert d["rate constants"] == {"type": "ARRHENIUS", "A": 1e3, "C": 100.0}
+        # Internal-only fields have no configuration key and must not be emitted.
+        assert "solvent floor" not in d and "min halflife" not in d
+
+    def test_dissolved_reaction_callable_raises(self):
+        rxn = DissolvedReaction(phase="AQ", solvent="H2O", rate_constants=lambda T: 1.0)
+        with pytest.raises(TypeError):
+            rxn.serialize()
+
+    def test_dissolved_reversible_reaction(self):
+        d = DissolvedReversibleReaction(
+            phase="AQ", solvent="H2O",
+            reactants=[Species(name="A")], products=[Species(name="B")],
+            forward_rate_constants=Arrhenius(A=1e3, C=100.0),
+            equilibrium_constant=Equilibrium(A=1725.0),
+        ).serialize()
+        assert d["type"] == "DISSOLVED_REVERSIBLE_REACTION"
+        assert d["forward rate constants"] == {"type": "ARRHENIUS", "A": 1e3, "C": 100.0}
+        assert d["equilibrium constant"]["type"] == "EQUILIBRIUM"
+        # Unset optional rate constants are omitted entirely.
+        assert "reverse rate constants" not in d
+
+    def test_henry_law_phase_transfer(self):
+        d = HenryLawPhaseTransfer(
+            gas_phase="gas", gas_species="A", condensed_phase="AQ",
+            condensed_species="A", solvent="H2O",
+            henry_law_constant=HenryLawConstant(HLC_ref=1e-2, C=3000.0),
+            diffusion_coefficient=1.5e-5, accommodation_coefficient=0.1,
+        ).serialize()
+        assert d["type"] == "HENRY_LAW_PHASE_TRANSFER"
+        assert d["gas-phase species"] == "A"
+        assert d["condensed-phase species"] == "A"
+        assert d["accommodation coefficient"] == 0.1
+        assert d["Henry's law constant"]["HLC_ref [mol m-3 Pa-1]"] == 1e-2
+        # Diffusion coefficient is derived from the species definition, not serialized.
+        assert "diffusion coefficient [m2 s-1]" not in d
+
+
+class TestConstraintSerialize:
+    def test_henry_law_equilibrium(self):
+        d = HenryLawEquilibrium(
+            gas_phase="gas", gas_species="A", condensed_phase="AQ",
+            condensed_species="A", solvent="H2O",
+            henry_law_constant=HenryLawConstant(HLC_ref=1e-2, C=3000.0),
+            solvent_molecular_weight=0.018, solvent_density=1000.0,
+        ).serialize()
+        assert d["type"] == "HENRY_LAW_EQUILIBRIUM"
+        assert d["gas-phase species"] == "A"
+        # Solvent molecular weight/density are derived from the species definition.
+        assert "solvent molecular weight [kg mol-1]" not in d
+        assert "solvent density [kg m-3]" not in d
+
+    def test_dissolved_equilibrium(self):
+        d = DissolvedEquilibrium(
+            phase="AQ", solvent="H2O",
+            reactants=[Species(name="A")], products=[Species(name="B")],
+            algebraic_species="A", equilibrium_constant=Equilibrium(A=1.0),
+        ).serialize()
+        assert d["type"] == "DISSOLVED_EQUILIBRIUM"
+        assert d["condensed phase"] == "AQ"
+        assert d["algebraic species"] == "A"
+        assert d["equilibrium constant"]["type"] == "EQUILIBRIUM"
+
+    def test_linear_constraint_term(self):
+        assert LinearConstraintTerm("AQ", "SO4mm", 2.0).serialize() == {
+            "phase": "AQ",
+            "name": "SO4mm",
+            "coefficient": 2.0,
+        }
+
+    def test_linear_constraint_fixed_constant(self):
+        d = LinearConstraint(
+            algebraic_phase="AQ", algebraic_species="A",
+            terms=[LinearConstraintTerm("AQ", "A", 1.0)],
+            constant=FixedConstant(3e-8),
+        ).serialize()
+        assert d["type"] == "LINEAR_CONSTRAINT"
+        assert d["constant [mol m-3]"] == 3e-8
+        assert "diagnose from state" not in d
+        assert d["terms"] == [{"phase": "AQ", "name": "A", "coefficient": 1.0}]
+
+    def test_linear_constraint_diagnose_from_state(self):
+        d = LinearConstraint(
+            algebraic_phase="AQ", algebraic_species="A",
+            terms=[LinearConstraintTerm("AQ", "A", 1.0)],
+            constant=DiagnoseFromState(),
+        ).serialize()
+        assert d["diagnose from state"] is True
+        assert "constant [mol m-3]" not in d
+
+
+class TestAerosolContainerSerialize:
+    def test_processes_and_constraints_share_processes_section(self):
+        aerosol = Aerosol(
+            representations=[
+                SingleMomentMode(name="aitken", phases=["AQ"],
+                                 geometric_mean_radius=1e-6, geometric_standard_deviation=1.5),
+            ],
+            processes=[
+                DissolvedReaction(phase="AQ", solvent="H2O",
+                                  reactants=[Species(name="A")], products=[Species(name="B")],
+                                  rate_constants=Arrhenius(A=1e3, C=100.0)),
+            ],
+            constraints=[
+                LinearConstraint(algebraic_phase="AQ", algebraic_species="A",
+                                 terms=[LinearConstraintTerm("AQ", "A", 1.0)]),
+            ],
+        )
+        d = aerosol.serialize()
+        assert set(d.keys()) == {"aerosol representations", "aerosol processes"}
+        assert len(d["aerosol representations"]) == 1
+        # Processes come first, then constraints, in the shared section.
+        assert len(d["aerosol processes"]) == 2
+        assert d["aerosol processes"][0]["type"] == "DISSOLVED_REACTION"
+        assert d["aerosol processes"][1]["type"] == "LINEAR_CONSTRAINT"

--- a/python/test/unit/mechanism_configuration/test_serializer.py
+++ b/python/test/unit/mechanism_configuration/test_serializer.py
@@ -1,7 +1,79 @@
 import pytest
 import os
+import musica.mechanism_configuration as mc
 from musica.mechanism_configuration import Mechanism, parse
 from test_util_full_mechanism import get_fully_defined_mechanism, validate_full_v1_mechanism
+
+
+def _get_aerosol_mechanism():
+    """A mechanism with a full aerosol section that satisfies the aerosol model validator."""
+    A = mc.Species(name="A", molecular_weight_kg_mol=0.05)
+    B = mc.Species(name="B")
+    H2O = mc.Species(name="H2O", molecular_weight_kg_mol=0.018)
+
+    gas = mc.Phase(name="gas", species=[mc.PhaseSpecies(name="A", diffusion_coefficient_m2_s=1.5e-5)])
+    aqueous = mc.Phase(name="aqueous", species=[
+        mc.PhaseSpecies(name="A"),
+        mc.PhaseSpecies(name="B"),
+        mc.PhaseSpecies(name="H2O", density_kg_m3=1000.0),
+    ])
+
+    aerosol = mc.Aerosol(
+        representations=[
+            mc.SingleMomentMode(name="aitken", phases=[aqueous],
+                                geometric_mean_radius=1e-6, geometric_standard_deviation=1e-5),
+            mc.UniformSection(name="coarse", phases=[aqueous], min_radius=1e-6, max_radius=1e-5),
+            mc.TwoMomentMode(name="fine", phases=[aqueous], geometric_standard_deviation=1.6),
+        ],
+        processes=[
+            mc.HenryLawPhaseTransfer(
+                gas_phase="gas", gas_species="A", condensed_phase="aqueous",
+                condensed_species="A", solvent="H2O",
+                henry_law_constant=mc.HenryLawConstant(HLC_ref=1e-2, C=3000.0),
+                accommodation_coefficient=0.1),
+            mc.DissolvedReaction(
+                phase="aqueous", solvent="H2O",
+                reactants=[mc.Species(name="A")], products=[mc.Species(name="B")],
+                rate_constants=mc.Arrhenius(A=1e3, C=100.0)),
+            mc.DissolvedReversibleReaction(
+                phase="aqueous", solvent="H2O",
+                reactants=[mc.Species(name="A")], products=[mc.Species(name="B")],
+                forward_rate_constants=mc.Arrhenius(A=1e3, C=100.0),
+                equilibrium_constant=mc.Equilibrium(A=1725.0, C=0.0)),
+        ],
+        constraints=[
+            mc.HenryLawEquilibrium(
+                gas_phase="gas", gas_species="A", condensed_phase="aqueous",
+                condensed_species="A", solvent="H2O",
+                henry_law_constant=mc.HenryLawConstant(HLC_ref=1e-2, C=3000.0)),
+            mc.DissolvedEquilibrium(
+                phase="aqueous", solvent="H2O",
+                reactants=[mc.Species(name="A")], products=[mc.Species(name="B")],
+                algebraic_species="A", equilibrium_constant=mc.Equilibrium(A=1.0)),
+            mc.LinearConstraint(
+                algebraic_phase="gas", algebraic_species="A",
+                terms=[mc.LinearConstraintTerm("gas", "A", 1.0)],
+                constant=mc.DiagnoseFromState()),
+            mc.LinearConstraint(
+                algebraic_phase="aqueous", algebraic_species="B",
+                terms=[mc.LinearConstraintTerm("aqueous", "B", 1.0)],
+                constant=mc.FixedConstant(3e-8)),
+        ],
+    )
+    return mc.Mechanism(name="aerosol test", version=mc.Version(1, 0, 0),
+                        species=[A, B, H2O], phases=[gas, aqueous], aerosol=aerosol)
+
+
+def test_aerosol_serialize_export_loop(tmp_path):
+    mechanism = _get_aerosol_mechanism()
+    for extension in (".json", ".yml", ".yaml"):
+        path = f"{tmp_path}/aerosol_mechanism{extension}"
+        mechanism.export(path)
+        parsed = parse(path)
+        assert parsed.aerosol is not None
+        assert len(parsed.aerosol.representations) == 3
+        assert len(parsed.aerosol.processes) == 3
+        assert len(parsed.aerosol.constraints) == 4
 
 
 def test_mechanism_export_loop(tmp_path):


### PR DESCRIPTION
Close #965 

Implements serialization for aerosol types, adds tests for aerosol serialization

AI usage: i had claude do this one since it was wrote work