### PR TITLE
Fix size-distribution graphs in tutorial 18 (CAM aerosol distributions)

### DIFF
--- a/tutorials/18. cam_aerosol_distributions.ipynb
+++ b/tutorials/18. cam_aerosol_distributions.ipynb
@@ -42,12 +42,7 @@
    "cell_type": "markdown",
    "id": "546e9dba",
    "metadata": {},
-   "source": [
-    "## Part 1 — Size-distribution shapes\n",
-    "\n",
-    "We'll create one panel per scheme, plotting the number distribution `dN/dln(r)` normalized to\n",
-    "unit total number, on a shared log-radius axis."
-   ]
+   "source": "## Part 1 — Size-distribution shapes\n\nWe'll create one panel per scheme, plotting the number distribution `dN/dln(r)` normalized to\nunit total number, on a **shared log-radius axis (µm)** so the three schemes are directly comparable.\n\nTwo placement notes, since not every scheme prescribes an absolute size:\n\n- **MAM (modal)**: `TwoMomentMode` fixes only σ_g — the modal diameter is *prognostic*, drifting\n  within a fixed range. To place each mode on the shared axis we center it at the **geometric mean\n  of its published diameter range** (Liu et al. 2012, *Geosci. Model Dev.* 5, 709–739, Table 1 —\n  MAM3 rows for accumulation/aitken/coarse, the MAM7 row for primary carbon); σ_g is the real\n  prescribed shape.\n- **CARMA (sectional)**: the bins prescribe only edges, not a number-per-bin. We overlay an\n  *illustrative* lognormal number distribution sampled onto the bins to show how a sectional scheme\n  approximates a smooth distribution with piecewise-constant steps."
   },
   {
    "cell_type": "code",
@@ -55,16 +50,7 @@
    "id": "4136802f",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def lognormal_dNdlnr(r, r_g, sigma_g):\n",
-    "    \"\"\"Unit-area lognormal number distribution dN/dln(r).\"\"\"\n",
-    "    ln_s = np.log(sigma_g)\n",
-    "    return np.exp(-(np.log(r / r_g))**2 / (2.0 * ln_s**2)) / (np.sqrt(2.0 * np.pi) * ln_s)\n",
-    "\n",
-    "radius = np.logspace(-9, -4, 600)         # absolute radius grid [m] (1 nm .. 100 um)\n",
-    "radius_um = radius * 1e6\n",
-    "size_ratio = np.logspace(-1.3, 1.3, 400)  # r / r_g, for modes whose position is prognostic"
-   ]
+   "source": "def lognormal_dNdlnr(r, r_g, sigma_g):\n    \"\"\"Unit-area lognormal number distribution dN/dln(r).\"\"\"\n    ln_s = np.log(sigma_g)\n    return np.exp(-(np.log(r / r_g))**2 / (2.0 * ln_s**2)) / (np.sqrt(2.0 * np.pi) * ln_s)\n\nradius = np.logspace(-9, -4, 600)         # absolute radius grid [m] (1 nm .. 100 um)\nradius_um = radius * 1e6\n\n# MAM modal diameters are prognostic within a fixed range; TwoMomentMode stores only\n# sigma_g.  For placement on the shared axis we center each mode at the geometric-mean\n# *radius* of its published diameter range -- Liu et al. (2012), Geosci. Model Dev. 5,\n# 709-739, Table 1 (MAM3 rows for accum/aitken/coarse, MAM7 row for primary carbon):\n#   mode            diameter range [um]   geometric-mean radius [m]\n#   accumulation    0.058 - 0.27          sqrt(0.058*0.27)/2  = 6.26e-8\n#   aitken          0.015 - 0.053         sqrt(0.015*0.053)/2 = 1.41e-8\n#   coarse          0.80  - 3.65          sqrt(0.80*3.65)/2   = 8.54e-7\n#   primary_carbon  0.039 - 0.13          sqrt(0.039*0.13)/2  = 3.56e-8\nMAM_NOMINAL_RG = {\n    \"ACCUM\": 6.26e-8, \"AITKEN\": 1.41e-8, \"COARSE\": 8.54e-7, \"PRIMARY_CARBON\": 3.56e-8,\n}"
   },
   {
    "cell_type": "code",
@@ -72,45 +58,7 @@
    "id": "c7475916",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "fig, axes = plt.subplots(3, 1, figsize=(8.5, 12))\n",
-    "\n",
-    "# --- MAM4: modal.  TwoMomentMode fixes ONLY sigma_g (the diameter is diagnosed\n",
-    "#     at runtime), so we plot the normalized shape vs r/r_g straight from the type. ---\n",
-    "ax = axes[0]\n",
-    "for mode in mam_representations()[\"mam4\"]:\n",
-    "    ax.plot(size_ratio, lognormal_dNdlnr(size_ratio, 1.0, mode.geometric_standard_deviation),\n",
-    "            label=f\"{mode.name} (σ={mode.geometric_standard_deviation})\")\n",
-    "ax.set_xlabel(\"radius / geometric mean radius\")\n",
-    "ax.set_title(\"MAM4 — modal (TwoMomentMode: only σ_g fixed; diameter is prognostic)\")\n",
-    "\n",
-    "# --- BAM: SingleMomentMode fixes both geometric mean radius and sigma_g ---\n",
-    "ax = axes[1]\n",
-    "for rep in bam_representations():\n",
-    "    ax.plot(radius_um, lognormal_dNdlnr(radius, rep.geometric_mean_radius,\n",
-    "                                        rep.geometric_standard_deviation),\n",
-    "            label=rep.name, lw=1.2)\n",
-    "ax.set_xlabel(\"radius [µm]\")\n",
-    "ax.set_title(\"BAM — SingleMomentMode (fixed geometric mean radius + σ_g)\")\n",
-    "\n",
-    "# --- CARMA sulfate: UniformSection per bin, using each section's min/max radius ---\n",
-    "ax = axes[2]\n",
-    "bins = carma_representations(\"sulfate\")\n",
-    "edges = np.array([bins[0].min_radius] + [b.max_radius for b in bins]) * 1e6\n",
-    "dlnr = np.log(edges[1:] / edges[:-1])\n",
-    "heights = (1.0 / len(bins)) / dlnr             # equal N per bin -> dN/dlnr\n",
-    "ax.stairs(heights, edges, fill=True, alpha=0.4, color=\"C0\")\n",
-    "ax.stairs(heights, edges, color=\"C0\")\n",
-    "ax.set_xlabel(\"radius [µm]\")\n",
-    "ax.set_title(f\"CARMA sulfate — UniformSection per bin ({len(bins)} bins, equal N/bin)\")\n",
-    "\n",
-    "for ax in axes:\n",
-    "    ax.set_xscale(\"log\")\n",
-    "    ax.set_ylabel(\"dN/dln(r)  (unit total N)\")\n",
-    "    ax.legend(fontsize=7, ncol=2)\n",
-    "fig.tight_layout()\n",
-    "plt.show()"
-   ]
+   "source": "fig, axes = plt.subplots(3, 1, figsize=(8.5, 12))\n\n# --- MAM4: modal.  TwoMomentMode fixes ONLY sigma_g (the diameter is diagnosed at\n#     runtime within a range), so we place each mode at the geometric-mean radius of\n#     its Liu et al. 2012 diameter range and plot the true sigma_g shape. ---\nax = axes[0]\nfor mode in mam_representations()[\"mam4\"]:\n    r_g = MAM_NOMINAL_RG[mode.name]\n    ax.plot(radius_um, lognormal_dNdlnr(radius, r_g, mode.geometric_standard_deviation),\n            label=f\"{mode.name} (r_g≈{r_g*1e6:.3g} µm, σ={mode.geometric_standard_deviation})\")\nax.set_xlabel(\"radius [µm]\")\nax.set_title(\"MAM4 — modal (σ_g fixed; placed at geometric mean of Liu et al. 2012 range)\")\n\n# --- BAM: SingleMomentMode fixes both geometric mean radius and sigma_g ---\nax = axes[1]\nfor rep in bam_representations():\n    ax.plot(radius_um, lognormal_dNdlnr(radius, rep.geometric_mean_radius,\n                                        rep.geometric_standard_deviation),\n            label=rep.name, lw=1.2)\nax.set_xlabel(\"radius [µm]\")\nax.set_title(\"BAM — SingleMomentMode (fixed geometric mean radius + σ_g)\")\n\n# --- CARMA sulfate: UniformSection per bin, using each section's min/max radius.\n#     The bins prescribe only edges, so we overlay an ILLUSTRATIVE lognormal number\n#     distribution sampled onto the bins -> the sectional (piecewise-constant)\n#     approximation to a smooth dN/dln(r). ---\nax = axes[2]\nbins = carma_representations(\"sulfate\")\nedges = np.array([bins[0].min_radius] + [b.max_radius for b in bins]) * 1e6\ncenters = np.array([np.sqrt(b.min_radius * b.max_radius) for b in bins])   # geometric bin centers [m]\ndlnr = np.log(edges[1:] / edges[:-1])\nCARMA_RG, CARMA_SIGMA = 0.06e-6, 1.8          # illustrative background-sulfate lognormal\nn_per_bin = lognormal_dNdlnr(centers, CARMA_RG, CARMA_SIGMA) * dlnr\nn_per_bin /= n_per_bin.sum()                   # normalize to unit total N\nheights = n_per_bin / dlnr                     # -> dN/dlnr\nax.stairs(heights, edges, fill=True, alpha=0.4, color=\"C0\")\nax.stairs(heights, edges, color=\"C0\", label=f\"illustrative lognormal (r_g={CARMA_RG*1e6:.2g} µm)\")\nax.set_title(f\"CARMA sulfate — UniformSection per bin ({len(bins)} bins, illustrative N)\")\n\nfor ax in axes:\n    ax.set_xscale(\"log\")\n    ax.set_xlabel(\"radius [µm]\")\n    ax.set_ylabel(\"dN/dln(r)  (unit total N)\")\n    ax.legend(fontsize=7, ncol=2)\nfig.tight_layout()\nplt.show()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Update graphs of cam aerosol configurations to better show their differences

- **MAM4:** modes were plotted vs `r/r_g` at 1.0, so modes sharing σ_g overlapped exactly (4 legend entries, only 2 visible curves). Now each mode is placed at the geometric-mean radius of its published diameter range — Liu et al. (2012), *Geosci. Model Dev.* 5, 709–739, Table 1 (MAM3 rows for accum/aitken/coarse, MAM7 row for primary carbon) — plotted with its true σ_g; 4 distinct modes render.
- **CARMA sulfate:** replaced the flat equal-N rectangle with an illustrative lognormal (r_g=0.06 µm, σ=1.8) sampled onto the bins, showing the piecewise-constant sectional approximation. 

🤖 Generated with [Claude Code](https://claude.com/claude-code), but I verified the citation and values from the citation by hand