### PR TITLE
Stamp v1 version when converting a v0 config with musica-cli

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -64,4 +64,4 @@ number: 10
 page: "E1743 - E1760"
 doi: "10.1175/BAMS-D-19-0331.1"
 url: "https://journals.ametsoc.org/view/journals/bams/101/10/bamsD190331.xml"
-version: 0.16.3
+version: 0.16.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 # pyproject.toml extracts the version from this line via regex — keep version on this line
-project(musica VERSION 0.16.3)
+project(musica VERSION 0.16.4)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -67,7 +67,7 @@ endif()
 
 if(MUSICA_BUILD_C_CXX_INTERFACE AND NOT MUSICA_USE_PREBUILT)
   set_git_default(MECH_CONFIG_GIT_REPOSITORY https://github.com/NCAR/MechanismConfiguration.git)
-  set_git_default(MECH_CONFIG_GIT_TAG 2484131c347449291c28be7b5c0aa62acf0e1157)
+  set_git_default(MECH_CONFIG_GIT_TAG 2fb23128b3828e84c0bb73f87a678af3a8c3786c)
 
   FetchContent_Declare(mechanism_configuration
       GIT_REPOSITORY ${MECH_CONFIG_GIT_REPOSITORY}

--- a/python/musica/main.py
+++ b/python/musica/main.py
@@ -6,7 +6,7 @@ import os
 import sys
 from musica import Examples
 from musica import __version__
-from musica.mechanism_configuration import parse
+from musica.mechanism_configuration import parse, Version
 import musica.examples
 import importlib.resources as ir
 import musica
@@ -84,6 +84,9 @@ def convert_configuration(logger, configuration, output_path):
         raise ValueError(f"Configuration file '{configuration}' does not exist.")
 
     mechanism = parse(configuration)
+    # The parser stamps the source version (0.0.0 for a v0 config); this command emits a
+    # v1 document, so re-label it as v1 or the output routes back to the v0 parser on load.
+    mechanism.version = Version(1, 0, 0)
     mechanism.export(output_path)
 
 

--- a/python/test/unit/mechanism_configuration/test_parser.py
+++ b/python/test/unit/mechanism_configuration/test_parser.py
@@ -58,5 +58,22 @@ def test_convert_v0_to_v1():
         assert mechanism is not None
 
 
+def test_convert_command_stamps_v1_version(tmp_path):
+    # `musica-cli --convert` emits a v1 document; the parser stamps the source version
+    # (0.0.0 for a v0 config), so the command must re-label it or the output routes back
+    # to the v0 parser on load.
+    import json
+    import logging
+    from musica.main import convert_configuration
+
+    path = find_config_path("v0", "surface", "config.json")
+    out = tmp_path / "converted.json"
+    convert_configuration(logging.getLogger(__name__), path, str(out))
+
+    with open(out) as f:
+        data = json.load(f)
+    assert data["version"] == "1.0.0"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Problem

`musica-cli --convert <v0-config> -o out.json` produces a v1-structured mechanism, but the output is stamped `"version": "0.0.0"`. `convert_configuration` does `parse()` then `export()`, and the v0 parser stamps the mechanism version as `0.0.0`. On the next load, `Parse()` reads that version and dispatches to the **v0** parser, which then looks for `camp-files` and fails — the converted file is v1-structured.

This blocks the intended workflow of converting a v0 config and embedding the result as an inline `mechanism` in a music_box v1 configuration.

## Fix

Re-label the mechanism as `1.0.0` in `convert_configuration` before export, since the command's job is to emit a v1 document. Added a test asserting the exported file carries `"version": "1.0.0"`.

> Note: fully round-tripping a v0 config to a loadable v1 mechanism also needs the companion v0-parser fixes in NCAR/MechanismConfiguration#309 (diffusion coefficient, merged) and NCAR/MechanismConfiguration#310 (`THIRD_BODY`, per-reaction gas phase, surface-name prefix). This PR addresses only the version stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)