### PR TITLE
Evaluate allocation and deallocation mechanism matches in Fortran routine

### DIFF
--- a/fortran/test/unit/util.F90
+++ b/fortran/test/unit/util.F90
@@ -10,13 +10,15 @@ program test_util
 #define ASSERT_EQ( a, b ) call assert( a == b, __FILE__, __LINE__ )
 #define ASSERT_NE( a, b ) call assert( a /= b, __FILE__, __LINE__ )
 
-   use, intrinsic :: iso_c_binding, only: c_char, c_ptr, c_loc, c_size_t, c_null_char
+   use, intrinsic :: iso_c_binding, only: c_char, c_ptr, c_loc, c_size_t, &
+      c_null_char, c_associated
    use musica_util
    implicit none
 
    integer, parameter :: dk = musica_dk
 
    call test_string_t()
+   call test_string_t_c()
    call test_error_t()
    call test_mapping_t()
    call test_index_mapping_t()
@@ -83,6 +85,29 @@ contains
       ASSERT_EQ( c_char, "grault" )
 
    end subroutine test_string_t
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   !> Tests the string_t_c create/delete
+   subroutine test_string_t_c()
+
+      type(string_t_c) :: a_c, b_c
+      type(string_t) :: a
+      character(len=:), allocatable :: a_char
+
+      a_c = create_string_t_c( "musica" )
+      ASSERT( c_associated( a_c%ptr_ ) )
+      ASSERT_EQ( int( a_c%size_ ), len( "musica" ) )
+      a = string_t( a_c )
+      a_char = a
+      ASSERT_EQ( a_char, "musica" )
+
+      ! The buffer is allocated on the C++ side, and must be freed there.
+      call delete_string_t_c( a_c )
+      ASSERT( .not. c_associated( a_c%ptr_ ) )
+      ASSERT_EQ( int( a_c%size_ ), 0 )
+
+   end subroutine test_string_t_c
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/fortran/util.F90
+++ b/fortran/util.F90
@@ -906,21 +906,12 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !> Delete a string_t_c object
+   !! C++ allocates the underlying buffer, so C++ must also free it.
    subroutine delete_string_t_c( string )
-
-      use iso_c_binding,                 only : c_char, c_null_ptr, c_size_t, &
-         c_f_pointer, c_associated
 
       type(string_t_c), intent(inout) :: string
 
-      character(kind=c_char, len=1), pointer :: c_string_ptr(:)
-
-      if ( c_associated( string%ptr_ ) ) then
-         call c_f_pointer( string%ptr_, c_string_ptr, [ string%size_ + 1 ] )
-         deallocate( c_string_ptr )
-         string%ptr_ = c_null_ptr
-         string%size_ = 0_c_size_t
-      end if
+      call delete_string_c( string )
 
    end subroutine delete_string_t_c
 


### PR DESCRIPTION
Creating a string type in Fortran delegates to C++, which creates a buffer with `new[]`, but the Fortran side calls `deallocate`, which can result in undefined behavior.

This PR fixes the issue by delegating the destruction to C++.

It also adds a unit test that was previously missing. (This routine had never been called in the project, so the issue remained hidden.)

- Closes #846 