### PR TITLE
Support photolysis reactions with no reactants

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -67,7 +67,9 @@ endif()
 
 if(MUSICA_BUILD_C_CXX_INTERFACE AND NOT MUSICA_USE_PREBUILT)
   set_git_default(MECH_CONFIG_GIT_REPOSITORY https://github.com/NCAR/MechanismConfiguration.git)
-  set_git_default(MECH_CONFIG_GIT_TAG 2fb23128b3828e84c0bb73f87a678af3a8c3786c)
+  # TODO: update to the merged commit of NCAR/MechanismConfiguration#312 before merging;
+  # this points at that PR's branch so photolysis reactants are list-valued here.
+  set_git_default(MECH_CONFIG_GIT_TAG 95a828f6ac1fd8eec60823c39c828f81001e7a3d)
 
   FetchContent_Declare(mechanism_configuration
       GIT_REPOSITORY ${MECH_CONFIG_GIT_REPOSITORY}

--- a/python/musica/mechanism_configuration/reactions/photolysis.py
+++ b/python/musica/mechanism_configuration/reactions/photolysis.py
@@ -70,14 +70,14 @@ class Photolysis(CppWrapper):
 
     @property
     def reactants(self) -> list:
-        return [ReactionComponent._from_cpp(self._cpp.reactants)]
+        return _wrap_list(ReactionComponent, self._cpp.reactants)
 
     @reactants.setter
     def reactants(self, value):
         items = value if isinstance(value, list) else [value]
-        if len(items) != 1:
-            raise ValueError("Photolysis can only have one reactant.")
-        self._cpp.reactants = _unwrap_list(items)[0]
+        if len(items) > 1:
+            raise ValueError("Photolysis can have at most one reactant.")
+        self._cpp.reactants = _unwrap_list(items)
 
     @property
     def products(self) -> list:

--- a/python/test/unit/mechanism_configuration/test_parser.py
+++ b/python/test/unit/mechanism_configuration/test_parser.py
@@ -5,6 +5,22 @@ from musica.utils import find_config_path
 from test_util_full_mechanism import get_fully_defined_mechanism, validate_full_v1_mechanism
 
 
+def test_photolysis_allows_zero_or_one_reactant():
+    A = mc.Species(name="A")
+    B = mc.Species(name="B")
+    # A reactant-less photolysis (e.g. an emission encoded as photolysis) is allowed.
+    emission = mc.Photolysis(name="emis", products=[B])
+    assert emission.reactants == []
+    assert emission.serialize()["reactants"] == []
+    # A single reactant works as before.
+    photo = mc.Photolysis(name="p", reactants=[A], products=[B])
+    assert len(photo.reactants) == 1
+    assert photo.reactants[0].name == "A"
+    # More than one reactant is rejected.
+    with pytest.raises(ValueError):
+        mc.Photolysis(name="bad", reactants=[A, B], products=[B])
+
+
 def test_parsed_full_v1_configuration():
     extensions = [".yaml", ".json"]
     for extension in extensions:


### PR DESCRIPTION
Pairs with **NCAR/MechanismConfiguration#312**, which makes `Photolysis.reactants` a list (0 or 1) so a reactant-less photolysis — an emission encoded as photolysis to carry an `irr__` product — is kept instead of dropped.

## Changes

- **Python `Photolysis` wrapper**: `reactants` getter/setter now use `_wrap_list`/`_unwrap_list` (mirroring `products`) instead of assuming exactly one reactant; at most one reactant is allowed, and `serialize()` emits an empty `reactants` list when there are none.
- **`cmake/dependencies.cmake`**: points `MECH_CONFIG_GIT_TAG` at the #312 branch so this builds against the list-valued type. **Must be updated to the merged commit of #312 before merging.**
- Adds a test that a reactant-less `Photolysis` is allowed and round-trips.

No C++ change is needed: `convert_user_defined` already consumes `reaction.reactants` via the vector overload (an empty list yields no reactants).

## Why

MBI encodes emissions as reactant-less photolysis; musica's v0 parser dropped them, so converted configs (e.g. CB05) failed to run with `PHOTO.EMIS_NO not found`. Keeping them as photolysis preserves the `PHOTO.<name>` rate-parameter label, so the conditions CSVs match with no remapping.

Closes #986 together with NCAR/MechanismConfiguration#312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)