### PR TITLE
Re-export mechanism_configuration types through the namespace

### DIFF
--- a/javascript/mechanism_configuration/index.js
+++ b/javascript/mechanism_configuration/index.js
@@ -1,4 +1,9 @@
 // mechanism_configuration/index.js
-import { types, reactionTypes, Mechanism } from './mechanism_configuration.js';
-
-export { types, reactionTypes, Mechanism };
+//
+// Re-export everything from mechanism_configuration.js (not just the runtime
+// values types/reactionTypes/Mechanism) so that consumers can also reach the
+// exported type aliases — e.g. SpeciesParams, MechanismParams, the per-reaction
+// *Params types, and the Reaction union — through the `mechanismConfiguration`
+// namespace. The value surface is unchanged (mechanism_configuration.js only
+// exports those same three values); this additionally forwards the types.
+export * from "./mechanism_configuration.js";


### PR DESCRIPTION
`mechanism_configuration/index.js` re-exported only the runtime values (`types`, `reactionTypes`, `Mechanism`), so the module's exported **type aliases** (`SpeciesParams`, `MechanismParams`, the per-reaction `*Params` types, and the `Reaction` union) were unreachable through the `mechanismConfiguration` namespace.

This PR exports them all

