### PR TITLE
Use default diffusion coefficient for GLYOXAL in ts1.json

### DIFF
--- a/configs/v1/ts1/ts1.json
+++ b/configs/v1/ts1/ts1.json
@@ -17565,7 +17565,7 @@
                 },
                 {
                     "name": "GLYOXAL",
-                    "diffusion coefficient [m2 s-1]": 1e+300
+                    "diffusion coefficient [m2 s-1]": 1e-05
                 },
                 {
                     "name": "MPAN"


### PR DESCRIPTION
I don't actually know what the diffusion coefficents should be, but this one is definitely wrong