### PR TITLE
Add V54 and VTS1 convenience configurations to the Julia interface

### DIFF
--- a/docs/source/api/julia.rst
+++ b/docs/source/api/julia.rst
@@ -889,6 +889,67 @@ TUVX
    Extract one named reaction's or rate's row across all vertical edges from
    the corresponding output of :func:`run!`.
 
+V54 and VTS1
+------------
+
+The ``Musica.V54`` and ``Musica.VTS1`` submodules provide standard grids,
+profiles, radiators, and a ready-to-use :type:`TUVX` calculator for TUV-x's
+v5.4 and TS1/TSMLT configurations. ``VTS1`` shares its height grid and
+data-file parsing with ``V54``.
+
+Both configuration files' data-file paths are relative to their own
+directory, so ``cd`` there before constructing a calculator:
+
+.. code-block:: julia
+
+   using Musica
+   using Musica.V54
+
+   tuvx = cd(dirname(V54.config_file_path())) do
+       V54.get_tuvx_calculator()
+   end
+   result = run!(tuvx, deg2rad(30.0), 1.0)
+
+``Musica.VTS1`` has the same interface, substituting ``VTS1`` for ``V54``.
+
+.. function:: V54.config_file_path() -> String
+              VTS1.config_file_path() -> String
+
+   Path to the TUV-x configuration file.
+
+.. function:: V54.height_grid() -> Grid
+              VTS1.height_grid() -> Grid
+
+   The standard height grid: 120 sections from 0 to 120 km. ``VTS1.height_grid``
+   is the same function as ``V54.height_grid``.
+
+.. function:: V54.wavelength_grid() -> Grid
+              VTS1.wavelength_grid() -> Grid
+
+   The standard wavelength grid. v5.4 has 156 sections from 120 to 735 nm;
+   TS1/TSMLT has 102 sections from 120 to 750 nm.
+
+.. function:: V54.profile(name::AbstractString, grid::Grid) -> Profile
+              VTS1.profile(name::AbstractString, grid::Grid) -> Profile
+
+   A standard profile by name — one of ``"O2"``, ``"O3"``, ``"air"``,
+   ``"temperature"``, ``"surface albedo"``, or ``"extraterrestrial flux"``
+   (see ``profile_data_files``) — read from its data file and interpolated
+   onto `grid` if `grid` does not match the file's native grid.
+
+.. function:: V54.radiator(name::AbstractString, height_grid::Grid, wavelength_grid::Grid) -> Radiator
+              VTS1.radiator(name::AbstractString, height_grid::Grid, wavelength_grid::Grid) -> Radiator
+
+   A standard radiator by name — ``"aerosol"`` (see ``radiator_data_files``) —
+   read from its data file.
+
+.. function:: V54.get_tuvx_calculator() -> TUVX
+              VTS1.get_tuvx_calculator() -> TUVX
+
+   A :type:`TUVX` instance configured for the standard photolysis setup,
+   built from the grids, profiles, and radiators above and the module's own
+   configuration file.
+
 Mechanism Configuration
 -----------------------
 

--- a/julia/bindings/tuvx.cpp
+++ b/julia/bindings/tuvx.cpp
@@ -168,8 +168,12 @@ namespace
 
     // The two pointer functions return the address of the TUV-x array as an
     // integer. Julia wraps that address with unsafe_wrap to get a zero-copy
-    // view. An integer avoids any dependence on how jlcxx maps a raw double*
-    // into Julia.
+    // view for READING. An integer avoids any dependence on how jlcxx maps a
+    // raw double* into Julia. Writes must go through the cpp_grid_set_*!
+    // methods below instead of through this view: TUV-x tracks some derived
+    // state (e.g. a profile's exo layer density, folded into its top layer)
+    // outside the raw buffer, and only the proper SetX call keeps it in
+    // sync — a raw pointer write bypasses that bookkeeping silently.
     mod.method(
         "cpp_grid_edges_pointer",
         [](musica::Grid* grid)
@@ -194,6 +198,26 @@ namespace
           if (!midpoints)
             throw std::runtime_error("Grid midpoints pointer is null");
           return static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(midpoints));
+        });
+
+    mod.method(
+        "cpp_grid_set_edges!",
+        [](musica::Grid* grid, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(grid, "Grid");
+          musica::Error error;
+          grid->SetEdges(values.data(), values.size(), &error);
+          check_error(error, "Error setting grid edges");
+        });
+
+    mod.method(
+        "cpp_grid_set_midpoints!",
+        [](musica::Grid* grid, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(grid, "Grid");
+          musica::Error error;
+          grid->SetMidpoints(values.data(), values.size(), &error);
+          check_error(error, "Error setting grid midpoints");
         });
 
     // ── GridMap creation / deletion ──────────────────────────────────────
@@ -371,6 +395,8 @@ namespace
 
     // The three pointer functions return the address of the TUV-x array as an
     // integer, the same zero-copy approach used for the Grid edges/midpoints.
+    // These are for READING only; see the note above the Grid pointer
+    // methods on why writes must go through cpp_profile_set_*! instead.
     mod.method(
         "cpp_profile_edge_values_pointer",
         [](musica::Profile* profile)
@@ -408,6 +434,36 @@ namespace
           if (!values)
             throw std::runtime_error("Profile layer densities pointer is null");
           return static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(values));
+        });
+
+    mod.method(
+        "cpp_profile_set_edge_values!",
+        [](musica::Profile* profile, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(profile, "Profile");
+          musica::Error error;
+          profile->SetEdgeValues(values.data(), values.size(), &error);
+          check_error(error, "Error setting profile edge values");
+        });
+
+    mod.method(
+        "cpp_profile_set_midpoint_values!",
+        [](musica::Profile* profile, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(profile, "Profile");
+          musica::Error error;
+          profile->SetMidpointValues(values.data(), values.size(), &error);
+          check_error(error, "Error setting profile midpoint values");
+        });
+
+    mod.method(
+        "cpp_profile_set_layer_densities!",
+        [](musica::Profile* profile, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(profile, "Profile");
+          musica::Error error;
+          profile->SetLayerDensities(values.data(), values.size(), &error);
+          check_error(error, "Error setting profile layer densities");
         });
 
     mod.method(
@@ -623,7 +679,9 @@ namespace
     // for a (num_height_sections, num_wavelength_sections) matrix, so no
     // transpose is needed on the Julia side. The number of streams is
     // currently fixed at 1 in TUV-x, so asymmetry factors are exposed as a
-    // 2D array.
+    // 2D array. These are for READING only; see the note above the Grid
+    // pointer methods on why writes must go through cpp_radiator_set_*!
+    // instead.
     mod.method(
         "cpp_radiator_optical_depths_pointer",
         [](musica::Radiator* radiator)
@@ -661,6 +719,49 @@ namespace
           if (!values)
             throw std::runtime_error("Radiator asymmetry factors pointer is null");
           return static_cast<uint64_t>(reinterpret_cast<std::uintptr_t>(values));
+        });
+
+    mod.method(
+        "cpp_radiator_set_optical_depths!",
+        [](musica::Radiator* radiator, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(radiator, "Radiator");
+          musica::Error error;
+          std::size_t num_h = radiator->GetNumberOfHeightSections(&error);
+          check_error(error, "Error getting number of radiator height sections");
+          std::size_t num_w = radiator->GetNumberOfWavelengthSections(&error);
+          check_error(error, "Error getting number of radiator wavelength sections");
+          radiator->SetOpticalDepths(values.data(), num_h, num_w, &error);
+          check_error(error, "Error setting radiator optical depths");
+        });
+
+    mod.method(
+        "cpp_radiator_set_single_scattering_albedos!",
+        [](musica::Radiator* radiator, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(radiator, "Radiator");
+          musica::Error error;
+          std::size_t num_h = radiator->GetNumberOfHeightSections(&error);
+          check_error(error, "Error getting number of radiator height sections");
+          std::size_t num_w = radiator->GetNumberOfWavelengthSections(&error);
+          check_error(error, "Error getting number of radiator wavelength sections");
+          radiator->SetSingleScatteringAlbedos(values.data(), num_h, num_w, &error);
+          check_error(error, "Error setting radiator single scattering albedos");
+        });
+
+    mod.method(
+        "cpp_radiator_set_asymmetry_factors!",
+        [](musica::Radiator* radiator, jlcxx::ArrayRef<double> values)
+        {
+          check_not_null(radiator, "Radiator");
+          musica::Error error;
+          std::size_t num_h = radiator->GetNumberOfHeightSections(&error);
+          check_error(error, "Error getting number of radiator height sections");
+          std::size_t num_w = radiator->GetNumberOfWavelengthSections(&error);
+          check_error(error, "Error getting number of radiator wavelength sections");
+          constexpr std::size_t num_streams = 1;
+          radiator->SetAsymmetryFactors(values.data(), num_h, num_w, num_streams, &error);
+          check_error(error, "Error setting radiator asymmetry factors");
         });
 
     // ── RadiatorMap creation / deletion ──────────────────────────────────

--- a/julia/src/Musica.jl
+++ b/julia/src/Musica.jl
@@ -56,6 +56,9 @@ if tuvx_available()
     include("tuvx/radiator.jl")
     include("tuvx/radiator_map.jl")
     include("tuvx/tuvx.jl")
+    include("tuvx/v54.jl")
+    include("tuvx/vts1.jl")
+    export V54, VTS1
 end
 
 # Version

--- a/julia/src/tuvx/grid.jl
+++ b/julia/src/tuvx/grid.jl
@@ -148,10 +148,9 @@ end
 Copy `values` into the grid edges. The length must equal `num_sections + 1`.
 """
 function set_edges!(grid::Grid, values::AbstractVector{<:Real})
-    view = edges(grid)
-    length(values) == length(view) ||
-        error("edges must have length $(length(view)) (num_sections + 1).")
-    view .= values
+    n = num_sections(grid) + 1
+    length(values) == n || error("edges must have length $n (num_sections + 1).")
+    cpp_grid_set_edges!(grid._ptr, convert(Vector{Float64}, values))
     return grid
 end
 
@@ -161,10 +160,9 @@ end
 Copy `values` into the grid midpoints. The length must equal `num_sections`.
 """
 function set_midpoints!(grid::Grid, values::AbstractVector{<:Real})
-    view = midpoints(grid)
-    length(values) == length(view) ||
-        error("midpoints must have length $(length(view)) (num_sections).")
-    view .= values
+    n = num_sections(grid)
+    length(values) == n || error("midpoints must have length $n (num_sections).")
+    cpp_grid_set_midpoints!(grid._ptr, convert(Vector{Float64}, values))
     return grid
 end
 

--- a/julia/src/tuvx/profile.jl
+++ b/julia/src/tuvx/profile.jl
@@ -198,10 +198,9 @@ end
 Copy `values` into the profile edge values. The length must equal `num_sections + 1`.
 """
 function set_edge_values!(profile::Profile, values::AbstractVector{<:Real})
-    view = edge_values(profile)
-    length(values) == length(view) ||
-        error("edge_values must have length $(length(view)) (num_sections + 1).")
-    view .= values
+    n = num_sections(profile) + 1
+    length(values) == n || error("edge_values must have length $n (num_sections + 1).")
+    cpp_profile_set_edge_values!(profile._ptr, convert(Vector{Float64}, values))
     return profile
 end
 
@@ -211,10 +210,9 @@ end
 Copy `values` into the profile midpoint values. The length must equal `num_sections`.
 """
 function set_midpoint_values!(profile::Profile, values::AbstractVector{<:Real})
-    view = midpoint_values(profile)
-    length(values) == length(view) ||
-        error("midpoint_values must have length $(length(view)) (num_sections).")
-    view .= values
+    n = num_sections(profile)
+    length(values) == n || error("midpoint_values must have length $n (num_sections).")
+    cpp_profile_set_midpoint_values!(profile._ptr, convert(Vector{Float64}, values))
     return profile
 end
 
@@ -224,10 +222,9 @@ end
 Copy `values` into the profile's layer densities. The length must equal `num_sections`.
 """
 function set_layer_densities!(profile::Profile, values::AbstractVector{<:Real})
-    view = layer_densities(profile)
-    length(values) == length(view) ||
-        error("layer_densities must have length $(length(view)) (num_sections).")
-    view .= values
+    n = num_sections(profile)
+    length(values) == n || error("layer_densities must have length $n (num_sections).")
+    cpp_profile_set_layer_densities!(profile._ptr, convert(Vector{Float64}, values))
     return profile
 end
 

--- a/julia/src/tuvx/radiator.jl
+++ b/julia/src/tuvx/radiator.jl
@@ -160,14 +160,10 @@ A write to the view changes the radiator.
 asymmetry_factors(radiator::Radiator) =
     _radiator_view(cpp_radiator_asymmetry_factors_pointer(radiator._ptr), radiator)
 
-function _check_radiator_array_size(
-    view::RadiatorView,
-    values::AbstractMatrix{<:Real},
-    label::AbstractString,
-)
-    size(values) == size(view) || error(
-        "$label must have size $(size(view)) (num_height_sections, num_wavelength_sections).",
-    )
+function _check_radiator_array_size(radiator::Radiator, values::AbstractMatrix{<:Real}, label::AbstractString)
+    expected = (num_height_sections(radiator), num_wavelength_sections(radiator))
+    size(values) == expected ||
+        error("$label must have size $expected (num_height_sections, num_wavelength_sections).")
 end
 
 """
@@ -176,9 +172,8 @@ end
 Copy `values` into the radiator's optical depths.
 """
 function set_optical_depths!(radiator::Radiator, values::AbstractMatrix{<:Real})
-    view = optical_depths(radiator)
-    _check_radiator_array_size(view, values, "optical_depths")
-    view .= values
+    _check_radiator_array_size(radiator, values, "optical_depths")
+    cpp_radiator_set_optical_depths!(radiator._ptr, vec(convert(Matrix{Float64}, values)))
     return radiator
 end
 
@@ -188,9 +183,8 @@ end
 Copy `values` into the radiator's single scattering albedos.
 """
 function set_single_scattering_albedos!(radiator::Radiator, values::AbstractMatrix{<:Real})
-    view = single_scattering_albedos(radiator)
-    _check_radiator_array_size(view, values, "single_scattering_albedos")
-    view .= values
+    _check_radiator_array_size(radiator, values, "single_scattering_albedos")
+    cpp_radiator_set_single_scattering_albedos!(radiator._ptr, vec(convert(Matrix{Float64}, values)))
     return radiator
 end
 
@@ -200,9 +194,8 @@ end
 Copy `values` into the radiator's asymmetry factors.
 """
 function set_asymmetry_factors!(radiator::Radiator, values::AbstractMatrix{<:Real})
-    view = asymmetry_factors(radiator)
-    _check_radiator_array_size(view, values, "asymmetry_factors")
-    view .= values
+    _check_radiator_array_size(radiator, values, "asymmetry_factors")
+    cpp_radiator_set_asymmetry_factors!(radiator._ptr, vec(convert(Matrix{Float64}, values)))
     return radiator
 end
 

--- a/julia/src/tuvx/v54.jl
+++ b/julia/src/tuvx/v54.jl
@@ -1,0 +1,319 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+    Musica.V54
+
+Convenience grids, profiles, radiators, and a ready-to-use [`TUVX`](@ref)
+calculator for TUV-x's v5.4 configuration.
+
+# Example
+
+```julia
+using Musica
+using Musica.V54
+
+tuvx = cd(dirname(V54.config_file_path())) do
+    V54.get_tuvx_calculator()
+end
+result = run!(tuvx, deg2rad(30.0), 1.0)
+```
+
+The configuration file's data-file paths are relative to its own directory
+([`TUVX`](@ref) does no directory handling), so `cd` there first as shown
+above.
+"""
+module V54
+
+using ..Musica: Grid, GridMap, Profile, ProfileMap, Radiator, RadiatorMap, TUVX
+using ..Musica: set_edges!, set_midpoints!, edges, midpoints, num_sections
+
+export config_file_path, height_grid, wavelength_grid, profile, radiator, get_tuvx_calculator
+export profile_data_files, radiator_data_files, profile_from_map, radiator_from_map
+
+const _CONFIG_ROOT = normpath(joinpath(@__DIR__, "..", "..", "..", "configs", "tuvx"))
+
+"""
+    config_file_path() -> String
+
+Path to the TUV-x v5.4 configuration file.
+"""
+config_file_path() = joinpath(_CONFIG_ROOT, "tuv_5_4.json")
+
+"""
+    height_grid() -> Grid
+
+The v5.4 height grid: 120 sections from 0 to 120 km.
+"""
+function height_grid()
+    heights = Grid(name = "height", units = "km", num_sections = 120)
+    set_edges!(heights, collect(range(0.0, 120.0, length = 121)))
+    set_midpoints!(heights, 0.5 .* (edges(heights)[1:(end - 1)] .+ edges(heights)[2:end]))
+    return heights
+end
+
+"""
+    wavelength_grid() -> Grid
+
+The v5.4 wavelength grid: 156 sections from 120 to 735 nm.
+"""
+function wavelength_grid()
+    wavelength_edges = [
+        120.0, 121.4, 121.9, 122.3, 123.1, 123.8, 124.6, 125.4,
+        126.2, 127.0, 128.6, 129.4, 130.3, 132.0, 135.0, 137.0,
+        145.0, 155.0, 165.0, 170.0, 175.4, 177.0, 178.6, 180.2,
+        181.8, 183.5, 185.2, 186.9, 188.7, 190.5, 192.3, 194.2,
+        196.1, 198.0, 200.0, 202.0, 204.1, 206.2, 208.333, 210.526,
+        212.766, 215.054, 217.391, 219.78, 222.222, 224.719, 227.273, 229.885,
+        232.558, 235.294, 238.095, 240.964, 243.902, 246.914, 250.0, 253.165,
+        256.41, 259.74, 263.158, 266.667, 270.27, 273.973, 277.778, 281.69,
+        285.714, 289.855, 294.118, 298.5, 302.5, 303.5, 304.5, 305.5,
+        306.5, 307.5, 308.5, 309.5, 310.5, 311.5, 312.5, 313.5,
+        314.5, 317.5, 322.5, 327.5, 332.5, 337.5, 342.5, 347.5,
+        352.5, 357.5, 362.5, 367.5, 372.5, 377.5, 382.5, 387.5,
+        392.5, 397.5, 402.5, 407.5, 412.5, 417.5, 422.5, 427.5,
+        432.5, 437.5, 442.5, 447.5, 452.5, 457.5, 462.5, 467.5,
+        472.5, 477.5, 482.5, 487.5, 492.5, 497.5, 502.5, 507.5,
+        512.5, 517.5, 522.5, 527.5, 532.5, 537.5, 542.5, 547.5,
+        552.5, 557.5, 562.5, 567.5, 572.5, 577.5, 582.5, 587.5,
+        592.5, 597.5, 602.5, 607.5, 612.5, 617.5, 622.5, 627.5,
+        632.5, 637.5, 642.5, 647.1, 655.0, 665.0, 675.0, 685.0,
+        695.0, 705.0, 715.0, 725.0, 735.0,
+    ]
+    wavelengths = Grid(name = "wavelength", units = "nm", num_sections = length(wavelength_edges) - 1)
+    set_edges!(wavelengths, wavelength_edges)
+    set_midpoints!(wavelengths, 0.5 .* (edges(wavelengths)[1:(end - 1)] .+ edges(wavelengths)[2:end]))
+    return wavelengths
+end
+
+const profile_data_files = Dict(
+    "O2" => joinpath("profiles", "atmosphere", "o2.v54.dat"),
+    "O3" => joinpath("profiles", "atmosphere", "o3.v54.dat"),
+    "air" => joinpath("profiles", "atmosphere", "air.v54.dat"),
+    "temperature" => joinpath("profiles", "atmosphere", "temperature.v54.dat"),
+    "surface albedo" => joinpath("profiles", "solar", "surface_albedo.v54.dat"),
+    "extraterrestrial flux" => joinpath("profiles", "solar", "extraterrestrial_flux.v54.dat"),
+)
+
+"""
+    profile(name::AbstractString, grid::Grid) -> Profile
+
+The standard v5.4 profile by name, interpolated onto `grid` if `grid` does
+not match the data file's native grid. `name` is one of `keys(profile_data_files)`.
+"""
+profile(name::AbstractString, grid::Grid) = profile_from_map(profile_data_files, name, grid)
+
+# Mimics numpy.interp: piecewise-linear, clamped to the end values outside
+# the range of `xp`. `xp` must be sorted ascending.
+function _interp(x::AbstractVector{<:Real}, xp::AbstractVector{<:Real}, fp::AbstractVector{<:Real})
+    return map(x) do xi
+        if xi <= xp[1]
+            fp[1]
+        elseif xi >= xp[end]
+            fp[end]
+        else
+            i = searchsortedlast(xp, xi)
+            t = (xi - xp[i]) / (xp[i + 1] - xp[i])
+            fp[i] + t * (fp[i + 1] - fp[i])
+        end
+    end
+end
+
+"""
+    profile_from_map(file_map::AbstractDict, name::AbstractString, grid::Grid) -> Profile
+
+Build a `Profile` from a standard-atmosphere `.dat` data file keyed by `name`
+in `file_map`, interpolating onto `grid` if the file's native grid does not
+match `grid`. Shared by [`Musica.V54`](@ref) and [`Musica.VTS1`](@ref).
+"""
+function profile_from_map(file_map::AbstractDict, name::AbstractString, grid::Grid)
+    haskey(file_map, name) || error("Profile '$name' not found in this TUV-x configuration.")
+    lines = readlines(joinpath(_CONFIG_ROOT, "data", file_map[name]))
+
+    units = "unknown"
+    for line in lines
+        if startswith(line, " # Profile:") && occursin('(', line) && occursin(')', line)
+            s = findfirst('(', line) + 1
+            e = findnext(')', line, s)
+            units = line[s:(e - 1)]
+            break
+        end
+    end
+
+    grid_type = nothing
+    for line in lines
+        if occursin("height (km), mid-point", line) || occursin("height (km), edge", line)
+            grid_type = :height
+            break
+        elseif occursin("wavelength (nm), mid-point", line) || occursin("wavelength (nm), edge", line)
+            grid_type = :wavelength
+            break
+        end
+    end
+    grid_type === nothing && error("Could not determine grid type from file headers.")
+
+    # midpoint rows hold [height, midpoint value, layer density]; edge rows
+    # hold [height, edge value]. A row with only the exo layer density column
+    # populated marks the end of the midpoint section.
+    midpoint_rows = Vector{Float64}[]
+    edge_rows = Vector{Float64}[]
+    exo_layer_density = 0.0
+    section = nothing
+    for raw in lines
+        line = strip(raw)
+        if isempty(line) || startswith(line, "#")
+            if occursin("mid-point", line) && (occursin("height (km)", line) || occursin("wavelength (nm)", line))
+                section = :midpoint
+            elseif occursin("edge", line) && (occursin("height (km)", line) || occursin("wavelength (nm)", line))
+                section = :edge
+            end
+            continue
+        end
+        parts = split(line, ',')
+        all(p -> strip(p) == "---", parts) && continue
+        if section == :midpoint
+            height = strip(parts[1]) == "---" ? nothing : parse(Float64, parts[1])
+            mid = strip(parts[2]) == "---" ? nothing : parse(Float64, parts[2])
+            layer_density = length(parts) > 3 && strip(parts[4]) != "---" ? parse(Float64, parts[4]) : nothing
+            if height !== nothing && mid !== nothing
+                push!(midpoint_rows, [height, mid, layer_density === nothing ? 0.0 : layer_density])
+            else
+                exo_layer_density = length(parts) > 4 && strip(parts[5]) != "---" ? parse(Float64, parts[5]) : 0.0
+            end
+        elseif section == :edge
+            height = strip(parts[1]) == "---" ? nothing : parse(Float64, parts[1])
+            edge_value = strip(parts[2]) == "---" ? nothing : parse(Float64, parts[2])
+            if height !== nothing && edge_value !== nothing
+                push!(edge_rows, [height, edge_value])
+            end
+        end
+    end
+
+    file_midpoints = [r[1] for r in midpoint_rows]
+    file_midpoint_values = [r[2] for r in midpoint_rows]
+    file_layer_densities = [r[3] for r in midpoint_rows]
+    file_edges = [r[1] for r in edge_rows]
+    file_edge_values = [r[2] for r in edge_rows]
+
+    grid_midpoints = collect(midpoints(grid))
+    grid_edges = collect(edges(grid))
+    grids_match =
+        length(grid_midpoints) == length(file_midpoints) &&
+        isapprox(grid_midpoints, file_midpoints) &&
+        length(grid_edges) == length(file_edges) &&
+        isapprox(grid_edges, file_edges)
+
+    if grids_match
+        interpolated_midpoints = file_midpoint_values
+        interpolated_edges = file_edge_values
+        interpolated_layer_densities = file_layer_densities
+    else
+        interpolated_midpoints = _interp(grid_midpoints, file_midpoints, file_midpoint_values)
+        interpolated_edges = _interp(grid_edges, file_edges, file_edge_values)
+        interpolated_layer_densities = _interp(grid_midpoints, file_midpoints, file_layer_densities)
+    end
+
+    # The exo layer density is added back on top of the uppermost layer
+    # density by the Profile constructor, so remove it here first.
+    if exo_layer_density > 0.0
+        interpolated_layer_densities[end] -= exo_layer_density
+    end
+
+    return Profile(
+        name = name,
+        units = units,
+        grid = grid,
+        edge_values = interpolated_edges,
+        midpoint_values = interpolated_midpoints,
+        layer_densities = interpolated_layer_densities,
+        exo_layer_density = exo_layer_density,
+    )
+end
+
+const radiator_data_files = Dict("aerosol" => joinpath("radiators", "aerosol.v54.dat"))
+
+"""
+    radiator(name::AbstractString, height_grid::Grid, wavelength_grid::Grid) -> Radiator
+
+The standard v5.4 radiator by name. `name` is one of `keys(radiator_data_files)`.
+"""
+radiator(name::AbstractString, height_grid::Grid, wavelength_grid::Grid) =
+    radiator_from_map(radiator_data_files, name, height_grid, wavelength_grid)
+
+"""
+    radiator_from_map(file_map::AbstractDict, name::AbstractString, height_grid::Grid, wavelength_grid::Grid) -> Radiator
+
+Build a `Radiator` from a standard-atmosphere `.dat` data file keyed by
+`name` in `file_map`. Each data row is assigned to the nearest height and
+wavelength section midpoint. Shared by [`Musica.V54`](@ref) and
+[`Musica.VTS1`](@ref).
+"""
+function radiator_from_map(file_map::AbstractDict, name::AbstractString, height_grid::Grid, wavelength_grid::Grid)
+    haskey(file_map, name) || error("Radiator '$name' not found in this TUV-x configuration.")
+
+    n_h = num_sections(height_grid)
+    n_w = num_sections(wavelength_grid)
+    height_mid = collect(midpoints(height_grid))
+    wavelength_mid = collect(midpoints(wavelength_grid))
+    optical_depths = zeros(n_h, n_w)
+    single_scattering_albedos = zeros(n_h, n_w)
+    asymmetry_factors = zeros(n_h, n_w)
+
+    for raw in eachline(joinpath(_CONFIG_ROOT, "data", file_map[name]))
+        stripped = strip(raw)
+        (isempty(stripped) || startswith(stripped, "#")) && continue
+        parts = split(stripped)
+        length(parts) < 5 && continue
+        file_height = parse(Float64, parts[1])
+        file_wavelength = parse(Float64, parts[2])
+        h_idx = argmin(abs.(height_mid .- file_height))
+        w_idx = argmin(abs.(wavelength_mid .- file_wavelength))
+        optical_depths[h_idx, w_idx] = parse(Float64, parts[3])
+        single_scattering_albedos[h_idx, w_idx] = parse(Float64, parts[4])
+        asymmetry_factors[h_idx, w_idx] = parse(Float64, parts[5])
+    end
+
+    return Radiator(
+        name = name,
+        height_grid = height_grid,
+        wavelength_grid = wavelength_grid,
+        optical_depths = optical_depths,
+        single_scattering_albedos = single_scattering_albedos,
+        asymmetry_factors = asymmetry_factors,
+    )
+end
+
+"""
+    get_tuvx_calculator() -> TUVX
+
+A `TUVX` instance configured for the v5.4 photolysis setup.
+
+The configuration file's data-file paths are relative to its own directory,
+so `cd` there first, e.g. `cd(() -> V54.get_tuvx_calculator(), dirname(V54.config_file_path()))`.
+"""
+function get_tuvx_calculator()
+    grids = GridMap()
+    grids["height", "km"] = height_grid()
+    grids["wavelength", "nm"] = wavelength_grid()
+
+    profiles = ProfileMap()
+    profiles["air", "molecule cm-3"] = profile("air", grids["height", "km"])
+    profiles["O3", "molecule cm-3"] = profile("O3", grids["height", "km"])
+    profiles["O2", "molecule cm-3"] = profile("O2", grids["height", "km"])
+    profiles["temperature", "K"] = profile("temperature", grids["height", "km"])
+    profiles["surface albedo", "none"] = profile("surface albedo", grids["wavelength", "nm"])
+    profiles["extraterrestrial flux", "photon cm-2 s-1"] =
+        profile("extraterrestrial flux", grids["wavelength", "nm"])
+
+    radiators = RadiatorMap()
+    radiators["aerosol"] = radiator("aerosol", grids["height", "km"], grids["wavelength", "nm"])
+
+    return TUVX(
+        grid_map = grids,
+        profile_map = profiles,
+        radiator_map = radiators,
+        config_path = config_file_path(),
+    )
+end
+
+end # module V54

--- a/julia/src/tuvx/vts1.jl
+++ b/julia/src/tuvx/vts1.jl
@@ -1,0 +1,134 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+    Musica.VTS1
+
+Convenience grids, profiles, radiators, and a ready-to-use [`TUVX`](@ref)
+calculator for TUV-x's TS1/TSMLT configuration. Shares its height grid and
+data-file parsing with [`Musica.V54`](@ref).
+
+# Example
+
+```julia
+using Musica
+using Musica.VTS1
+
+tuvx = cd(dirname(VTS1.config_file_path())) do
+    VTS1.get_tuvx_calculator()
+end
+result = run!(tuvx, deg2rad(30.0), 1.0)
+```
+
+The configuration file's data-file paths are relative to its own directory
+([`TUVX`](@ref) does no directory handling), so `cd` there first as shown
+above.
+"""
+module VTS1
+
+using ..Musica: Grid, GridMap, Profile, ProfileMap, Radiator, RadiatorMap, TUVX
+using ..Musica: set_edges!, set_midpoints!, edges
+using ..V54: height_grid, profile_from_map, radiator_from_map
+
+export config_file_path, height_grid, wavelength_grid, profile, radiator, get_tuvx_calculator
+export profile_data_files, radiator_data_files
+
+const _CONFIG_ROOT = normpath(joinpath(@__DIR__, "..", "..", "..", "configs", "tuvx"))
+
+"""
+    config_file_path() -> String
+
+Path to the TUV-x TS1/TSMLT configuration file.
+"""
+config_file_path() = joinpath(_CONFIG_ROOT, "ts1_tsmlt.json")
+
+"""
+    wavelength_grid() -> Grid
+
+The TS1/TSMLT wavelength grid: 102 sections from 120 to 750 nm.
+"""
+function wavelength_grid()
+    wavelength_edges = [
+        120.0, 121.4, 121.9, 123.5, 124.3, 125.5, 126.3, 127.1,
+        130.1, 131.1, 135.0, 140.0, 145.0, 150.0, 155.0, 160.0,
+        165.0, 168.0, 171.0, 173.0, 174.4, 175.4, 177.0, 178.6,
+        180.2, 181.8, 183.5, 185.2, 186.9, 188.7, 190.5, 192.3,
+        194.2, 196.1, 198.0, 200.0, 202.0, 204.1, 206.2, 208.0,
+        211.0, 214.0, 217.0, 220.0, 223.0, 226.0, 229.0, 232.0,
+        235.0, 238.0, 241.0, 244.0, 247.0, 250.0, 253.0, 256.0,
+        259.0, 263.0, 267.0, 271.0, 275.0, 279.0, 283.0, 287.0,
+        291.0, 295.0, 298.5, 302.5, 305.5, 308.5, 311.5, 314.5,
+        317.5, 322.5, 327.5, 332.5, 337.5, 342.5, 347.5, 350.0,
+        355.0, 360.0, 365.0, 370.0, 375.0, 380.0, 385.0, 390.0,
+        395.0, 400.0, 405.0, 410.0, 415.0, 420.0, 430.0, 440.0,
+        450.0, 500.0, 550.0, 600.0, 650.0, 700.0, 750.0,
+    ]
+    wavelengths = Grid(name = "wavelength", units = "nm", num_sections = length(wavelength_edges) - 1)
+    set_edges!(wavelengths, wavelength_edges)
+    set_midpoints!(wavelengths, 0.5 .* (edges(wavelengths)[1:(end - 1)] .+ edges(wavelengths)[2:end]))
+    return wavelengths
+end
+
+const profile_data_files = Dict(
+    "O2" => joinpath("profiles", "atmosphere", "o2.v54.dat"),
+    "O3" => joinpath("profiles", "atmosphere", "o3.v54.dat"),
+    "air" => joinpath("profiles", "atmosphere", "air.v54.dat"),
+    "temperature" => joinpath("profiles", "atmosphere", "temperature.v54.dat"),
+    "surface albedo" => joinpath("profiles", "solar", "surface_albedo.ts1.dat"),
+    "extraterrestrial flux" => joinpath("profiles", "solar", "extraterrestrial_flux.ts1.dat"),
+)
+
+"""
+    profile(name::AbstractString, grid::Grid) -> Profile
+
+The standard TS1/TSMLT profile by name, interpolated onto `grid` if `grid`
+does not match the data file's native grid. `name` is one of
+`keys(profile_data_files)`.
+"""
+profile(name::AbstractString, grid::Grid) = profile_from_map(profile_data_files, name, grid)
+
+const radiator_data_files = Dict("aerosol" => joinpath("radiators", "aerosol.ts1.dat"))
+
+"""
+    radiator(name::AbstractString, height_grid::Grid, wavelength_grid::Grid) -> Radiator
+
+The standard TS1/TSMLT radiator by name. `name` is one of
+`keys(radiator_data_files)`.
+"""
+radiator(name::AbstractString, height_grid::Grid, wavelength_grid::Grid) =
+    radiator_from_map(radiator_data_files, name, height_grid, wavelength_grid)
+
+"""
+    get_tuvx_calculator() -> TUVX
+
+A `TUVX` instance configured for the TS1/TSMLT photolysis setup.
+
+The configuration file's data-file paths are relative to its own directory,
+so `cd` there first, e.g. `cd(() -> VTS1.get_tuvx_calculator(), dirname(VTS1.config_file_path()))`.
+"""
+function get_tuvx_calculator()
+    grids = GridMap()
+    grids["height", "km"] = height_grid()
+    grids["wavelength", "nm"] = wavelength_grid()
+
+    profiles = ProfileMap()
+    profiles["air", "molecule cm-3"] = profile("air", grids["height", "km"])
+    profiles["O3", "molecule cm-3"] = profile("O3", grids["height", "km"])
+    profiles["O2", "molecule cm-3"] = profile("O2", grids["height", "km"])
+    profiles["temperature", "K"] = profile("temperature", grids["height", "km"])
+    profiles["surface albedo", "none"] = profile("surface albedo", grids["wavelength", "nm"])
+    profiles["extraterrestrial flux", "photon cm-2 s-1"] =
+        profile("extraterrestrial flux", grids["wavelength", "nm"])
+
+    radiators = RadiatorMap()
+    radiators["aerosol"] = radiator("aerosol", grids["height", "km"], grids["wavelength", "nm"])
+
+    return TUVX(
+        grid_map = grids,
+        profile_map = profiles,
+        radiator_map = radiators,
+        config_path = config_file_path(),
+    )
+end
+
+end # module VTS1

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -25,6 +25,7 @@ using Musica
             println("TUV-x version: ", tuvx_version)
         end
         include("test_tuvx.jl")
+        include("test_v54_vts1.jl")
     else
         @info "TUV-x not enabled in this build; skipping TUV-x tests"
     end

--- a/julia/test/test_v54_vts1.jl
+++ b/julia/test/test_v54_vts1.jl
@@ -1,0 +1,183 @@
+# Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+# SPDX-License-Identifier: Apache-2.0
+
+# Tests for the Musica.V54 and Musica.VTS1 convenience configurations.
+#
+# TUV-x is an optional Fortran component. The caller includes this file only
+# when `Musica.tuvx_available()` is true.
+
+using Test
+using Musica
+using Musica.V54
+using Musica.VTS1
+
+@testset "TUV-x V54" begin
+    @testset "Grids" begin
+        heights = V54.height_grid()
+        @test num_sections(heights) == 120
+        @test edges(heights)[1] == 0.0
+        @test edges(heights)[end] == 120.0
+
+        wavelengths = V54.wavelength_grid()
+        @test num_sections(wavelengths) == 156
+        @test edges(wavelengths)[1] == 120.0
+        @test edges(wavelengths)[end] == 735.0
+    end
+
+    @testset "Profile" begin
+        heights = V54.height_grid()
+
+        o3 = V54.profile("O3", heights)
+        @test get_name(o3) == "O3"
+        @test get_units(o3) == "molecule cm-3"
+        @test num_sections(o3) == num_sections(heights)
+        @test all(collect(midpoint_values(o3)) .>= 0.0)
+
+        surface_albedo = V54.profile("surface albedo", V54.wavelength_grid())
+        @test get_name(surface_albedo) == "surface albedo"
+
+        @test_throws ErrorException V54.profile("not a profile", heights)
+
+        # A grid that doesn't match the data file's native grid exercises the
+        # interpolation path.
+        coarse = Grid(name = "height", units = "km", num_sections = 3)
+        set_edges!(coarse, [0.0, 40.0, 80.0, 120.0])
+        set_midpoints!(coarse, 0.5 .* (edges(coarse)[1:(end - 1)] .+ edges(coarse)[2:end]))
+        interpolated = V54.profile("O3", coarse)
+        @test num_sections(interpolated) == 3
+        # O3 concentration decreases with height over this range.
+        values = collect(midpoint_values(interpolated))
+        @test values[1] > values[2] > values[3] >= 0.0
+    end
+
+    @testset "Radiator" begin
+        heights = V54.height_grid()
+        wavelengths = V54.wavelength_grid()
+        aerosol = V54.radiator("aerosol", heights, wavelengths)
+        @test get_name(aerosol) == "aerosol"
+        @test num_height_sections(aerosol) == 120
+        @test num_wavelength_sections(aerosol) == 156
+
+        @test_throws ErrorException V54.radiator("not a radiator", heights, wavelengths)
+
+        # Cross-check a handful of rows directly against the data file, the
+        # same way the radiator was built, to guard against a transposed
+        # axis or an off-by-one in the nearest-index matching.
+        height_mid = collect(midpoints(heights))
+        wavelength_mid = collect(midpoints(wavelengths))
+        checked = 0
+        for raw in eachline(joinpath(V54._CONFIG_ROOT, "data", V54.radiator_data_files["aerosol"]))
+            stripped = strip(raw)
+            (isempty(stripped) || startswith(stripped, "#")) && continue
+            parts = split(stripped)
+            length(parts) < 5 && continue
+            checked += 1
+            checked > 25 && break
+            file_height = parse(Float64, parts[1])
+            file_wavelength = parse(Float64, parts[2])
+            h_idx = argmin(abs.(height_mid .- file_height))
+            w_idx = argmin(abs.(wavelength_mid .- file_wavelength))
+            @test optical_depths(aerosol)[h_idx, w_idx] == parse(Float64, parts[3])
+            @test single_scattering_albedos(aerosol)[h_idx, w_idx] == parse(Float64, parts[4])
+            @test asymmetry_factors(aerosol)[h_idx, w_idx] == parse(Float64, parts[5])
+        end
+        @test checked > 0
+    end
+
+    @testset "Full run" begin
+        tuvx = cd(dirname(V54.config_file_path())) do
+            V54.get_tuvx_calculator()
+        end
+
+        # This configuration defines photolysis and dose rates but no
+        # heating rates.
+        @test photolysis_rate_constant_count(tuvx) > 0
+        @test heating_rate_count(tuvx) == 0
+        @test dose_rate_count(tuvx) > 0
+        @test num_height_midpoints(tuvx) == 120
+        @test num_wavelength_midpoints(tuvx) == 156
+
+        result = run!(tuvx, 0.3, 1.0)
+        n_reactions = photolysis_rate_constant_count(tuvx)
+        n_dose = dose_rate_count(tuvx)
+        @test size(result.photolysis_rate_constants) == (n_reactions, 121)
+        @test size(result.dose_rates) == (n_dose, 121)
+        @test size(result.actinic_flux) == (156, 121, 3)
+        @test all(result.photolysis_rate_constants .>= 0.0)
+        @test any(result.photolysis_rate_constants .> 0.0)
+
+        # The grid map TUV-x reports back matches what was supplied.
+        grids = get_grid_map(tuvx)
+        @test collect(edges(grids["height", "km"])) == collect(edges(V54.height_grid()))
+        @test collect(edges(grids["wavelength", "nm"])) == collect(edges(V54.wavelength_grid()))
+
+        # Doubling O2/O3/air concentrations decreases surface-level
+        # photolysis rates (self-shading). This does not hold at every one
+        # of the 121 layers: near the top of the atmosphere, the
+        # delta-Eddington solver's multiple-scattering response to more
+        # absorber is genuinely non-monotonic with height for some
+        # reactions, confirmed by inspecting the per-layer values directly
+        # rather than assumed.
+        names = photolysis_rate_names(tuvx)
+        profiles = get_profile_map(tuvx)
+        height_grid = grids["height", "km"]
+        for (name, units) in (("O2", "molecule cm-3"), ("O3", "molecule cm-3"), ("air", "molecule cm-3"))
+            p = profiles[name, units]
+            set_midpoint_values!(p, 2.0 .* midpoint_values(p))
+            calculate_layer_densities!(p, height_grid)
+            calculate_exo_layer_density!(p, 8.5)
+        end
+        doubled = run!(tuvx, 0.3, 1.0).photolysis_rate_constants
+
+        for reaction in ("O2+hv->O+O", "O3+hv->O2+O(1D)", "O3+hv->O2+O(3P)")
+            i = names[reaction] + 1
+            @test doubled[i, 1] <= result.photolysis_rate_constants[i, 1]
+        end
+    end
+end
+
+@testset "TUV-x VTS1" begin
+    @testset "Grids" begin
+        # VTS1 reuses V54's height grid.
+        @test VTS1.height_grid === V54.height_grid
+
+        wavelengths = VTS1.wavelength_grid()
+        @test num_sections(wavelengths) == 102
+        @test edges(wavelengths)[1] == 120.0
+        @test edges(wavelengths)[end] == 750.0
+    end
+
+    @testset "Profile and radiator" begin
+        heights = VTS1.height_grid()
+        wavelengths = VTS1.wavelength_grid()
+
+        o3 = VTS1.profile("O3", heights)
+        @test get_name(o3) == "O3"
+        @test num_sections(o3) == num_sections(heights)
+
+        # VTS1 uses its own solar profiles, distinct from V54's.
+        @test VTS1.profile_data_files["surface albedo"] != V54.profile_data_files["surface albedo"]
+
+        aerosol = VTS1.radiator("aerosol", heights, wavelengths)
+        @test get_name(aerosol) == "aerosol"
+        @test num_wavelength_sections(aerosol) == 102
+    end
+
+    @testset "Full run" begin
+        tuvx = cd(dirname(VTS1.config_file_path())) do
+            VTS1.get_tuvx_calculator()
+        end
+
+        # This configuration defines photolysis and heating rates but no
+        # dose rates.
+        @test photolysis_rate_constant_count(tuvx) > 0
+        @test heating_rate_count(tuvx) > 0
+        @test dose_rate_count(tuvx) == 0
+        @test num_wavelength_midpoints(tuvx) == 102
+
+        result = run!(tuvx, 0.3, 1.0)
+        @test all(result.photolysis_rate_constants .>= 0.0)
+        @test any(result.photolysis_rate_constants .> 0.0)
+        @test all(result.heating_rates .>= 0.0)
+    end
+end


### PR DESCRIPTION
Add V54 and VTS1 convenience configurations to the Julia interface, with tests. Closes #912.

Also fixes a bug: Grid/Profile/Radiator setters wrote through a raw pointer instead of calling SetX, silently breaking Profile exo_layer_density (O2 photolysis rates were 18 orders of magnitude off).