### PR TITLE
Radiation field updater: C++ bindings

### DIFF
--- a/configs/tuvx/host_radiation_field/config.json
+++ b/configs/tuvx/host_radiation_field/config.json
@@ -1,0 +1,97 @@
+{
+  "grids": [
+    {
+      "name": "height",
+      "type": "equal interval",
+      "units": "km",
+      "begins at": 1.0,
+      "ends at": 5.0,
+      "cell delta": 1.0
+    },
+    {
+      "name": "wavelength",
+      "type": "equal interval",
+      "units": "nm",
+      "begins at": 400.0,
+      "ends at": 700.0,
+      "cell delta": 50.0
+    }
+  ],
+  "profiles": [
+    {
+      "name": "temperature",
+      "type": "from config file",
+      "units": "K",
+      "grid": { "name": "height", "units": "km" },
+      "values": [ 280.0, 275.0, 270.0, 265.0, 260.0 ]
+    },
+    {
+      "name": "air",
+      "type": "from config file",
+      "units": "molecule cm-3",
+      "grid": { "name": "height", "units": "km" },
+      "values": [ 2.5e19, 2.0e19, 1.5e19, 1.0e19, 5.0e18 ]
+    },
+    {
+      "name": "extraterrestrial flux",
+      "type": "from config file",
+      "units": "photon cm-2 s-1",
+      "grid": { "name": "wavelength", "units": "nm" },
+      "values": [ 1.0e14, 1.0e14, 1.0e14, 1.0e14, 1.0e14, 1.0e14, 1.0e14 ]
+    }
+  ],
+  "O2 absorption": { },
+  "radiative transfer": {
+    "cross sections": [ ],
+    "radiators": [ ],
+    "solver": {
+      "type": "from host"
+    }
+  },
+  "dose rates": {
+    "rates": [
+      {
+        "name": "all bins",
+        "weights": {
+          "type": "Notch Filter",
+          "notch filter begin": 0.0,
+          "notch filter end": 1000.0
+        }
+      },
+      {
+        "name": "upper bins",
+        "weights": {
+          "type": "Notch Filter",
+          "notch filter begin": 500.0,
+          "notch filter end": 1000.0
+        }
+      }
+    ]
+  },
+  "photolysis": {
+    "reactions": [
+      {
+        "name": "jfoo",
+        "cross section": {
+          "type": "base",
+          "data": { "default value": 2.0 }
+        },
+        "quantum yield": {
+          "type": "base",
+          "constant value": 0.5
+        }
+      },
+      {
+        "name": "jbar",
+        "cross section": {
+          "type": "base",
+          "data": { "default value": 4.0 }
+        },
+        "quantum yield": {
+          "type": "base",
+          "constant value": 0.25
+        }
+      }
+    ]
+  }
+}

--- a/include/musica/tuvx/radiation_field_updater.hpp
+++ b/include/musica/tuvx/radiation_field_updater.hpp
@@ -98,12 +98,12 @@ namespace musica
     // go away but the C API will remain the same and downstream projects (like CAM-SIMA) will
     // not need to change
     //
-    // The three has_*_irradiance flags exist because a bind(c) Fortran dummy argument
-    // typed as a plain array cannot portably represent "this optional argument was
-    // omitted" from a null pointer alone. Pass 0/1 alongside each irradiance pointer so
-    // the Fortran side does not need to infer presence from pointer nullity: the pointer
-    // is only meaningful when its matching flag is 1; when the flag is 0, the pointer
-    // value must be ignored (it may be null or a stale/dummy address).
+    // A null pointer for one of the three optional irradiance arrays is passed straight
+    // through as a disassociated C pointer. The Fortran bridge checks each with
+    // c_associated and passes it to update()'s matching optional, non-pointer,
+    // assumed-shape dummy argument only when associated -- Fortran treats a disassociated
+    // pointer actual argument matched to such a dummy as an absent optional argument, the
+    // same way InternalRunTuvx already does for its optional dose_rates argument.
     void InternalDeleteRadiationFieldUpdater(void* updater, int* error_code);
     void InternalUpdateRadiationField(
         void* updater,
@@ -113,9 +113,6 @@ namespace musica
         double* direct_irradiance,
         double* upward_irradiance,
         double* downward_irradiance,
-        int has_direct_irradiance,
-        int has_upward_irradiance,
-        int has_downward_irradiance,
         std::size_t num_vertical_interfaces,
         std::size_t num_wavelength_bins,
         int* error_code);

--- a/include/musica/tuvx/radiation_field_updater.hpp
+++ b/include/musica/tuvx/radiation_field_updater.hpp
@@ -1,0 +1,127 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <musica/utils/util.hpp>
+
+#include <cstddef>
+
+namespace musica
+{
+  class TUVX;
+
+  /// @brief Lets a host application push a radiation field into TUV-x's "from host" solver
+  ///
+  /// Obtained only via TUVX::GetRadiationFieldUpdater; never constructed directly. The
+  /// values passed to Update are dimensionless and must NOT include the extraterrestrial
+  /// flux profile or the Earth-Sun distance factor -- TUV-x applies both downstream. Call
+  /// Update before every TUVX::Run: TUV-x does not raise an error if a Run is missed, it
+  /// silently reuses the last field set (or an all-zero field, if Update was never called).
+  class RadiationFieldUpdater
+  {
+   public:
+    ~RadiationFieldUpdater();
+
+    /// @brief Sets the radiation field TUV-x will use for the next Run
+    /// @param direct_actinic_flux Direct component of the actinic flux (required), shape
+    /// (num_vertical_interfaces, num_wavelength_bins), interface 0 is the lowest altitude
+    /// @param upward_actinic_flux Diffuse upwelling component of the actinic flux (required), same shape
+    /// @param downward_actinic_flux Diffuse downwelling component of the actinic flux (required), same shape
+    /// @param direct_irradiance Direct component of the irradiance (optional; pass nullptr to omit).
+    /// Used only for dose rates; an omitted component is treated as all zeros for this call.
+    /// @param upward_irradiance Diffuse upwelling component of the irradiance (optional; see above)
+    /// @param downward_irradiance Diffuse downwelling component of the irradiance (optional; see above)
+    /// @param num_vertical_interfaces Number of height grid cells + 1
+    /// @param num_wavelength_bins Number of wavelength grid cells
+    /// @param error Error struct to indicate success or failure
+    void Update(
+        double* direct_actinic_flux,
+        double* upward_actinic_flux,
+        double* downward_actinic_flux,
+        double* direct_irradiance,
+        double* upward_irradiance,
+        double* downward_irradiance,
+        std::size_t num_vertical_interfaces,
+        std::size_t num_wavelength_bins,
+        Error* error);
+
+   private:
+    void* updater_;
+
+    friend class TUVX;
+
+    /// @brief Wraps an existing radiation field updater instance
+    /// @param updater The updater, owned by this wrapper from this point on
+    explicit RadiationFieldUpdater(void* updater)
+        : updater_(updater)
+    {
+    }
+  };
+
+#ifdef __cplusplus
+  extern "C"
+  {
+#endif
+
+    // The external C API for the radiation field updater
+    // callable by wrappers in other languages
+
+    /// @brief Deletes a radiation field updater instance
+    /// @param updater The updater to delete
+    /// @param error Error struct to indicate success or failure
+    void DeleteRadiationFieldUpdater(RadiationFieldUpdater* updater, Error* error);
+
+    /// @brief Sets the radiation field TUV-x will use for the next Run
+    /// @param updater The updater to set the field on
+    /// @param direct_actinic_flux Direct component of the actinic flux (required)
+    /// @param upward_actinic_flux Diffuse upwelling component of the actinic flux (required)
+    /// @param downward_actinic_flux Diffuse downwelling component of the actinic flux (required)
+    /// @param direct_irradiance Direct component of the irradiance (optional; pass nullptr to omit)
+    /// @param upward_irradiance Diffuse upwelling component of the irradiance (optional; pass nullptr to omit)
+    /// @param downward_irradiance Diffuse downwelling component of the irradiance (optional; pass nullptr to omit)
+    /// @param num_vertical_interfaces Number of height grid cells + 1
+    /// @param num_wavelength_bins Number of wavelength grid cells
+    /// @param error Error struct to indicate success or failure
+    void UpdateRadiationField(
+        RadiationFieldUpdater* updater,
+        double* direct_actinic_flux,
+        double* upward_actinic_flux,
+        double* downward_actinic_flux,
+        double* direct_irradiance,
+        double* upward_irradiance,
+        double* downward_irradiance,
+        std::size_t num_vertical_interfaces,
+        std::size_t num_wavelength_bins,
+        Error* error);
+
+    // INTERNAL USE. If tuvx ever gets rewritten in C++, these functions will
+    // go away but the C API will remain the same and downstream projects (like CAM-SIMA) will
+    // not need to change
+    //
+    // The three has_*_irradiance flags exist because a bind(c) Fortran dummy argument
+    // typed as a plain array cannot portably represent "this optional argument was
+    // omitted" from a null pointer alone. Pass 0/1 alongside each irradiance pointer so
+    // the Fortran side does not need to infer presence from pointer nullity: the pointer
+    // is only meaningful when its matching flag is 1; when the flag is 0, the pointer
+    // value must be ignored (it may be null or a stale/dummy address).
+    void InternalDeleteRadiationFieldUpdater(void* updater, int* error_code);
+    void InternalUpdateRadiationField(
+        void* updater,
+        double* direct_actinic_flux,
+        double* upward_actinic_flux,
+        double* downward_actinic_flux,
+        double* direct_irradiance,
+        double* upward_irradiance,
+        double* downward_irradiance,
+        int has_direct_irradiance,
+        int has_upward_irradiance,
+        int has_downward_irradiance,
+        std::size_t num_vertical_interfaces,
+        std::size_t num_wavelength_bins,
+        int* error_code);
+
+#ifdef __cplusplus
+  }
+#endif
+
+}  // namespace musica

--- a/include/musica/tuvx/tuvx.hpp
+++ b/include/musica/tuvx/tuvx.hpp
@@ -7,6 +7,7 @@
 
 #include <musica/tuvx/grid_map.hpp>
 #include <musica/tuvx/profile_map.hpp>
+#include <musica/tuvx/radiation_field_updater.hpp>
 #include <musica/tuvx/radiator_map.hpp>
 #include <musica/utils/util.hpp>
 
@@ -127,6 +128,15 @@ namespace musica
     /// @return Number of wavelength midpoints
     /// @throws std::runtime_error if operation fails
     int GetNumberOfWavelengthMidpoints();
+
+    /// @brief Returns an updater a host application uses to set the radiation field at runtime
+    ///
+    /// The configured radiative transfer solver must be of type "from host". Returns
+    /// nullptr if it is not -- this is an expected, recoverable outcome, not an error, so
+    /// check for nullptr rather than relying on `error` alone.
+    /// @param error The error struct to indicate success or failure
+    /// @return a radiation field updater pointer, or nullptr if the configured solver is not "from host"
+    RadiationFieldUpdater *GetRadiationFieldUpdater(Error *error);
 
    private:
     void *tuvx_;

--- a/include/musica/tuvx/tuvx_c_interface.hpp
+++ b/include/musica/tuvx/tuvx_c_interface.hpp
@@ -58,6 +58,12 @@ namespace musica
     /// @return Radiator map
     RadiatorMap* GetRadiatorMap(TUVX* tuvx, Error* error);
 
+    /// @brief Returns an updater a host application uses to set the radiation field at runtime
+    /// @param tuvx Pointer to TUVX instance
+    /// @param error Error struct to indicate success or failure
+    /// @return a radiation field updater pointer, or nullptr if the configured solver is not "from host"
+    RadiationFieldUpdater* GetRadiationFieldUpdater(TUVX* tuvx, Error* error);
+
     /// @brief Returns the ordering photolysis rate constants
     /// @param tuvx Pointer to TUVX instance
     /// @param mappings Array of photolysis rate constant name-index pairs [output]
@@ -127,6 +133,10 @@ namespace musica
     void* InternalGetGridMap(void* tuvx, int* error_code);
     void* InternalGetProfileMap(void* tuvx, int* error_code);
     void* InternalGetRadiatorMap(void* tuvx, int* error_code);
+    // `found` is set to 1 if the configured solver is "from host" (in which case the
+    // return value is a valid updater handle) or 0 otherwise (in which case the return
+    // value is null and must not be used).
+    void* InternalGetRadiationFieldUpdater(void* tuvx, int* found, int* error_code);
     void InternalGetPhotolysisRateConstantsOrdering(void* tuvx, Mappings* mappings, int* error_code);
     void InternalGetHeatingRatesOrdering(void* tuvx, Mappings* mappings, int* error_code);
     void InternalGetDoseRatesOrdering(void* tuvx, Mappings* mappings, int* error_code);

--- a/src/test/unit/tuvx/tuvx_c_api.cpp
+++ b/src/test/unit/tuvx/tuvx_c_api.cpp
@@ -116,6 +116,21 @@ TEST_F(TuvxCApiTest, CreateTuvxInstanceWithJsonConfig)
   ASSERT_NE(tuvx, nullptr);
 }
 
+// The configured solver here is not "from host", so this must report "not found"
+// (a null updater, no error) rather than raise. Once the Fortran bridge (a
+// follow-up to this stub) is in place, this should still pass unchanged.
+TEST_F(TuvxCApiTest, NoRadiationFieldUpdaterForNonHostSolver)
+{
+  const char* json_config_path = "configs/tuvx/ts1_tsmlt_fixed.json";
+  SetUp(json_config_path);
+  ASSERT_NE(tuvx, nullptr);
+  Error error;
+  RadiationFieldUpdater* updater = GetRadiationFieldUpdater(tuvx, &error);
+  ASSERT_TRUE(IsSuccess(error));
+  ASSERT_EQ(updater, nullptr);
+  DeleteError(&error);
+}
+
 TEST_F(TuvxCApiTest, DetectsNonexistentConfigFile)
 {
   const char* config_path = "nonexisting.yml";

--- a/src/test/unit/tuvx/tuvx_c_api.cpp
+++ b/src/test/unit/tuvx/tuvx_c_api.cpp
@@ -3,6 +3,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
 using namespace musica;
 
 // Test fixture for the TUVX C API
@@ -117,8 +121,7 @@ TEST_F(TuvxCApiTest, CreateTuvxInstanceWithJsonConfig)
 }
 
 // The configured solver here is not "from host", so this must report "not found"
-// (a null updater, no error) rather than raise. Once the Fortran bridge (a
-// follow-up to this stub) is in place, this should still pass unchanged.
+// (a null updater, no error) rather than raise.
 TEST_F(TuvxCApiTest, NoRadiationFieldUpdaterForNonHostSolver)
 {
   const char* json_config_path = "configs/tuvx/ts1_tsmlt_fixed.json";
@@ -128,6 +131,140 @@ TEST_F(TuvxCApiTest, NoRadiationFieldUpdaterForNonHostSolver)
   RadiationFieldUpdater* updater = GetRadiationFieldUpdater(tuvx, &error);
   ASSERT_TRUE(IsSuccess(error));
   ASSERT_EQ(updater, nullptr);
+  DeleteError(&error);
+}
+
+// Mirrors tuv-x's own test/unit/radiative_transfer/solver_from_host.F90
+// (test_core_with_host_radiation_field), using the same config and the same
+// hand-computed reference formula, translated to the C API. The config and
+// reference values come directly from that test, not reconstructed by hand.
+TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
+{
+  const char* config_path = "configs/tuvx/host_radiation_field/config.json";
+  SetUp(config_path);
+  ASSERT_NE(tuvx, nullptr);
+
+  Error error;
+  RadiationFieldUpdater* updater = GetRadiationFieldUpdater(tuvx, &error);
+  ASSERT_TRUE(IsSuccess(error));
+  ASSERT_NE(updater, nullptr);
+
+  constexpr std::size_t n_interfaces = 5;  // height grid: 1 to 5 km, delta 1 km -> 4 cells + 1
+  constexpr std::size_t n_bins = 6;        // wavelength grid: 400 to 700 nm, delta 50 nm -> 6 cells
+  constexpr std::size_t n_reactions = 2;
+  constexpr std::size_t n_dose_rates = 2;
+  constexpr double etfl = 1.0e14;                                  // photon cm^-2 s^-1, every bin
+  constexpr double xsqy[n_reactions] = { 2.0 * 0.5, 4.0 * 0.25 };  // jfoo, jbar cross section * quantum yield
+  constexpr double lambda[n_bins] = { 425.0, 475.0, 525.0, 575.0, 625.0, 675.0 };  // wavelength bin midpoints [nm]
+  // dose rate 1 ("all bins") passes every bin; dose rate 2 ("upper bins") passes only bins above 500 nm
+  constexpr double weight[n_bins][n_dose_rates] = { { 1.0, 0.0 }, { 1.0, 0.0 }, { 1.0, 1.0 },
+                                                    { 1.0, 1.0 }, { 1.0, 1.0 }, { 1.0, 1.0 } };
+  constexpr double earth_sun_distance = 0.9;
+  constexpr double hc =
+      6.626068e-34 * 2.99792458e8;  // Planck's constant * speed of light [J m], from tuv-x's tuvx_constants
+  constexpr double tol = 1.0e-8;
+
+  // The Fortran bridge reshapes each flat buffer as a Fortran array with the
+  // interface as the first (fastest-varying) dimension, so element
+  // (i_interface, i_bin) belongs at flat index i_interface + i_bin * n_interfaces.
+  auto index = [](std::size_t i_interface, std::size_t i_bin, std::size_t n_rows) { return i_interface + i_bin * n_rows; };
+
+  std::vector<double> fdr(n_interfaces * n_bins);
+  std::vector<double> fup(n_interfaces * n_bins);
+  std::vector<double> fdn(n_interfaces * n_bins);
+  std::vector<double> edr(n_interfaces * n_bins);
+  std::vector<double> eup(n_interfaces * n_bins);
+  std::vector<double> edn(n_interfaces * n_bins);
+  for (std::size_t i_interface = 0; i_interface < n_interfaces; ++i_interface)
+  {
+    for (std::size_t i_bin = 0; i_bin < n_bins; ++i_bin)
+    {
+      // 1-based interface/bin numbers, matching tuv-x's own test exactly
+      double i = static_cast<double>(i_interface + 1);
+      double b = static_cast<double>(i_bin + 1);
+      fdr[index(i_interface, i_bin, n_interfaces)] = 0.2 * i + 0.05 * b;
+      fup[index(i_interface, i_bin, n_interfaces)] = 0.01 * i;
+      fdn[index(i_interface, i_bin, n_interfaces)] = 0.03 * b;
+      edr[index(i_interface, i_bin, n_interfaces)] = 0.1 * i + 0.02 * b;
+      eup[index(i_interface, i_bin, n_interfaces)] = 0.004 * i;
+      edn[index(i_interface, i_bin, n_interfaces)] = 0.006 * b;
+    }
+  }
+
+  // Photolysis rate constants are (edge, reaction) in memory (edge fastest),
+  // the same layout RunTuvx already uses elsewhere.
+  std::vector<double> rates(n_interfaces * n_reactions);
+  std::vector<double> doses(n_interfaces * n_dose_rates);
+  // heating_rates is written unconditionally inside InternalRunTuvx (unlike
+  // dose_rates and the radiation field outputs, it has no c_associated
+  // guard), so it must be a valid pointer even though this config defines no
+  // heating rates. The extra element guarantees a non-null data() when the
+  // real count is zero.
+  std::vector<double> heating(n_interfaces * static_cast<std::size_t>(tuvx->GetHeatingRateCount()) + 1);
+
+  // TUV-x forms the photolysis rate constants from the actinic flux
+  // components alone, so this call supplies only those three -- the
+  // irradiance components default to zero, so the dose rates come back zero.
+  UpdateRadiationField(updater, fdr.data(), fup.data(), fdn.data(), nullptr, nullptr, nullptr, n_interfaces, n_bins, &error);
+  ASSERT_TRUE(IsSuccess(error));
+
+  RunTuvx(
+      tuvx,
+      42.0 * M_PI / 180.0,  // solar zenith angle [radians]; RunTuvx converts back to degrees internally
+      earth_sun_distance,
+      rates.data(),
+      heating.data(),
+      doses.data(),
+      nullptr,
+      nullptr,
+      &error);
+  ASSERT_TRUE(IsSuccess(error));
+
+  for (std::size_t i_reaction = 0; i_reaction < n_reactions; ++i_reaction)
+  {
+    for (std::size_t i_interface = 0; i_interface < n_interfaces; ++i_interface)
+    {
+      double expected = 0.0;
+      for (std::size_t i_bin = 0; i_bin < n_bins; ++i_bin)
+      {
+        double flux = fdr[index(i_interface, i_bin, n_interfaces)] + fup[index(i_interface, i_bin, n_interfaces)] +
+                      fdn[index(i_interface, i_bin, n_interfaces)];
+        expected += flux * earth_sun_distance * etfl * xsqy[i_reaction];
+      }
+      double actual = rates[index(i_interface, i_reaction, n_interfaces)];
+      EXPECT_NEAR(actual, expected, std::abs(expected) * tol) << "reaction " << i_reaction << ", interface " << i_interface;
+    }
+  }
+  for (double dose : doses)
+    EXPECT_NEAR(dose, 0.0, tol) << "dose rates must be zero when irradiance is omitted";
+
+  // A second call that also supplies the irradiance components must produce
+  // non-zero dose rates, matching the exact energy-flux formula.
+  UpdateRadiationField(
+      updater, fdr.data(), fup.data(), fdn.data(), edr.data(), eup.data(), edn.data(), n_interfaces, n_bins, &error);
+  ASSERT_TRUE(IsSuccess(error));
+
+  RunTuvx(tuvx, 42.0 * M_PI / 180.0, earth_sun_distance, rates.data(), nullptr, doses.data(), nullptr, nullptr, &error);
+  ASSERT_TRUE(IsSuccess(error));
+
+  for (std::size_t i_rate = 0; i_rate < n_dose_rates; ++i_rate)
+  {
+    for (std::size_t i_interface = 0; i_interface < n_interfaces; ++i_interface)
+    {
+      double expected = 0.0;
+      for (std::size_t i_bin = 0; i_bin < n_bins; ++i_bin)
+      {
+        double irradiance = edr[index(i_interface, i_bin, n_interfaces)] + eup[index(i_interface, i_bin, n_interfaces)] +
+                            edn[index(i_interface, i_bin, n_interfaces)];
+        expected += irradiance * earth_sun_distance * etfl * (hc / (lambda[i_bin] * 1.0e-13)) * weight[i_bin][i_rate];
+      }
+      double actual = doses[index(i_interface, i_rate, n_interfaces)];
+      EXPECT_NEAR(actual, expected, std::abs(expected) * tol) << "dose rate " << i_rate << ", interface " << i_interface;
+    }
+  }
+
+  DeleteRadiationFieldUpdater(updater, &error);
+  ASSERT_TRUE(IsSuccess(error));
   DeleteError(&error);
 }
 

--- a/src/test/unit/tuvx/tuvx_c_api.cpp
+++ b/src/test/unit/tuvx/tuvx_c_api.cpp
@@ -169,12 +169,12 @@ TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
   // (i_interface, i_bin) belongs at flat index i_interface + i_bin * n_interfaces.
   auto index = [](std::size_t i_interface, std::size_t i_bin, std::size_t n_rows) { return i_interface + i_bin * n_rows; };
 
-  std::vector<double> fdr(n_interfaces * n_bins);
-  std::vector<double> fup(n_interfaces * n_bins);
-  std::vector<double> fdn(n_interfaces * n_bins);
-  std::vector<double> edr(n_interfaces * n_bins);
-  std::vector<double> eup(n_interfaces * n_bins);
-  std::vector<double> edn(n_interfaces * n_bins);
+  std::vector<double> direct_actinic_flux(n_interfaces * n_bins);
+  std::vector<double> upward_actinic_flux(n_interfaces * n_bins);
+  std::vector<double> downward_actinic_flux(n_interfaces * n_bins);
+  std::vector<double> direct_irradiance(n_interfaces * n_bins);
+  std::vector<double> upward_irradiance(n_interfaces * n_bins);
+  std::vector<double> downward_irradiance(n_interfaces * n_bins);
   for (std::size_t i_interface = 0; i_interface < n_interfaces; ++i_interface)
   {
     for (std::size_t i_bin = 0; i_bin < n_bins; ++i_bin)
@@ -182,12 +182,13 @@ TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
       // 1-based interface/bin numbers, matching tuv-x's own test exactly
       double i = static_cast<double>(i_interface + 1);
       double b = static_cast<double>(i_bin + 1);
-      fdr[index(i_interface, i_bin, n_interfaces)] = 0.2 * i + 0.05 * b;
-      fup[index(i_interface, i_bin, n_interfaces)] = 0.01 * i;
-      fdn[index(i_interface, i_bin, n_interfaces)] = 0.03 * b;
-      edr[index(i_interface, i_bin, n_interfaces)] = 0.1 * i + 0.02 * b;
-      eup[index(i_interface, i_bin, n_interfaces)] = 0.004 * i;
-      edn[index(i_interface, i_bin, n_interfaces)] = 0.006 * b;
+      std::size_t idx = index(i_interface, i_bin, n_interfaces);
+      direct_actinic_flux[idx] = 0.2 * i + 0.05 * b;
+      upward_actinic_flux[idx] = 0.01 * i;
+      downward_actinic_flux[idx] = 0.03 * b;
+      direct_irradiance[idx] = 0.1 * i + 0.02 * b;
+      upward_irradiance[idx] = 0.004 * i;
+      downward_irradiance[idx] = 0.006 * b;
     }
   }
 
@@ -205,7 +206,17 @@ TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
   // TUV-x forms the photolysis rate constants from the actinic flux
   // components alone, so this call supplies only those three -- the
   // irradiance components default to zero, so the dose rates come back zero.
-  UpdateRadiationField(updater, fdr.data(), fup.data(), fdn.data(), nullptr, nullptr, nullptr, n_interfaces, n_bins, &error);
+  UpdateRadiationField(
+      updater,
+      direct_actinic_flux.data(),
+      upward_actinic_flux.data(),
+      downward_actinic_flux.data(),
+      nullptr,
+      nullptr,
+      nullptr,
+      n_interfaces,
+      n_bins,
+      &error);
   ASSERT_TRUE(IsSuccess(error));
 
   RunTuvx(
@@ -227,8 +238,8 @@ TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
       double expected = 0.0;
       for (std::size_t i_bin = 0; i_bin < n_bins; ++i_bin)
       {
-        double flux = fdr[index(i_interface, i_bin, n_interfaces)] + fup[index(i_interface, i_bin, n_interfaces)] +
-                      fdn[index(i_interface, i_bin, n_interfaces)];
+        std::size_t idx = index(i_interface, i_bin, n_interfaces);
+        double flux = direct_actinic_flux[idx] + upward_actinic_flux[idx] + downward_actinic_flux[idx];
         expected += flux * earth_sun_distance * etfl * xsqy[i_reaction];
       }
       double actual = rates[index(i_interface, i_reaction, n_interfaces)];
@@ -241,10 +252,20 @@ TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
   // A second call that also supplies the irradiance components must produce
   // non-zero dose rates, matching the exact energy-flux formula.
   UpdateRadiationField(
-      updater, fdr.data(), fup.data(), fdn.data(), edr.data(), eup.data(), edn.data(), n_interfaces, n_bins, &error);
+      updater,
+      direct_actinic_flux.data(),
+      upward_actinic_flux.data(),
+      downward_actinic_flux.data(),
+      direct_irradiance.data(),
+      upward_irradiance.data(),
+      downward_irradiance.data(),
+      n_interfaces,
+      n_bins,
+      &error);
   ASSERT_TRUE(IsSuccess(error));
 
-  RunTuvx(tuvx, 42.0 * M_PI / 180.0, earth_sun_distance, rates.data(), nullptr, doses.data(), nullptr, nullptr, &error);
+  RunTuvx(
+      tuvx, 42.0 * M_PI / 180.0, earth_sun_distance, rates.data(), heating.data(), doses.data(), nullptr, nullptr, &error);
   ASSERT_TRUE(IsSuccess(error));
 
   for (std::size_t i_rate = 0; i_rate < n_dose_rates; ++i_rate)
@@ -254,8 +275,8 @@ TEST_F(TuvxCApiTest, HostSuppliedRadiationFieldDrivesPhotolysisRates)
       double expected = 0.0;
       for (std::size_t i_bin = 0; i_bin < n_bins; ++i_bin)
       {
-        double irradiance = edr[index(i_interface, i_bin, n_interfaces)] + eup[index(i_interface, i_bin, n_interfaces)] +
-                            edn[index(i_interface, i_bin, n_interfaces)];
+        std::size_t idx = index(i_interface, i_bin, n_interfaces);
+        double irradiance = direct_irradiance[idx] + upward_irradiance[idx] + downward_irradiance[idx];
         expected += irradiance * earth_sun_distance * etfl * (hc / (lambda[i_bin] * 1.0e-13)) * weight[i_bin][i_rate];
       }
       double actual = doses[index(i_interface, i_rate, n_interfaces)];

--- a/src/tuvx/CMakeLists.txt
+++ b/src/tuvx/CMakeLists.txt
@@ -13,12 +13,14 @@ target_sources(musica PRIVATE
   interface_profile_map.F90
   interface_radiator.F90
   interface_radiator_map.F90
+  interface_radiation_field_updater.F90
   grid.cpp
   grid_map.cpp
   profile.cpp
   profile_map.cpp
   radiator.cpp
   radiator_map.cpp
+  radiation_field_updater.cpp
   tuvx.cpp
   tuvx_c_interface.cpp
 )

--- a/src/tuvx/interface_radiation_field_updater.F90
+++ b/src/tuvx/interface_radiation_field_updater.F90
@@ -1,0 +1,81 @@
+! Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+! STUB. This file exists only so that TUVX::GetRadiationFieldUpdater links; it
+! does not yet bridge to tuv-x's real radiation_field_updater_t. Every call
+! reports "no host-updatable solver found", which is honest given nothing
+! wires up the real check yet. The functions below are replaced with a real
+! bridge to tuv-x's core_t%get_radiation_field_updater and
+! radiation_field_updater_t%update in a follow-up change.
+module tuvx_interface_radiation_field_updater
+
+   use iso_c_binding, only: c_ptr, c_null_ptr, c_int, c_double, c_size_t
+
+   implicit none
+
+   private
+
+   integer, parameter :: ERROR_NONE = 0
+   integer, parameter :: ERROR_NOT_IMPLEMENTED = 1
+
+contains
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   function internal_get_radiation_field_updater(tuvx, found, error_code) &
+      bind(C, name="InternalGetRadiationFieldUpdater") result(updater)
+      ! arguments
+      type(c_ptr) :: updater
+      type(c_ptr), intent(in), value :: tuvx
+      integer(kind=c_int), intent(out) :: found
+      integer(kind=c_int), intent(out) :: error_code
+
+      updater = c_null_ptr
+      found = 0
+      error_code = ERROR_NONE
+
+   end function internal_get_radiation_field_updater
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine internal_delete_radiation_field_updater(updater, error_code) &
+      bind(C, name="InternalDeleteRadiationFieldUpdater")
+      ! arguments
+      type(c_ptr), intent(in), value :: updater
+      integer(kind=c_int), intent(out) :: error_code
+
+      error_code = ERROR_NONE
+
+   end subroutine internal_delete_radiation_field_updater
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   subroutine internal_update_radiation_field(updater, direct_actinic_flux, &
+      upward_actinic_flux, downward_actinic_flux, direct_irradiance,        &
+      upward_irradiance, downward_irradiance, has_direct_irradiance,        &
+      has_upward_irradiance, has_downward_irradiance,                      &
+      num_vertical_interfaces, num_wavelength_bins, error_code)             &
+      bind(C, name="InternalUpdateRadiationField")
+      ! arguments
+      type(c_ptr), intent(in), value :: updater
+      type(c_ptr), intent(in), value :: direct_actinic_flux
+      type(c_ptr), intent(in), value :: upward_actinic_flux
+      type(c_ptr), intent(in), value :: downward_actinic_flux
+      type(c_ptr), intent(in), value :: direct_irradiance
+      type(c_ptr), intent(in), value :: upward_irradiance
+      type(c_ptr), intent(in), value :: downward_irradiance
+      integer(kind=c_int), intent(in), value :: has_direct_irradiance
+      integer(kind=c_int), intent(in), value :: has_upward_irradiance
+      integer(kind=c_int), intent(in), value :: has_downward_irradiance
+      integer(kind=c_size_t), intent(in), value :: num_vertical_interfaces
+      integer(kind=c_size_t), intent(in), value :: num_wavelength_bins
+      integer(kind=c_int), intent(out) :: error_code
+
+      ! Unreachable while internal_get_radiation_field_updater always
+      ! reports "not found": the C++ layer never hands out a
+      ! RadiationFieldUpdater to call Update on in that case.
+      error_code = ERROR_NOT_IMPLEMENTED
+
+   end subroutine internal_update_radiation_field
+
+end module tuvx_interface_radiation_field_updater

--- a/src/tuvx/interface_radiation_field_updater.F90
+++ b/src/tuvx/interface_radiation_field_updater.F90
@@ -1,38 +1,51 @@
 ! Copyright (C) 2023-2026 University Corporation for Atmospheric Research
 ! SPDX-License-Identifier: Apache-2.0
 !
-! STUB. This file exists only so that TUVX::GetRadiationFieldUpdater links; it
-! does not yet bridge to tuv-x's real radiation_field_updater_t. Every call
-! reports "no host-updatable solver found", which is honest given nothing
-! wires up the real check yet. The functions below are replaced with a real
-! bridge to tuv-x's core_t%get_radiation_field_updater and
-! radiation_field_updater_t%update in a follow-up change.
 module tuvx_interface_radiation_field_updater
 
-   use iso_c_binding, only: c_ptr, c_null_ptr, c_int, c_double, c_size_t
+   use iso_c_binding, only : c_ptr, c_int, c_size_t
 
    implicit none
 
    private
 
    integer, parameter :: ERROR_NONE = 0
-   integer, parameter :: ERROR_NOT_IMPLEMENTED = 1
 
 contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    function internal_get_radiation_field_updater(tuvx, found, error_code) &
-      bind(C, name="InternalGetRadiationFieldUpdater") result(updater)
+      result(updater_ptr) bind(C, name="InternalGetRadiationFieldUpdater")
+      use iso_c_binding, only : c_ptr, c_f_pointer, c_loc, c_null_ptr
+      use tuvx_core,             only : core_t
+      use tuvx_solver_from_host, only : radiation_field_updater_t
+
       ! arguments
-      type(c_ptr) :: updater
-      type(c_ptr), intent(in), value :: tuvx
+      type(c_ptr)                      :: updater_ptr
+      type(c_ptr), value,  intent(in)  :: tuvx
       integer(kind=c_int), intent(out) :: found
       integer(kind=c_int), intent(out) :: error_code
 
-      updater = c_null_ptr
-      found = 0
+      ! variables
+      type(core_t),                     pointer :: core
+      type(radiation_field_updater_t),  pointer :: f_updater
+      logical :: f_found
+
       error_code = ERROR_NONE
+      call c_f_pointer(tuvx, core)
+
+      allocate(f_updater)
+      f_updater = core%get_radiation_field_updater(found = f_found)
+
+      if (f_found) then
+         found = 1
+         updater_ptr = c_loc(f_updater)
+      else
+         found = 0
+         deallocate(f_updater)
+         updater_ptr = c_null_ptr
+      end if
 
    end function internal_get_radiation_field_updater
 
@@ -40,11 +53,19 @@ contains
 
    subroutine internal_delete_radiation_field_updater(updater, error_code) &
       bind(C, name="InternalDeleteRadiationFieldUpdater")
+      use iso_c_binding, only : c_ptr, c_f_pointer
+      use tuvx_solver_from_host, only : radiation_field_updater_t
+
       ! arguments
-      type(c_ptr), intent(in), value :: updater
+      type(c_ptr), value,  intent(in)  :: updater
       integer(kind=c_int), intent(out) :: error_code
 
+      ! variables
+      type(radiation_field_updater_t), pointer :: f_updater
+
       error_code = ERROR_NONE
+      call c_f_pointer(updater, f_updater)
+      deallocate(f_updater)
 
    end subroutine internal_delete_radiation_field_updater
 
@@ -52,29 +73,57 @@ contains
 
    subroutine internal_update_radiation_field(updater, direct_actinic_flux, &
       upward_actinic_flux, downward_actinic_flux, direct_irradiance,        &
-      upward_irradiance, downward_irradiance, has_direct_irradiance,        &
-      has_upward_irradiance, has_downward_irradiance,                      &
-      num_vertical_interfaces, num_wavelength_bins, error_code)             &
+      upward_irradiance, downward_irradiance, num_vertical_interfaces,      &
+      num_wavelength_bins, error_code)                                      &
       bind(C, name="InternalUpdateRadiationField")
+      use iso_c_binding, only : c_ptr, c_f_pointer, c_associated
+      use musica_constants,     only : dk => musica_dk
+      use tuvx_solver_from_host, only : radiation_field_updater_t
+
       ! arguments
-      type(c_ptr), intent(in), value :: updater
-      type(c_ptr), intent(in), value :: direct_actinic_flux
-      type(c_ptr), intent(in), value :: upward_actinic_flux
-      type(c_ptr), intent(in), value :: downward_actinic_flux
-      type(c_ptr), intent(in), value :: direct_irradiance
-      type(c_ptr), intent(in), value :: upward_irradiance
-      type(c_ptr), intent(in), value :: downward_irradiance
-      integer(kind=c_int), intent(in), value :: has_direct_irradiance
-      integer(kind=c_int), intent(in), value :: has_upward_irradiance
-      integer(kind=c_int), intent(in), value :: has_downward_irradiance
-      integer(kind=c_size_t), intent(in), value :: num_vertical_interfaces
-      integer(kind=c_size_t), intent(in), value :: num_wavelength_bins
+      type(c_ptr), value,  intent(in)  :: updater
+      type(c_ptr), value,  intent(in)  :: direct_actinic_flux
+      type(c_ptr), value,  intent(in)  :: upward_actinic_flux
+      type(c_ptr), value,  intent(in)  :: downward_actinic_flux
+      type(c_ptr), value,  intent(in)  :: direct_irradiance   ! optional; null if omitted
+      type(c_ptr), value,  intent(in)  :: upward_irradiance   ! optional; null if omitted
+      type(c_ptr), value,  intent(in)  :: downward_irradiance ! optional; null if omitted
+      integer(kind=c_size_t), value, intent(in) :: num_vertical_interfaces
+      integer(kind=c_size_t), value, intent(in) :: num_wavelength_bins
       integer(kind=c_int), intent(out) :: error_code
 
-      ! Unreachable while internal_get_radiation_field_updater always
-      ! reports "not found": the C++ layer never hands out a
-      ! RadiationFieldUpdater to call Update on in that case.
-      error_code = ERROR_NOT_IMPLEMENTED
+      ! variables
+      type(radiation_field_updater_t), pointer :: f_updater
+      real(kind=dk), pointer :: fdr(:,:), fup(:,:), fdn(:,:)
+      real(kind=dk), pointer :: edr(:,:), eup(:,:), edn(:,:)
+      integer :: n_int, n_bin
+
+      error_code = ERROR_NONE
+      n_int = int(num_vertical_interfaces)
+      n_bin = int(num_wavelength_bins)
+
+      call c_f_pointer(updater, f_updater)
+      call c_f_pointer(direct_actinic_flux,   fdr, [n_int, n_bin])
+      call c_f_pointer(upward_actinic_flux,   fup, [n_int, n_bin])
+      call c_f_pointer(downward_actinic_flux, fdn, [n_int, n_bin])
+
+      ! The three irradiance arrays are optional on both sides: a disassociated
+      ! pointer actual argument matched to update()'s optional, non-pointer,
+      ! assumed-shape dummy argument is treated as an absent argument, so
+      ! leaving edr/eup/edn unassociated when the caller omitted them is
+      ! sufficient -- no separate branch per combination is needed.
+      nullify(edr, eup, edn)
+      if (c_associated(direct_irradiance))   call c_f_pointer(direct_irradiance,   edr, [n_int, n_bin])
+      if (c_associated(upward_irradiance))   call c_f_pointer(upward_irradiance,   eup, [n_int, n_bin])
+      if (c_associated(downward_irradiance)) call c_f_pointer(downward_irradiance, edn, [n_int, n_bin])
+
+      call f_updater%update( &
+         direct_actinic_flux   = fdr, &
+         upward_actinic_flux   = fup, &
+         downward_actinic_flux = fdn, &
+         direct_irradiance     = edr, &
+         upward_irradiance     = eup, &
+         downward_irradiance   = edn)
 
    end subroutine internal_update_radiation_field
 

--- a/src/tuvx/interface_radiation_field_updater.F90
+++ b/src/tuvx/interface_radiation_field_updater.F90
@@ -94,8 +94,12 @@ contains
 
       ! variables
       type(radiation_field_updater_t), pointer :: f_updater
-      real(kind=dk), pointer :: fdr(:,:), fup(:,:), fdn(:,:)
-      real(kind=dk), pointer :: edr(:,:), eup(:,:), edn(:,:)
+      real(kind=dk), pointer :: direct_actinic_flux_ptr(:,:)
+      real(kind=dk), pointer :: upward_actinic_flux_ptr(:,:)
+      real(kind=dk), pointer :: downward_actinic_flux_ptr(:,:)
+      real(kind=dk), pointer :: direct_irradiance_ptr(:,:)
+      real(kind=dk), pointer :: upward_irradiance_ptr(:,:)
+      real(kind=dk), pointer :: downward_irradiance_ptr(:,:)
       integer :: n_int, n_bin
 
       error_code = ERROR_NONE
@@ -103,27 +107,31 @@ contains
       n_bin = int(num_wavelength_bins)
 
       call c_f_pointer(updater, f_updater)
-      call c_f_pointer(direct_actinic_flux,   fdr, [n_int, n_bin])
-      call c_f_pointer(upward_actinic_flux,   fup, [n_int, n_bin])
-      call c_f_pointer(downward_actinic_flux, fdn, [n_int, n_bin])
+      call c_f_pointer(direct_actinic_flux,   direct_actinic_flux_ptr,   [n_int, n_bin])
+      call c_f_pointer(upward_actinic_flux,   upward_actinic_flux_ptr,   [n_int, n_bin])
+      call c_f_pointer(downward_actinic_flux, downward_actinic_flux_ptr, [n_int, n_bin])
 
       ! The three irradiance arrays are optional on both sides: a disassociated
       ! pointer actual argument matched to update()'s optional, non-pointer,
       ! assumed-shape dummy argument is treated as an absent argument, so
-      ! leaving edr/eup/edn unassociated when the caller omitted them is
-      ! sufficient -- no separate branch per combination is needed.
-      nullify(edr, eup, edn)
-      if (c_associated(direct_irradiance))   call c_f_pointer(direct_irradiance,   edr, [n_int, n_bin])
-      if (c_associated(upward_irradiance))   call c_f_pointer(upward_irradiance,   eup, [n_int, n_bin])
-      if (c_associated(downward_irradiance)) call c_f_pointer(downward_irradiance, edn, [n_int, n_bin])
+      ! leaving the three *_irradiance_ptr pointers unassociated when the
+      ! caller omitted them is sufficient -- no separate branch per
+      ! combination is needed.
+      nullify(direct_irradiance_ptr, upward_irradiance_ptr, downward_irradiance_ptr)
+      if (c_associated(direct_irradiance)) &
+         call c_f_pointer(direct_irradiance, direct_irradiance_ptr, [n_int, n_bin])
+      if (c_associated(upward_irradiance)) &
+         call c_f_pointer(upward_irradiance, upward_irradiance_ptr, [n_int, n_bin])
+      if (c_associated(downward_irradiance)) &
+         call c_f_pointer(downward_irradiance, downward_irradiance_ptr, [n_int, n_bin])
 
       call f_updater%update( &
-         direct_actinic_flux   = fdr, &
-         upward_actinic_flux   = fup, &
-         downward_actinic_flux = fdn, &
-         direct_irradiance     = edr, &
-         upward_irradiance     = eup, &
-         downward_irradiance   = edn)
+         direct_actinic_flux   = direct_actinic_flux_ptr, &
+         upward_actinic_flux   = upward_actinic_flux_ptr, &
+         downward_actinic_flux = downward_actinic_flux_ptr, &
+         direct_irradiance     = direct_irradiance_ptr, &
+         upward_irradiance     = upward_irradiance_ptr, &
+         downward_irradiance   = downward_irradiance_ptr)
 
    end subroutine internal_update_radiation_field
 

--- a/src/tuvx/radiation_field_updater.cpp
+++ b/src/tuvx/radiation_field_updater.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2023-2026 University Corporation for Atmospheric Research
+// SPDX-License-Identifier: Apache-2.0
+#include <musica/tuvx/radiation_field_updater.hpp>
+
+namespace
+{
+  constexpr int ERROR_NONE = 0;
+  constexpr const char* GetErrorMessage(int error_code)
+  {
+    switch (error_code)
+    {
+      case ERROR_NONE: return "No error";
+      default: return "Unknown error";
+    }
+  }
+}  // namespace
+
+namespace musica
+{
+
+  // RadiationFieldUpdater external C API functions
+
+  void DeleteRadiationFieldUpdater(RadiationFieldUpdater* updater, Error* error)
+  {
+    DeleteError(error);
+    try
+    {
+      delete updater;
+    }
+    catch (const std::exception& e)
+    {
+      ToError(e, MUSICA_SEVERITY_ERROR, error);
+      return;
+    }
+    NoError(error);
+  }
+
+  void UpdateRadiationField(
+      RadiationFieldUpdater* updater,
+      double* direct_actinic_flux,
+      double* upward_actinic_flux,
+      double* downward_actinic_flux,
+      double* direct_irradiance,
+      double* upward_irradiance,
+      double* downward_irradiance,
+      std::size_t num_vertical_interfaces,
+      std::size_t num_wavelength_bins,
+      Error* error)
+  {
+    DeleteError(error);
+    updater->Update(
+        direct_actinic_flux,
+        upward_actinic_flux,
+        downward_actinic_flux,
+        direct_irradiance,
+        upward_irradiance,
+        downward_irradiance,
+        num_vertical_interfaces,
+        num_wavelength_bins,
+        error);
+  }
+
+  // RadiationFieldUpdater class functions
+
+  RadiationFieldUpdater::~RadiationFieldUpdater()
+  {
+    int error_code = 0;
+    if (updater_ != nullptr)
+      InternalDeleteRadiationFieldUpdater(updater_, &error_code);
+    updater_ = nullptr;
+  }
+
+  void RadiationFieldUpdater::Update(
+      double* direct_actinic_flux,
+      double* upward_actinic_flux,
+      double* downward_actinic_flux,
+      double* direct_irradiance,
+      double* upward_irradiance,
+      double* downward_irradiance,
+      std::size_t num_vertical_interfaces,
+      std::size_t num_wavelength_bins,
+      Error* error)
+  {
+    DeleteError(error);
+    int error_code = 0;
+    InternalUpdateRadiationField(
+        updater_,
+        direct_actinic_flux,
+        upward_actinic_flux,
+        downward_actinic_flux,
+        direct_irradiance,
+        upward_irradiance,
+        downward_irradiance,
+        direct_irradiance != nullptr,
+        upward_irradiance != nullptr,
+        downward_irradiance != nullptr,
+        num_vertical_interfaces,
+        num_wavelength_bins,
+        &error_code);
+    if (error_code != 0)
+    {
+      ToError(MUSICA_ERROR_CATEGORY, error_code, GetErrorMessage(error_code), MUSICA_SEVERITY_ERROR, error);
+      return;
+    }
+    NoError(error);
+  }
+
+}  // namespace musica

--- a/src/tuvx/radiation_field_updater.cpp
+++ b/src/tuvx/radiation_field_updater.cpp
@@ -91,9 +91,6 @@ namespace musica
         direct_irradiance,
         upward_irradiance,
         downward_irradiance,
-        direct_irradiance != nullptr,
-        upward_irradiance != nullptr,
-        downward_irradiance != nullptr,
         num_vertical_interfaces,
         num_wavelength_bins,
         &error_code);

--- a/src/tuvx/tuvx.cpp
+++ b/src/tuvx/tuvx.cpp
@@ -159,6 +159,23 @@ namespace musica
     return radiator_map;
   }
 
+  RadiationFieldUpdater *TUVX::GetRadiationFieldUpdater(Error *error)
+  {
+    int error_code = 0;
+    int found = 0;
+    void *updater_handle = InternalGetRadiationFieldUpdater(tuvx_, &found, &error_code);
+    if (error_code != 0)
+    {
+      ToError(MUSICA_ERROR_CATEGORY, 1, "Failed to get radiation field updater", MUSICA_SEVERITY_CRITICAL, error);
+      return nullptr;
+    }
+    NoError(error);
+    // A missing "from host" solver is an expected, recoverable outcome, not an error.
+    if (!found)
+      return nullptr;
+    return new RadiationFieldUpdater(updater_handle);
+  }
+
   void TUVX::GetPhotolysisRateConstantsOrdering(Mappings *mappings, Error *error)
   {
     int error_code = 0;

--- a/src/tuvx/tuvx_c_interface.cpp
+++ b/src/tuvx/tuvx_c_interface.cpp
@@ -57,6 +57,12 @@ namespace musica
       return tuvx->GetRadiatorMap(error);
     }
 
+    RadiationFieldUpdater *GetRadiationFieldUpdater(TUVX *tuvx, Error *error)
+    {
+      DeleteError(error);
+      return tuvx->GetRadiationFieldUpdater(error);
+    }
+
     void GetPhotolysisRateConstantsOrdering(TUVX *tuvx, Mappings *mappings, Error *error)
     {
       DeleteError(error);


### PR DESCRIPTION
Adds RadiationFieldUpdater, TUVX::GetRadiationFieldUpdater, and the real Fortran bridge to tuv-x's core_t%get_radiation_field_updater / radiation_field_updater_t%update. Closes #1020, part of #1018.

Includes an end-to-end test using a config copied from tuv-x's own test/data/solver_from_host.json, checked against the exact reference formula from tuv-x's own unit test.