### PR TITLE
Pay run!'s one-time JIT cost with a throwaway warmup call

### DIFF
--- a/julia/test/test_ts1_column_model.jl
+++ b/julia/test/test_ts1_column_model.jl
@@ -170,11 +170,15 @@ end
     end
     @test get_radiation_field_updater(tuvx1) === nothing  # delta eddington, not "from host"
 
+    # run!'s first-ever call in a Julia session pays a one-time JIT compilation
+    # cost; this throwaway call pays it here, once, so delta_eddington_time and
+    # host_supplied_time below are comparable regardless of whether this file
+    # runs standalone or as part of the full test suite.
+    run!(tuvx1, sza, earth_sun_distance)
+
     # Timed on the same call already needed for the correctness checks below, so
     # this measures TUV-x's own delta-eddington radiative transfer solve, not an
-    # extra run added just for timing. (Comparable to host_supplied_time below only
-    # when test_tuvx.jl has already run first, e.g. via the full test suite --
-    # run!'s first-ever call in a session also pays one-time JIT compilation cost.)
+    # extra run added just for timing.
     timed1 = @timed run!(tuvx1, sza, earth_sun_distance)
     result1 = timed1.value
     delta_eddington_time = timed1.time


### PR DESCRIPTION
Follow-up to #1029, which merged before this fix landed.

Both timed `run!` calls in `test_ts1_column_model.jl` dispatch to the same specialized `run!(tuvx::TUVX, ...)` method, so whichever ran first in the Julia session absorbed Julia's one-time JIT compilation cost. Running the test file standalone made the delta-eddington time look ~14x inflated; run via the full test suite, where `test_tuvx.jl` already exercises `run!` first, the numbers were fine (~1.05x). A single throwaway call before the first timed run pays that cost unconditionally, so the reported speedup is correct regardless of how the file is invoked.

## Test plan

- [x] `julia --project=. test/runtests.jl` -- 1565 tests pass
- [x] Confirmed standalone (`include("test/test_ts1_column_model.jl")`) now reports ~1.1x, matching the full-suite number, instead of the previous ~14x