### PR TITLE
Fix TUVX Python interface bugs found while porting to Julia

### DIFF
--- a/python/bindings/tuvx/tuvx.cpp
+++ b/python/bindings/tuvx/tuvx.cpp
@@ -232,6 +232,7 @@ void bind_tuvx(py::module_& tuvx)
           std::size_t index = rate_map.mappings_[i].index_;
           rate_dict[name] = index;
         }
+        musica::DeleteMappings(&rate_map);
         return rate_dict;
       },
       "Get photolysis rate names and their ordering in the output arrays");
@@ -254,6 +255,7 @@ void bind_tuvx(py::module_& tuvx)
           std::size_t index = rate_map.mappings_[i].index_;
           rate_dict[name] = index;
         }
+        musica::DeleteMappings(&rate_map);
         return rate_dict;
       },
       "Get heating rate names and their ordering in the output arrays");
@@ -276,6 +278,7 @@ void bind_tuvx(py::module_& tuvx)
           std::size_t index = rate_map.mappings_[i].index_;
           rate_dict[name] = index;
         }
+        musica::DeleteMappings(&rate_map);
         return rate_dict;
       },
       "Get dose rate names and their ordering in the output arrays");

--- a/python/musica/tuvx/tuvx.py
+++ b/python/musica/tuvx/tuvx.py
@@ -9,9 +9,7 @@ Note: TUV-x is only available on macOS and Linux platforms.
 """
 
 import os
-import json
-import tempfile
-from typing import Dict, Optional
+from typing import Optional
 import numpy as np
 import xarray as xr
 from .. import backend
@@ -313,7 +311,7 @@ class TUVX:
             )
 
         reaction_index = names[reaction_name]
-        return photolysis_rates[:, reaction_index]
+        return photolysis_rates[reaction_index, :]
 
     def get_heating_rate(
         self,
@@ -341,7 +339,7 @@ class TUVX:
             )
 
         rate_index = names[rate_name]
-        return heating_rates[:, rate_index]
+        return heating_rates[rate_index, :]
 
     def get_dose_rate(
         self,
@@ -369,44 +367,4 @@ class TUVX:
             )
 
         rate_index = names[rate_name]
-        return dose_rates[:, rate_index]
-
-    @staticmethod
-    def create_config_from_dict(config_dict: Dict) -> 'TUVX':
-        """
-        Create a TUVX instance from a configuration dictionary.
-
-        Args:
-            config_dict: Configuration dictionary
-
-        Returns:
-            TUVX instance initialized with the configuration
-
-        Raises:
-            ValueError: If TUV-x backend is not available
-            FileNotFoundError: If required data files are not found
-        """
-        with tempfile.NamedTemporaryFile(
-                mode='w', suffix='.json', delete=True) as temp_file:
-            json.dump(config_dict, temp_file, indent=2)
-            temp_file.flush()  # Ensure all data is written to disk
-            return TUVX(temp_file.name)
-
-    @staticmethod
-    def create_config_from_json_string(json_string: str) -> 'TUVX':
-        """
-        Create a TUVX instance from a JSON configuration string.
-
-        Args:
-            json_string: JSON configuration as string
-
-        Returns:
-            TUVX instance initialized with the configuration
-
-        Raises:
-            json.JSONDecodeError: If json_string is not valid JSON
-            ValueError: If TUV-x backend is not available
-            FileNotFoundError: If required data files are not found
-        """
-        config_dict = json.loads(json_string)
-        return TUVX.create_config_from_dict(config_dict)
+        return dose_rates[rate_index, :]

--- a/python/test/integration/test_tuvx.py
+++ b/python/test/integration/test_tuvx.py
@@ -236,6 +236,38 @@ def test_fixed_tuvx_from_file():
     assert dataset["dose_rates"].shape[0] == len(dose_names_1), "Dose rates shape mismatch"
 
 
+def test_get_rate_constant_selects_the_named_reaction_across_all_layers():
+    # This config has 3 photolysis reactions, 2 heating rates, 3 dose rates, and 4
+    # vertical layers -- all different counts, so indexing the wrong axis would not
+    # go unnoticed the way it would if any two of those counts happened to match.
+    file = find_config_path("tuvx", "full_from_host", "config_python.json")
+    grid_map = get_fixed_grid_map()
+    profile_map = get_profile_map(grid_map)
+    radiator_map = get_radiator_map(grid_map)
+    tuvx = musica.TUVX(grid_map, profile_map, radiator_map, config_path=file)
+
+    dataset = tuvx.run(2.3, 1.0)
+    photolysis_rates = dataset["photolysis_rate_constants"].values
+    heating_rates = dataset["heating_rates"].values
+    dose_rates = dataset["dose_rates"].values
+    n_layers = photolysis_rates.shape[1]
+
+    for name, index in tuvx.photolysis_rate_names.items():
+        result = tuvx.get_photolysis_rate_constant(name, photolysis_rates)
+        assert result.shape == (n_layers,)
+        np.testing.assert_array_equal(result, photolysis_rates[index, :])
+
+    for name, index in tuvx.heating_rate_names.items():
+        result = tuvx.get_heating_rate(name, heating_rates)
+        assert result.shape == (n_layers,)
+        np.testing.assert_array_equal(result, heating_rates[index, :])
+
+    for name, index in tuvx.dose_rate_names.items():
+        result = tuvx.get_dose_rate(name, dose_rates)
+        assert result.shape == (n_layers,)
+        np.testing.assert_array_equal(result, dose_rates[index, :])
+
+
 def test_fixed_tuvx_from_string():
     file = find_config_path("tuvx", "full_from_host", "config_python.json")
     with open(file, 'r') as f:


### PR DESCRIPTION
Closes #1019.

Three fixes, all found while porting the TUVX core to Julia (#911), never fixed on the Python side since Julia's independent implementation got them right the first time.

- `_get_photolysis_rate_constants_ordering`, `_get_heating_rates_ordering`, and `_get_dose_rates_ordering` now call `musica::DeleteMappings` after copying into the returned `py::dict`. They leaked the C array on every call. Confirmed Julia's binding already does this correctly.
- `get_photolysis_rate_constant`, `get_heating_rate`, and `get_dose_rate` indexed `[:, index]` against arrays shaped `(rate, vertical_edge)` -- selecting one vertical edge across every rate instead of one rate across every vertical edge, the opposite of the documented behavior. Fixed to `[index, :]`.
- Removed `TUVX.create_config_from_dict` and `create_config_from_json_string`. Both called `TUVX(temp_file.name)` positionally, which doesn't match the real constructor signature, so calling either raised immediately. Confirmed neither is used anywhere in the codebase (tests, examples, docs, tutorials).

## Test plan

- [x] New regression test uses a fixture with 3 photolysis reactions, 2 heating rates, 3 dose rates, and 4 layers -- four different counts, so indexing the wrong axis can't go unnoticed by coincidentally matching another count
- [x] `pytest python/test/integration/test_tuvx.py -v` -- 7 passed
- [x] `pytest python/test/ -q` -- 396 passed, 5 skipped, no regressions
- [x] `codespell`, `autopep8`, and `clang-format` clean on modified files